### PR TITLE
Fix release validation performance policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,8 @@ jobs:
         run: npm run release:audit-policy
 
       - name: Run validation
+        env:
+          OPERON_TASK_FINDER_PERFORMANCE_MODE: diagnostic
         run: npm run check
 
       - name: Verify release guard

--- a/scripts/release-guard.mjs
+++ b/scripts/release-guard.mjs
@@ -421,6 +421,9 @@ function checkReleaseWorkflow() {
 		'run: npm run release:freeze:check',
 		'release workflow must require an accepted Public V1 freeze',
 	);
+	if (!/- name: Run validation\s+env:\s+OPERON_TASK_FINDER_PERFORMANCE_MODE: diagnostic\s+run: npm run check/u.test(workflowText)) {
+		fail('release workflow must keep shared-runner Task Finder timings diagnostic while reference runs enforce performance gates');
+	}
 	if (
 		exactTagIndex < 0
 		|| existingReleaseIndex < exactTagIndex


### PR DESCRIPTION
## Summary

- run tag-release validation with the same diagnostic Task Finder timing policy used by shared CI runners
- require that exact workflow structure in the release guard

## Root cause

The 3.0.0 tag workflow enforced the reference-machine cold Finder threshold on a shared GitHub runner. Two attempts measured 160.10 ms and 160.81 ms against the 150 ms reference threshold, so both stopped before freeze verification, attestations, or GitHub Release creation.

## Impact

This changes release infrastructure only. Runtime, CLI, Developer API, contracts, package contents, documentation, changelog, and frozen artifact bytes are unchanged. Reference performance runs continue to enforce the performance gates.

## Validation

- canonical Node 24.18.0 and npm 11.12.1
- release audit policy
- full `npm run check` with a 64.14 ms diagnostic Finder measurement
- release guard and release check tests
- accepted Public V1 freeze verification
- exact plugin bundle, CLI executable, and CLI tarball byte parity
- `git diff --check`

The existing `3.0.0` tag is not moved by this PR, and this PR does not create a GitHub Release or publish npm.