### PR TITLE
Feature: Cmd/Ctrl-click or middle-click a Kanban card to open the task's source file in a new tab

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -2030,6 +2030,11 @@ export default class OperonPlugin extends Plugin {
 					onCellAction: (context) => this.handleKanbanCellAction(leaf, context),
 					onItemAction: (taskId, actionId, context, invocation) => this.handleContextualMenuAction(taskId, actionId, context, invocation),
 					onStatusIconClick: (taskId) => this.handleCalendarStatusIconClick(taskId),
+					onOpenTaskInNewTab: (taskId) => {
+						const indexedTask = this.indexer.getTask(taskId);
+						if (!indexedTask) return;
+						this.navigateToTaskInNewTab(indexedTask);
+					},
 					onOpenPresetSettings: (presetId) => {
 						const preset = this.settings.kanbanPresets.find(entry => entry.id === presetId) ?? null;
 						new KanbanPresetQuickSettingsModal(this.app, {
@@ -2068,6 +2073,25 @@ export default class OperonPlugin extends Plugin {
 				}
 			});
 		}
+
+	private navigateToTaskInNewTab(task: IndexedTask): void {
+		if (task.primary.format === 'yaml') {
+			runAsyncAction('task file navigation failed', () => this.app.workspace.openLinkText(task.primary.filePath, '', 'tab'));
+			return;
+		}
+
+		const file = this.app.vault.getAbstractFileByPath(task.primary.filePath);
+		if (!(file instanceof TFile)) return;
+		const leaf = this.app.workspace.getLeaf('tab');
+		runAsyncAction('inline task navigation failed', async () => {
+			await leaf.openFile(file);
+			const editor = getCursorEditorFromView(leaf.view);
+			if (editor) {
+				editor.setCursor({ line: task.primary.lineNumber, ch: 0 });
+				editor.scrollIntoView?.({ from: { line: task.primary.lineNumber, ch: 0 }, to: { line: task.primary.lineNumber, ch: 0 } }, true);
+			}
+		});
+	}
 
 	private openTaskFile(task: IndexedTask | IndexedTaskInstance): void {
 		runAsyncAction('task file open failed', () => this.app.workspace.openLinkText(task.primary.filePath, '', false));

--- a/src/types/kanban.ts
+++ b/src/types/kanban.ts
@@ -107,6 +107,7 @@ export interface KanbanViewCallbacks {
 	onStatusIconClick?: (taskId: string) => void | Promise<void>;
 	onOpenPresetSettings?: (presetId: string) => void | Promise<void>;
 	onCellAction?: (context: KanbanCellActionContext) => void | Promise<void>;
+	onOpenTaskInNewTab?: (taskId: string) => void | Promise<void>;
 }
 
 export const DEFAULT_KANBAN_PRESETS: KanbanPreset[] = [

--- a/src/ui/kanban/kanban-view.ts
+++ b/src/ui/kanban/kanban-view.ts
@@ -1296,8 +1296,28 @@ export class KanbanView extends ItemView {
 			const card = target.closest<HTMLElement>('.operon-kanban-card');
 			const taskId = card?.dataset.operonTaskId;
 			if (!card || !taskId || !boardEl.contains(card)) return;
+			if ((event.metaKey || event.ctrlKey) && this.callbacks.onOpenTaskInNewTab) {
+				event.preventDefault();
+				event.stopPropagation();
+				void this.callbacks.onOpenTaskInNewTab(taskId);
+				return;
+			}
 			event.stopPropagation();
 			void this.callbacks.onItemAction?.(taskId, 'openEditor');
+		});
+
+		boardEl.addEventListener('auxclick', event => {
+			if (event.button !== 1) return;
+			const target = asHTMLElement(event.target, boardEl);
+			if (!target) return;
+			if (target.closest('.operon-calendar-status-button, .operon-calendar-hover-menu, a.internal-link, .operon-kanban-descendant-toggle, button, input, textarea, select, [contenteditable="true"]')) return;
+			const card = target.closest<HTMLElement>('.operon-kanban-card');
+			const taskId = card?.dataset.operonTaskId;
+			if (!card || !taskId || !boardEl.contains(card)) return;
+			if (!this.callbacks.onOpenTaskInNewTab) return;
+			event.preventDefault();
+			event.stopPropagation();
+			void this.callbacks.onOpenTaskInNewTab(taskId);
 		});
 
 		boardEl.addEventListener('dragstart', event => {


### PR DESCRIPTION
See #14 

## Changes
- New optional `onOpenTaskInNewTab` callback on `KanbanViewCallbacks`, wired in `main.ts` to `navigateToTaskInNewTab`, a sibling of `navigateToTask` that uses `getLeaf('tab')` and `openLinkText(.., 'tab')`.
- In `bindBoardDelegatedCardEvents` (`src/ui/kanban/kanban-view.ts:1279`):
  - The click listener checks `event.metaKey || event.ctrlKey` and routes to `onOpenTaskInNewTab` instead of `openEditor`.
  - A new auxclick listener handles `button === 1` (middle click) the same way. Browsers fire middle clicks as auxclick, not click, so a separate listener was needed.
- Both paths skip read-only preview cards and ignore clicks on status buttons, hover menus, descendant toggles, internal links, and other interactive children.