### PR TITLE
CSS fixes and view title bar removal on desktop

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -21858,6 +21858,13 @@ body.operon-calendar-touch-drag-active {
 	overflow: hidden;
 }
 
+/* Hide the native Obsidian view header (title bar) for the Kanban leaf on
+   desktop so the board's own toolbar is the only chrome above the columns.
+   The header is kept on mobile, where it also hosts the sidebar-drawer toggles. */
+body:not(.is-mobile) .workspace-leaf-content[data-type="operon-kanban-view"] .view-header {
+	display: none;
+}
+
 .operon-kanban-root {
 	--operon-kanban-surface-main: var(--background-primary);
 	--operon-kanban-surface-soft: var(--background-secondary);

--- a/styles.css
+++ b/styles.css
@@ -21852,10 +21852,11 @@ body.operon-calendar-touch-drag-active {
    Kanban View
    ======================================== */
 
-.operon-kanban-view {
+.workspace-tabs .workspace-leaf .view-content.operon-kanban-view {
 	height: 100%;
 	position: relative;
 	overflow: hidden;
+	padding: 0;
 }
 
 /* Hide the native Obsidian view header (title bar) for the Kanban leaf on


### PR DESCRIPTION
The Operon Kanban leaf renders its own toolbar (preset switcher, search, settings) directly above the board, which duplicates the chrome of Obsidian's native pane title bar. Hide that native header for the Kanban view on desktop so the board's toolbar is the only chrome above the columns, reclaiming vertical space.

Scoped via the leaf's data-type attribute so only the main Kanban view is affected; embedded boards and all other views keep their headers. Limited to non-mobile because Obsidian's mobile view header also hosts the sidebar-drawer toggles. The Kanban view registers no header actions, so nothing functional is lost.

Removed padding on the Kanban-View and added correct class hierachy to let the styles come into effect.
