### PR TITLE
Separate plugin and CLI release tag validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
 
       - name: Run validation
         env:
+          OPERON_PLUGIN_RELEASE_VALIDATION: "1"
           OPERON_TASK_FINDER_PERFORMANCE_MODE: diagnostic
         run: npm run check
 

--- a/scripts/agent-runtime/cli/check-release-routing.mjs
+++ b/scripts/agent-runtime/cli/check-release-routing.mjs
@@ -22,6 +22,9 @@ const pluginRoot = path.resolve(scriptDirectory, '../../..');
 const packageDocument = JSON.parse(
 	await readFile(path.join(pluginRoot, 'packages/operon-cli/package.json'), 'utf8'),
 );
+const pluginManifest = JSON.parse(
+	await readFile(path.join(pluginRoot, 'manifest.json'), 'utf8'),
+);
 const pluginWorkflow = await readFile(
 	path.join(pluginRoot, '.github/workflows/release.yml'),
 	'utf8',
@@ -119,8 +122,13 @@ assert.match(
 	/^permissions:\s*\n\s{2}contents:\s+read\s*$/mu,
 	'CLI CI must explicitly grant only contents: read.',
 );
+assert.doesNotMatch(ciWorkflow, /OPERON_PLUGIN_RELEASE_VALIDATION/u);
 
 assert.match(pluginWorkflow, /-\s+["']!cli-v\*["']/u);
+assert.match(
+	pluginWorkflow,
+	/- name: Run validation\s+env:\s+OPERON_PLUGIN_RELEASE_VALIDATION: "1"\s+OPERON_TASK_FINDER_PERFORMANCE_MODE: diagnostic\s+run: npm run check/u,
+);
 assert.match(
 	pluginWorkflow,
 	/actions\/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1/u,
@@ -285,11 +293,14 @@ for (const [name, workflow] of [
 
 const checker = path.join(scriptDirectory, 'check-release-tag.mjs');
 const exactTag = `cli-v${packageDocument.version}`;
+const checkerEnvironment = { ...process.env };
+delete checkerEnvironment.OPERON_PLUGIN_RELEASE_VALIDATION;
+delete checkerEnvironment.REQUIRE_EXACT_GIT_TAG;
 const accepted = spawnSync(process.execPath, [checker], {
 	cwd: pluginRoot,
 	encoding: 'utf8',
 	env: {
-		...process.env,
+		...checkerEnvironment,
 		GITHUB_REF: `refs/tags/${exactTag}`,
 		GITHUB_REF_NAME: exactTag,
 		GITHUB_REF_TYPE: 'tag',
@@ -301,13 +312,72 @@ const pullRequest = spawnSync(process.execPath, [checker], {
 	cwd: pluginRoot,
 	encoding: 'utf8',
 	env: {
-		...process.env,
+		...checkerEnvironment,
 		GITHUB_REF: 'refs/pull/87/merge',
 		GITHUB_REF_NAME: '87/merge',
 		GITHUB_REF_TYPE: 'branch',
 	},
 });
 assert.equal(pullRequest.status, 0, pullRequest.stderr);
+
+const pluginRelease = spawnSync(process.execPath, [checker], {
+	cwd: pluginRoot,
+	encoding: 'utf8',
+	env: {
+		...checkerEnvironment,
+		GITHUB_REF: `refs/tags/${pluginManifest.version}`,
+		GITHUB_REF_NAME: pluginManifest.version,
+		GITHUB_REF_TYPE: 'tag',
+		OPERON_PLUGIN_RELEASE_VALIDATION: '1',
+	},
+});
+assert.equal(pluginRelease.status, 0, pluginRelease.stderr);
+
+for (const [name, environment] of [
+	['plugin tag without release mode', {
+		GITHUB_REF: `refs/tags/${pluginManifest.version}`,
+		GITHUB_REF_NAME: pluginManifest.version,
+		GITHUB_REF_TYPE: 'tag',
+	}],
+	['CLI tag in plugin release mode', {
+		GITHUB_REF: `refs/tags/${exactTag}`,
+		GITHUB_REF_NAME: exactTag,
+		GITHUB_REF_TYPE: 'tag',
+		OPERON_PLUGIN_RELEASE_VALIDATION: '1',
+	}],
+	['wrong plugin tag in release mode', {
+		GITHUB_REF: 'refs/tags/0.0.0',
+		GITHUB_REF_NAME: '0.0.0',
+		GITHUB_REF_TYPE: 'tag',
+		OPERON_PLUGIN_RELEASE_VALIDATION: '1',
+	}],
+	['branch in plugin release mode', {
+		GITHUB_REF: 'refs/heads/main',
+		GITHUB_REF_NAME: 'main',
+		GITHUB_REF_TYPE: 'branch',
+		OPERON_PLUGIN_RELEASE_VALIDATION: '1',
+	}],
+	['inconsistent plugin release ref', {
+		GITHUB_REF: `refs/tags/${pluginManifest.version}-other`,
+		GITHUB_REF_NAME: pluginManifest.version,
+		GITHUB_REF_TYPE: 'tag',
+		OPERON_PLUGIN_RELEASE_VALIDATION: '1',
+	}],
+	['plugin and exact CLI release modes together', {
+		GITHUB_REF: `refs/tags/${pluginManifest.version}`,
+		GITHUB_REF_NAME: pluginManifest.version,
+		GITHUB_REF_TYPE: 'tag',
+		OPERON_PLUGIN_RELEASE_VALIDATION: '1',
+		REQUIRE_EXACT_GIT_TAG: '1',
+	}],
+]) {
+	const rejected = spawnSync(process.execPath, [checker], {
+		cwd: pluginRoot,
+		encoding: 'utf8',
+		env: { ...checkerEnvironment, ...environment },
+	});
+	assert.notEqual(rejected.status, 0, `Release checker accepted ${name}.`);
+}
 
 for (const invalidTag of [
 	packageDocument.version,
@@ -320,7 +390,7 @@ for (const invalidTag of [
 		cwd: pluginRoot,
 		encoding: 'utf8',
 		env: {
-			...process.env,
+			...checkerEnvironment,
 			GITHUB_REF: `refs/tags/${invalidTag}`,
 			GITHUB_REF_NAME: invalidTag,
 			GITHUB_REF_TYPE: 'tag',

--- a/scripts/agent-runtime/cli/check-release-tag.mjs
+++ b/scripts/agent-runtime/cli/check-release-tag.mjs
@@ -8,14 +8,40 @@ const pluginRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '.
 const packageDocument = JSON.parse(
 	await readFile(path.join(pluginRoot, 'packages', 'operon-cli', 'package.json'), 'utf8'),
 );
+const pluginManifest = JSON.parse(
+	await readFile(path.join(pluginRoot, 'manifest.json'), 'utf8'),
+);
 assert.equal(packageDocument.name, 'operon-cli');
 assert.match(packageDocument.version, /^[0-9]+\.[0-9]+\.[0-9]+$/u);
+assert.equal(pluginManifest.id, 'operon');
+assert.match(pluginManifest.version, /^[0-9]+\.[0-9]+\.[0-9]+$/u);
 
 const refName = process.env.GITHUB_REF_NAME;
+const pluginReleaseValidation = process.env.OPERON_PLUGIN_RELEASE_VALIDATION;
+assert.ok(
+	pluginReleaseValidation === undefined || pluginReleaseValidation === '1',
+	'OPERON_PLUGIN_RELEASE_VALIDATION must be unset or exactly 1.',
+);
 const isTagRef = process.env.GITHUB_REF_TYPE === 'tag'
 	|| process.env.GITHUB_REF?.startsWith('refs/tags/') === true
 	|| process.env.REQUIRE_EXACT_GIT_TAG === '1';
-if (isTagRef) {
+if (pluginReleaseValidation === '1') {
+	assert.notEqual(
+		process.env.REQUIRE_EXACT_GIT_TAG,
+		'1',
+		'Plugin release validation cannot authorize an exact CLI tag publication.',
+	);
+	assert.equal(isTagRef, true, 'Plugin release validation requires a tag ref.');
+	assert.ok(refName, 'Plugin release tag name is required.');
+	assert.equal(process.env.GITHUB_REF_TYPE, 'tag', 'Plugin release validation requires GITHUB_REF_TYPE=tag.');
+	assert.equal(
+		process.env.GITHUB_REF,
+		`refs/tags/${refName}`,
+		'Plugin release validation requires a self-consistent GitHub tag ref.',
+	);
+	assert.match(refName, /^[0-9]+\.[0-9]+\.[0-9]+$/u, 'Plugin release tag must be plain stable SemVer.');
+	assert.equal(refName, pluginManifest.version, 'Plugin release tag must exactly match manifest.json.');
+} else if (isTagRef) {
 	assert.ok(refName, 'CLI release tag name is required for a tag release.');
 	assert.equal(
 		refName,
@@ -41,6 +67,9 @@ if (isTagRef) {
 console.log(JSON.stringify({
 	status: 'ok',
 	package: `${packageDocument.name}@${packageDocument.version}`,
-	expectedTag: `cli-v${packageDocument.version}`,
+	validationTarget: pluginReleaseValidation === '1' ? 'plugin' : 'cli',
+	expectedTag: pluginReleaseValidation === '1'
+		? pluginManifest.version
+		: `cli-v${packageDocument.version}`,
 	publishPerformed: false,
 }, null, 2));

--- a/scripts/release-guard.mjs
+++ b/scripts/release-guard.mjs
@@ -383,6 +383,11 @@ function checkContinuousIntegrationWorkflow() {
 	if (!/- name: Run validation\s+env:\s+OPERON_TASK_FINDER_PERFORMANCE_MODE: diagnostic\s+run: npm run check/u.test(workflowText)) {
 		fail('CI must keep shared-runner Task Finder timings diagnostic while reference runs enforce performance gates');
 	}
+	assertNoMatch(
+		workflow,
+		/OPERON_PLUGIN_RELEASE_VALIDATION/u,
+		'CI must not enable plugin-release tag validation',
+	);
 	if (
 		installIndex < 0
 		|| auditPolicyIndex < installIndex
@@ -421,8 +426,8 @@ function checkReleaseWorkflow() {
 		'run: npm run release:freeze:check',
 		'release workflow must require an accepted Public V1 freeze',
 	);
-	if (!/- name: Run validation\s+env:\s+OPERON_TASK_FINDER_PERFORMANCE_MODE: diagnostic\s+run: npm run check/u.test(workflowText)) {
-		fail('release workflow must keep shared-runner Task Finder timings diagnostic while reference runs enforce performance gates');
+	if (!/- name: Run validation\s+env:\s+OPERON_PLUGIN_RELEASE_VALIDATION: "1"\s+OPERON_TASK_FINDER_PERFORMANCE_MODE: diagnostic\s+run: npm run check/u.test(workflowText)) {
+		fail('release workflow must explicitly separate plugin-tag validation and diagnostic shared-runner timings');
 	}
 	if (
 		exactTagIndex < 0


### PR DESCRIPTION
## Summary

- add an explicit plugin-release validation mode for plain SemVer plugin tags
- preserve the existing `cli-v<version>` validation contract for CLI releases
- keep plugin validation scoped to the GitHub Release workflow and prevent it from leaking into CI
- extend release-routing and release-guard coverage with fail-closed positive and negative cases

## Root cause

The plugin Release workflow runs the shared CLI package validation chain. A plain plugin tag such as `3.0.0` was therefore interpreted as a CLI publication tag and rejected because the CLI contract expects `cli-v1.0.0`.

## Impact

The plugin workflow can validate its exact manifest-bound tag without weakening or bypassing CLI tag validation. No Runtime, Developer API, CLI package, documentation, changelog, release asset, or Public V1 freeze bytes change.

## Validation

- full `npm run check` in exact plugin-release tag context
- `npm run release:audit-policy`: 0 production and 0 development vulnerabilities
- `npm run release:guard`
- `npm run release:freeze:check`
- exact plugin bundle, CLI executable, CLI tarball, and accepted-freeze byte parity
- parallel correctness and release-security review with no actionable findings

## Release boundary

This PR does not move or recreate tag `3.0.0`, create a GitHub Release, publish npm, or modify documentation.