### PR TITLE
Update Operon README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Operon
 
-Operon is a **task management plugin for humans and agents in Obsidian**. It keeps tasks in **Markdown** while giving them structured metadata, durable identity, reusable views, planning surfaces, recurrence, and time tracking.
+Operon is a **task management plugin for humans and agents in Obsidian**. It keeps tasks in **Markdown** while giving them structured metadata, durable identity, reusable views, planning surfaces, recurrence, reminders, and time tracking.
 
 ## What problem does Operon solve?
 
 Obsidian keeps work close to notes, but tasks can spread across daily notes, project notes, checklists, files, calendars, and boards as a vault grows. Operon brings those fragments into **one task system** without pulling them out of Markdown.
 
-A key part of that is unifying Obsidian's two natural task shapes: **lightweight inline tasks** inside notes and **larger file-based tasks** that deserve their own note. Operon indexes and manages both under the same workflows, filters, Calendar, Kanban, and Task Editor.
+A key part of that is unifying Obsidian's two natural task shapes: **lightweight inline tasks** inside notes and **larger file-based tasks** that deserve their own note. Operon indexes and manages both under the same workflows, filters, Table, Calendar, Kanban, and Task Editor.
 
 It helps you capture tasks where they naturally belong, then later find, edit, filter, schedule, pin, track, or move them through a workflow from one set of tools.
 
@@ -16,13 +16,15 @@ Operon is for Obsidian users who want task management to live inside their vault
 
 It is designed for people who need **more than plain checkboxes**, but still want their tasks to remain readable, editable, linkable Markdown.
 
-![Real Operon Calendar workflow showing day planning, multi-week context, task pools, and scheduled work](assets/readme/IMG02-real-operon-calendar-workflow.png)
+Operon supports **nine interface languages**: English, Turkish, German, French, Spanish, Simplified Chinese, Traditional Chinese, Russian, and Japanese. English is built in; the other eight languages install as small on-demand packs. Natural-language date input is available in all nine languages.
+
+![The Operon Calendar with all-day items and timed blocks across a week](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-028-1.png)
 
 ## Core features
 
 ### Durable task identity and index
 
-Every Operon task gets an `operonId` and is indexed from its source location in the vault. That lets **the same task stay recognizable** as it appears in notes, filters, Calendar, Kanban, the Pinned Task Dock, recurrence, and time tracking.
+Every Operon task gets an `operonId` and is indexed from its source location in the vault. That lets **the same task stay recognizable** as it appears in notes, filters, the Table, Calendar, Kanban, the Pinned Task Dock, recurrence, and time tracking.
 
 The result is one task record that can move through many views without becoming duplicated work.
 
@@ -30,11 +32,11 @@ The result is one task record that can move through many views without becoming 
 
 Operon brings lightweight inline checkbox tasks and larger file-based tasks into the same system. Inline tasks can behave like micro-files with identity, metadata, history, and context; larger work can become a file task with its own note.
 
-Both task shapes stay part of the same index, Task Editor, filters, schedules, Kanban boards, and Calendar views.
+Both task shapes stay part of the same index, Task Editor, filters, schedules, Table, Kanban boards, and Calendar views.
 
 At any point, an inline task can be converted into a file task, or a file task can be converted back into an inline task. Operon preserves **canonical task information** during these format changes, so the task can change shape without losing its core identity or structured fields.
 
-![Inline task and file task appearing together in the same filtered Operon view](assets/readme/IMG04-file-task-overlay-with-inline-child-tasks.png)
+[![Video: a file task note with its subtask list embedded automatically at the bottom of the body](https://img.youtube.com/vi/Jf8bItQUaUM/maxresdefault.jpg)](https://www.youtube.com/watch?v=Jf8bItQUaUM)
 
 The point is not choosing one task format forever; it is letting the task grow into the shape it needs.
 
@@ -58,7 +60,7 @@ Quick capture stays fast, while richer creation flows can add metadata, parent t
 - Attach existing subtasks, dependency links, and pinned state during creation.
 - Reopen the creator with the same draft if inline or file creation cannot be completed.
 
-![Task Creator showing inline/file mode, metadata fields, recurrence, parent task, and pinned state](assets/readme/IMG05-task-creator-inline-file-metadata.png)
+![The Task Creator dialog with the title field, inline/file toggle, status, priority, and date fields](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-020-1.png)
 
 #### Create or edit inline task
 
@@ -98,6 +100,7 @@ release checklist
 - Run `Create file task` from the Command Palette.
 - Create a new task as its own Markdown file.
 - Choose a file task template when the work needs a prepared structure.
+- Let templates fill themselves with variables such as `{{date}}`, `{{time}}`, `{{status}}`, `{{priority}}`, and `{{taskDescription}}`.
 - Use the configured file task folder or target rules.
 - If the cursor is on a convertible inline task, promote that inline task into a file task.
 - If a single non-task line or fragment is selected, seed the file task from that text and replace the source with **a wikilink to the new file**.
@@ -121,6 +124,7 @@ Source note after conversion:
 - Open the current file task for editing when the active note is already an Operon file task.
 - Open the Task Editor when the current note already has Operon task frontmatter.
 - Convert a normal Markdown note into an Operon file task when the note becomes actionable.
+- Start the same conversion from a note's context menu with `Convert to Operon File Task…` in the File Explorer, tab headers, links, and Bases.
 - Preserve existing managed frontmatter, tags, and the note body while applying the selected file task template.
 - Promote work into a file task when it needs sections, references, decisions, or inline subtasks.
 
@@ -219,16 +223,16 @@ After:
 - Keep the external event as read-only Calendar context while creating a local task record you can manage.
 - Use this when an outside commitment needs to become actionable inside the vault.
 
-![Read-only external Calendar sources shown beside local Operon tasks in Calendar](assets/readme/IMG11-external-calendars-in-calendar-view.png)
+![Adding an external calendar source with its ICS URL, color, and refresh interval](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-048-1.png)
 
 #### Create from TrackTime and FlowTime
 
 - Create a quick inline task from the TrackTime and FlowTime surface when a timed or focused session reveals a new piece of work.
 - Keep the capture lightweight so the task can be named, saved, and returned to without breaking the timing or focus flow.
 
-![TrackTime and FlowTime panel showing an active timed or focused task session](assets/readme/IMG12-tracktime-flowtime-active-session.png)
+![The FlowTime panel counting down on a focused task](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-035-1.png)
 
-![Task creation options from the command palette and Task Creator](assets/readme/IMG13-command-palette-operon-commands.png)
+![The command palette filtered to Operon, showing the available commands](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-022-1.png)
 
 **Creation is part of the workflow**, not a separate intake ritual.
 
@@ -236,27 +240,39 @@ After:
 
 Break larger work into subtasks, connect related tasks, define dependencies, and keep parent-child structure visible without leaving Markdown.
 
-When a subtask is created from a parent, Operon can seed it with inherited canonical context: `parentTask`, `status`, `priority`, `taskIcon`, and `taskColor`. These values are starting context, not a lock; they can be changed after the subtask is created.
+When a subtask is created from a parent, Operon can seed it with inherited context. Which fields follow the parent is configurable in the Relationships settings, so a child inherits exactly the fields you choose, while status can start from either the parent's pipeline or the default workflow. Inherited values are starting context, not a lock; they can be changed after the subtask is created.
 
-The `parentTask` field links the child back to the parent. Priority, icon, and color can follow the parent, while status starts from the relevant workflow's initial status.
+The `parentTask` field links the child back to the parent, and the **Dynamic Subtasks Filter** can open a focused window over any task that already has subtasks, showing just that task's subtree.
 
 Parent tasks can reflect descendant progress, estimates, and tracked duration, so larger work stays readable as it changes.
 
-![Parent task with subtasks visible in the Task Editor or task detail surface](assets/readme/IMG14-parent-task-subtasks-embedded-view.png)
+![A parent task with several subtasks shown nested, with a progress rollup on the parent](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-016-1.png)
 
 Hierarchy gives big work a shape without forcing it out of the note system.
 
+### Project serials
+
+A **project serial** is a short, stable label like `PROD-007` that Operon puts on every task inside a project. Like the issue IDs used by project tools, it is a handle you can say out loud, write in a commit message, or point to in a discussion. Serials are assigned automatically and in order across a whole parent task tree.
+
+They are **read-only and visual**. The task's `operonId` stays the machine identity underneath; the serial sits on top as a human-friendly name, stored in Operon's own state, so turning serials on does not rewrite a single line of your notes. Prefixes can be renamed inline, and each project counts its own numbers, so `PROD-12` and `MKTG-12` can coexist.
+
+Serial identity chips appear across task rows, Kanban cards, and the Table, where Project Serial can also serve as a column, and serial groups can drive Filter conditions, grouping, and sorting.
+
+![A task row showing its Project Serial identity chip before the normal task chips](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-097-1.png)
+
+Serials give tasks a name people can use while the `operonId` keeps the identity machines can trust.
+
 ### Task Editor
 
-Create and edit tasks with structured controls for canonical fields such as status, priority, dates, tags, contexts, assignees, parent task, dependencies, recurrence, pinning, and time tracking.
+Create and edit tasks with structured controls for canonical fields such as status, priority, dates, tags, contexts, assignees, parent task, dependencies, recurrence, reminders, pinning, and time tracking.
 
 The right side of the editor gives form-like control over task data. The file body panel keeps the Markdown source close, so file tasks and inline tasks can still be edited in the context of the note where they live.
 
 File tasks open with the file body visible by default. Inline tasks can also reveal their source file body when needed, making it possible to inspect the surrounding note, edit Markdown, and use familiar Obsidian editing behavior from inside the Task Editor.
 
-Body changes are **automatically saved when the Task Editor closes**. You can also save explicitly with the save button, and longer editing sessions are protected by a configurable autosave debounce of up to 60 seconds.
+Body changes are **saved automatically**: edits autosave two seconds after you stop typing, and closing the Task Editor saves any pending changes immediately. You can also save explicitly with the save button.
 
-![Task Editor split view with Markdown file body on the left and canonical task fields on the right](assets/readme/IMG15-task-editor-split-view-file-body-fields.png)
+![The Task Editor on a file task, the fields beside the Markdown body](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-021-3.png)
 
 The editor is a structured doorway into Markdown, not a replacement for it.
 
@@ -270,7 +286,7 @@ Task Finder uses a purpose-built ranking model instead of plain text filtering. 
 
 Task Finder can include or exclude inline tasks, file tasks, finished tasks, and cancelled tasks. It can also remember the last selected scope, use dot-shortcuts for scope switching, and show customizable compact chips in result rows.
 
-![Task Finder showing remembered-word search, task modes, inline/file toggles, and project scope controls](assets/readme/IMG16-task-finder-search-results-scope-controls.png)
+![Task Finder open with a search term and a list of matching tasks](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-027-1.png)
 
 Selecting a task from Task Finder opens that task in the Task Editor.
 
@@ -280,11 +296,11 @@ It is a fast recovery surface for the moment when you remember the work, but not
 
 Turn task rules into **reusable work scopes**. A filter can combine fields, operators, values, match logic, groups, sorting, grouping, and subgrouping into one saved view.
 
-Filters can work with task text, checkbox state, tags, pinned state, project trees, folder trees, dates, numbers, lists, and canonical task fields. That makes them useful for both small personal slices and large operational views.
+Filters can work with task text, checkbox state, tags, pinned state, project trees, folder trees, dates, numbers, lists, and canonical task fields. Saved filters can also reach discovered file-task frontmatter properties with typed conditions and presence operators, and go-to filters can be marked as favorites. That makes them useful for both small personal slices and large operational views.
 
 Saved filters can be reused in the Filter View, embedded inside notes with an `operon` code block, opened in side panels, or attached to Calendar and Kanban presets. You can also search inside an already filtered scope to narrow a large task set further.
 
-![Filter builder showing conditions, logic groups, sort/group controls, and reusable Filter View results](assets/readme/IMG17-filter-builder-conditions-groups-sort.png)
+![Building a filter by adding conditions, with the result list updating](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-010-2.png)
 
 A filter is not just a one-time query; it is a named slice of the vault that can travel across Operon surfaces.
 
@@ -294,7 +310,9 @@ Model different workflows with your own pipelines, statuses, priorities, icons, 
 
 A task field means the same thing in YAML, filters, Calendar, Kanban, and the Task Editor because the system maps it once and reuses it everywhere. Separate pipelines let different work types follow different status paths while still sharing one task model.
 
-![Pipeline or status configuration next to a status-based task view](assets/readme/IMG18-pipelines-status-configuration.png)
+Pipelines and priorities can also carry **descriptions**: human-readable guidance that tells both people and agents when each status path or priority level should be used during task creation.
+
+![The Pipelines settings showing a pipeline and its ordered statuses with colors](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-037-1.png)
 
 Customization works best when the same rules travel across every surface.
 
@@ -316,23 +334,63 @@ Operon inline tasks stay readable as normal Markdown checkboxes. Structured fiel
 
 The syntax lets a compact line carry identity, workflow, dates, priority, and other task metadata without turning the note into a separate database file.
 
-![Key mappings settings showing canonical keys, visible YAML property names, field types, icons, and hidden metadata toggles](assets/readme/IMG19-key-mappings-settings-canonical-fields.png)
+![The Keymapping settings listing canonical fields beside their visible property names](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-039-1.png)
 
 A task field means the same thing everywhere because it is mapped once.
 
+### Custom keys
+
+Operon's built-in fields cover the common task model; **custom keys** cover the rest. A custom key is a task field you define yourself—such as a client, an effort score, or a review flag—and add as a real canonical field rather than a loose YAML property.
+
+Each custom key gets a visible property name, a type (Text, Number, Date, Date & time, List, or Checkbox), and an optional icon. Custom keys are written as `{{your-key:: value}}` on inline tasks and as frontmatter on file tasks, and they can be used in filters, search, and Table columns. Text, Number, Date, Date & time, and List keys can also use type-matched controls across the Task Editor, Task Creator, compact chips, Kanban sorting, and swimlanes. Checkbox keys are stored and validated, but currently do not appear in the editor, creator, chip, or swimlane surfaces.
+
+```md
+- [ ] Send the proposal {{operonId:: abc1234}} {{status:: Project.InProgress}} {{client:: Acme}} {{effort:: 3}}
+```
+
+Value suggestions can come from existing vault frontmatter, so a custom field can reuse the values your notes already contain, and wikilink-backed values stay linked and previewable.
+
+![The Custom Keys settings listing user-defined fields with their types and surfaces](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-040-1.png)
+
+Custom keys let the task model grow in your direction without leaving Markdown.
+
+### Operon Table
+
+See tasks as rows and columns, like a spreadsheet over the vault. Inline tasks and file tasks sit in the same rows with the same fields, so one grid covers all your work regardless of how each task is written. Where Calendar plans by *when* and Kanban plans by *how far along*, the Table plans by **comparison**.
+
+A table is shaped by a **Table preset**: a filter chooses which tasks appear, columns choose which fields each row shows, and grouping, subgrouping, multi-sort, and summaries arrange the rows and roll up totals for each group and the whole table. Beyond Operon's own fields, **file task property columns** can surface unmanaged frontmatter properties from the current scope, so existing note metadata becomes workable without reshaping your notes first.
+
+The Table is not a read-only report. Editing a cell is a real change written back to the task's Markdown: date cells open the date picker, status cells the status picker, and a double-click opens the full Task Editor. Search and Task Finder-style scopes narrow the grid in place, and the source column jumps to the exact note or line behind any row.
+
+Every Table preset is stored as a portable `.table` file that opens as a normal Table view and can travel with the vault. The same table can also be embedded inside notes or exported.
+
+![The Operon Table showing tasks as rows with columns for task, status, priority and dates](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-105-1.png)
+
+![A grouped table with a summary row at the foot of each group and of the whole table](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-105-3.png)
+
+The Table lines fields up side by side so sorting, grouping, and summaries can surface what a card or a calendar cell would hide.
+
 ### Calendar planning
 
-Plan scheduled, due, recurring, and time-blocked work with Calendar presets. A preset can use **Time Grid** for day-style timed planning or **Multi-Week** for broader planning across several weeks, and multiple calendar leaves can stay open side by side when you want different views at the same time.
+Plan scheduled, due, recurring, and time-blocked work with Calendar presets. A preset can use **Time Grid** for day-style timed planning, **Multi-Week** for broader planning across several weeks, or the **Time Tracker Grid** for reviewing time, and multiple calendar leaves can stay open side by side when you want different views at the same time.
 
 Tasks can appear as all-day items, due items, timed blocks, finished work, or projected recurring occurrences depending on the view. Read-only external ICS calendars can sit beside Operon tasks in Calendar for context.
 
-The **Task Pool** turns the Calendar sidebar into a planning inbox. It can show **Overdue**, **Unscheduled**, or **All/Open** tasks, and tasks can be dragged from the pool onto Calendar to schedule them as all-day or timed work.
+The **Task Pool** turns the Calendar sidebar into a planning inbox. It can show **Overdue**, **Unscheduled**, **Open**, or **Finished** tasks, and it always shares the active Calendar preset filter, so the pool and the grid describe the same slice of the vault. Tasks can be dragged from the pool onto Calendar to schedule them as all-day or timed work.
 
 When screen space is tight, Calendar navigation can switch between **Sidebar** and **Toolbar** modes. That keeps the planning controls reachable without forcing the same layout on every workspace.
 
-![Calendar Time Grid view with Task Pool drag-and-drop scheduling and sidebar/toolbar navigation](assets/readme/IMG20-calendar-time-grid-task-pool.png)
+![The Time Grid preset, a week of timed blocks with hours down the side](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-029-2.png)
 
-![Calendar Multi-Week view showing broader planning across multiple weeks with a focused day view](assets/readme/IMG21-calendar-multi-week-day-planning.png)
+![The Task Pool in the Calendar sidebar, with its mode buttons and search box](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-095-1.png)
+
+![The Multi-Week preset showing several weeks of tasks as blocks](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-029-4.png)
+
+The **Time Tracker Grid** is built for looking back, not just ahead. It arranges each day into three lanes, **Planned**, **External**, and **Tracked**, so scheduled blocks, external calendar events, and recorded time sit side by side with daily totals. Past planned blocks can be logged as tracked time, and tracked sessions can be selected, moved, and edited directly on the grid.
+
+[![Video: the Time Tracker Grid with its Planned, External, and Tracked lanes side by side](https://img.youtube.com/vi/hDduQEnnnHU/maxresdefault.jpg)](https://www.youtube.com/watch?v=hDduQEnnnHU)
+
+On phones, Calendar cycles through **Agenda**, **Day**, **2 Days**, and **3 Days** views. Each mobile view can open with its own preset, and views can be included or skipped, so a phone can keep a dense review preset on Day while lighter planning presets serve the wider views.
 
 Calendar gives intention a place in time without stripping away task metadata.
 
@@ -342,23 +400,27 @@ Turn task metadata into a visual workflow board. Columns come from pipeline stat
 
 Cards are still **the same Operon task records**. Dragging a card across columns or swimlanes updates the underlying task metadata, so Kanban, Filters, Calendar, and the Task Editor stay aligned.
 
+Cards can carry **Kanban Task Chips** under the title, so priority, dates, assignees, recurrence, and custom fields can be scanned without opening anything. Trailing **action chips** such as start or stop timer, pin, note, add subtask, and open checkboxes keep the next step usable from the card itself, and Project Serial identity chips appear when a task has one.
+
+Cards can also show segmented **progress tracks** for subtasks and plain checkboxes, plus optional compact note previews, so a card reveals how far its work has come. Within a column, a board can sort automatically by rules or keep a **manual order** you arrange by hand.
+
 Saved board presets let different workflows keep their own pipeline, filter, swimlane, color source, appearance, collapsed sections, and sort rules.
 
 Kanban search uses the same task-search engine behind Task Finder. As you type or switch search scopes, the board narrows in place so matching cards stay visible on the same surface.
 
-![Kanban board showing custom status columns, swimlanes, and metadata-aware cards](assets/readme/IMG22-kanban-board-status-columns-swimlanes.png)
+![A Kanban with status columns across the top and priority swimlanes down the side](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-074-1.png)
 
-![Kanban search narrowing cards in place with Task Finder style scope controls](assets/readme/IMG23-kanban-search-narrowing-cards.png)
+[![Video: Kanban cards in action, with task chips, trailing action chips, an active timer shown as Stop, and the active column and swimlane highlighted](https://img.youtube.com/vi/9YjQEgOSoWQ/maxresdefault.jpg)](https://www.youtube.com/watch?v=9YjQEgOSoWQ)
 
 Kanban gives workflow shape to the same local task records without turning them into a separate board database.
 
 ### Pinned Task Dock
 
-Pin next actions from task rows and keep a focused working set visible. Use the pinned dock when you want active tasks nearby without keeping another full view open.
+Pin next actions from task rows and keep a focused working set visible. Pinned tasks live in a floating dock or in the side panel, so active tasks stay nearby without keeping another full view open.
 
 The vault can hold everything; the dock holds only what matters right now.
 
-![Pinned Task Dock showing a small focused set of active tasks](assets/readme/IMG24-pinned-task-dock-focused-set.png)
+![Pinned tasks shown in the side panel](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-032-1.png)
 
 Pinned tasks make focus portable across the vault.
 
@@ -366,11 +428,11 @@ Pinned tasks make focus portable across the vault.
 
 Operon keeps common task actions close to the task surface you are already using. A contextual menu can appear on pinned tasks, filter rows, Kanban cards, Calendar items, task pool entries, FlowTime tasks, and time history rows.
 
-The visible actions change by context. A task can offer actions such as **open editor**, **jump to source**, **mark done**, **start timer**, **pin or unpin**, **change status**, **cancel task**, **unschedule**, or **skip this occurrence** only when that action makes sense for the current surface.
+The visible actions change by context. A task can offer actions such as **open editor**, **jump to source**, **mark done**, **start timer**, **pin or unpin**, **change status**, **set a fixed or relative reminder**, **open subtasks or checkboxes**, **convert between inline and file form**, **cancel task**, **unschedule**, or **skip this occurrence** only when that action makes sense for the current surface.
 
 Contextual menu settings let you choose which globally enabled actions can appear on each supported surface.
 
-![Contextual menu on a pinned task showing task actions such as mark done, start timer, open editor, jump to source, status, and cancel](assets/readme/IMG25-contextual-menu-task-actions.png)
+![A task's contextual menu open, showing the available actions](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-042-1.png)
 
 Contextual menus reduce navigation by bringing the next useful action to the place where the task is already visible.
 
@@ -429,9 +491,23 @@ Weekly Planning W21.md -> Weekly Planning W22.md
 
 Projected occurrences can appear in Calendar, skipped dates can be managed from the repeat controls, and temporal edits can apply to one occurrence or to this and following tasks.
 
-![Recurrence picker showing schedule, when-done, count, frequency, weekdays, and end conditions](assets/readme/IMG26-recurrence-picker-count-weekdays.png)
+![The recurrence picker with a frequency, interval, and weekday selection](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-064-1.png)
 
 Recurrence keeps repeated work connected to its original context without making every occurrence feel like a copy-paste chore.
+
+### Reminders
+
+A due date tells you when something is expected; a reminder tells you when to look at it. Operon separates the two on purpose, so a task can be due Friday and still nudge you on Wednesday afternoon.
+
+Reminders live in two fields. **ReminderDatetimes** holds a fixed moment that nothing about the task changes. **ReminderRules** holds an offset relative to one of the task's own dates, such as `dateDue.1d` for one day before it is due; move the date and the reminder moves with it. A task can mix both freely, duplicates are refused, and reminders can be added from the Task Editor, dedicated pickers, or contextual menu actions with common offsets one click away.
+
+Delivery follows where you are. Inside Obsidian, reminders arrive as in-app notifications that open the task's source; on desktop, optional system notifications can reach you while Obsidian is in the background; missed reminders are caught up within a configurable window instead of being lost. A vault audio file or downloadable sound pack can play once per batch, and an optional automation pins a task when its reminder arrives.
+
+The companion currently supports Android: the opt-in **Mobile notification snapshot** keeps the next seven days of resolved reminders ready for the standalone **Operon Notify** app, which can deliver native notifications even while Obsidian itself is closed.
+
+![Tasks with both a fixed reminder and a rule-based reminder shown as chips](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-116-1.png)
+
+Reminders separate when work is due from when you want to be told about it.
 
 ### Time tracking
 
@@ -443,25 +519,37 @@ Task duration is stored in seconds, which keeps calculations stable even when th
 
 `totalDuration` is updated automatically as a cumulative value across parent and child tasks. Parent tasks can show the combined tracked effort of their descendants without manually recalculating the rollup.
 
-Recorded effort stays visible in the Task Editor, compact task chips, Calendar, Kanban, and time history views.
+Recorded effort stays visible in the Task Editor, compact task chips, Calendar, Kanban, and time history views. In Calendar, the **Time Tracker Grid** sets planned, external, and tracked time side by side, so tracking feeds review as well as records.
 
 #### Time Session History
 
 The **Time Session History** panel gathers tracked sessions into one review surface. Sessions can be opened for quick editing, removed when needed, or replayed by starting the timer again for the same task.
 
-![FlowTime and Time Session History showing an active timer, recorded sessions, and tracked duration](assets/readme/IMG27-flowtime-time-session-history.png)
+![The Time Session History panel listing recent tracked sessions by day](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-053-1.png)
 
 Time tracking turns effort into task history instead of leaving it as a separate timer log.
 
+## Documentation
+
+Operon ships with a full documentation set: **117 guides** covering every surface, from the first task to recurrence rules, field pickers, mobile behavior, and migration paths. Read it wherever it suits you:
+
+- **On the web**: the same set is browsable at [operon.cc/docs](https://operon.cc/docs/).
+- **Inside your vault**: Operon can download the docs as normal Markdown files into a folder you choose (default `Operon/Docs`), so they work with Obsidian search, links, and graph view, stay useful to an AI assistant reading your vault, and can refresh themselves after plugin updates.
+- **From Settings**: more than fifty contextual documentation links sit beside the settings they explain, opening your downloaded docs first and falling back to the matching web page.
+
+![The selected Operon Docs folder open in Obsidian](https://raw.githubusercontent.com/hasanyilmaz/operon/main/docs/media/MEDIA-DOCS-002-1.png)
+
+The manual lives where the work lives.
+
 ## Status
 
-Operon is maintained by Hasan Yılmaz and is prepared for public distribution as of version 1.0.0.
+Operon is maintained by Hasan Yılmaz and has been in public distribution since version 1.0.0 (May 2026). Development is active, with regular feature releases documented in [CHANGELOG.md](CHANGELOG.md).
 
-Operon has been developed in the maintainer's live Obsidian vault from the beginning and is still actively used there; the current working vault contains **about 3,000 indexed Operon tasks**. This is real-world usage evidence, not a formal benchmark.
+Operon has been developed in the maintainer's live Obsidian vault from the beginning and is still actively used there; the current working vault contains **more than 5,500 indexed Operon tasks**. This is real-world usage evidence, not a formal benchmark.
 
 ## Compatibility and Requirements
 
-Operon requires Obsidian `1.7.2` or newer and is not marked as desktop-only, so it can be installed on both desktop and mobile Obsidian. Some workflows are naturally more comfortable on larger screens, and the pinned dock can be disabled on phones.
+Operon requires Obsidian `1.7.2` or newer and is not marked as desktop-only, so it can be installed on both desktop and mobile Obsidian. Some workflows are naturally more comfortable on larger screens, and the pinned dock can be disabled on phones. The interface language can be chosen in Settings; English is built in, and the other eight languages download as small verified packs on demand.
 
 Operon's inline task metadata syntax is specific to Operon. Compatibility risk is more likely to come from overlapping surfaces: another task plugin may also render checkbox rows, rewrite Markdown tasks, manage recurrence, or add its own task planning views. If you use another task-management plugin, test the combination on a small set of notes first and avoid letting multiple plugins manage the same task surfaces.
 
@@ -475,6 +563,9 @@ Some workflows use Obsidian core plugin behavior:
 
 - **Daily Notes**: used by daily-note based inline task creation, daily-note navigation, and related date-based workflows. If you do not use Daily Notes, inline tasks can be directed to a fixed target file instead.
 - **Page Preview**: used by Obsidian's `hover-link` preview behavior for task title and wikilink previews. If Page Preview is disabled, those hover previews may not appear, but the task data and task actions still work.
+- **Web Viewer**: used to open web links from Operon Table cells in a new tab when available.
+
+One optional community integration: if the **Maps** plugin is installed, the Location picker's Map tab and location chip map previews use it. Places and manual coordinate entry work without it.
 
 Operon bundles **CodeMirror** modules for editor integrations and **ical.js** for parsing read-only external Calendar sources.
 


### PR DESCRIPTION
## What changed

- refreshed the README with current Operon features, screenshots, documentation, localization, and compatibility details
- corrected the Project Serial example and Checkbox custom-key limitations
- clarified canonical `.table` presets and current Android companion support

## Why

The README had fallen behind the current product and included a few claims that did not match the implementation or documentation.

## Impact

GitHub visitors get a more accurate overview of Operon. This PR changes only `README.md` and does not affect plugin behavior.

## Checks

- `git diff --cached --check`
- source-backed consistency and link review
