### PR TITLE
Fix release attestation action pin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,22 +153,22 @@ jobs:
           NODE
 
       - name: Attest manifest
-        uses: actions/attest@36051bcae73b7c2a8a6945a48cbf80953c6baa35 # v4
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4
         with:
           subject-path: manifest.json
 
       - name: Attest plugin bundle
-        uses: actions/attest@36051bcae73b7c2a8a6945a48cbf80953c6baa35 # v4
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4
         with:
           subject-path: main.js
 
       - name: Attest styles
-        uses: actions/attest@36051bcae73b7c2a8a6945a48cbf80953c6baa35 # v4
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4
         with:
           subject-path: styles.css
 
       - name: Attest locale packs
-        uses: actions/attest@36051bcae73b7c2a8a6945a48cbf80953c6baa35 # v4
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4
         with:
           subject-path: release-assets/locales/*.json
 

--- a/scripts/release-guard.mjs
+++ b/scripts/release-guard.mjs
@@ -476,7 +476,7 @@ function checkReleaseWorkflow() {
 	);
 	assertIncludes(
 		workflow,
-		'uses: actions/attest@36051bcae73b7c2a8a6945a48cbf80953c6baa35 # v4',
+		'uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4',
 		'release workflow must attest release assets with the approved immutable action revision',
 	);
 	assertNoMatch(


### PR DESCRIPTION
## What changed

- Replaced the four invalid `actions/attest` revisions in the Operon release workflow with the verified immutable v4 commit `508db95dd578ae2727ebd6217d5ba78e4fbda05d`.
- Updated the release guard to require the same verified revision.

## Why

The previously pinned commit does not exist in the official `actions/attest` repository. A `3.0.0` tag would therefore fail while resolving the attestation action, before GitHub Release creation.

## Impact

This restores the artifact-attestation path without changing Runtime, CLI, Developer API, plugin artifacts, release assets, documentation, or Public V1 contracts. This PR does not create a tag, GitHub Release, or npm publication.

## Validation

- Canonical Node `24.18.0` and npm `11.12.1`
- Live release audit policy: 0 production and 0 development vulnerabilities
- Full `npm run check`
- Release guard and CLI release-routing checks
- Accepted Public V1 freeze verification
- Exact plugin and CLI artifact digest parity
- `git diff --check`
