### PR TITLE
Release operon-cli 1.0.1

### DIFF
--- a/.github/workflows/cli-release-ready.yml
+++ b/.github/workflows/cli-release-ready.yml
@@ -66,8 +66,8 @@ jobs:
         env:
           npm_config_cache: ${{ runner.temp }}/operon-cli-npm-cache
         run: |
-          rm -rf packages/operon-cli/release
-          mkdir -p packages/operon-cli/release
+          rm -rf release
+          mkdir -p release
           npm pack --pack-destination release
         working-directory: packages/operon-cli
       - name: Download and verify the compatible public Operon plugin

--- a/contracts/agent-runtime/public-v1-freeze.json
+++ b/contracts/agent-runtime/public-v1-freeze.json
@@ -6,8 +6,8 @@
     "files": [
       {
         "path": "contracts/agent-runtime/public-v1-scope.md",
-        "sha256": "b1e987f42192b61084a334141cf132d11990ee44ef3b02fb147d4c6ab073f064",
-        "bytes": 17023
+        "sha256": "b1889ddb674639c289d13c06b8b45630edd07cfdab7cdb374ed365619c3bd38b",
+        "bytes": 16951
       },
       {
         "path": "contracts/agent-runtime/contract-evolution-v1.md",
@@ -26,8 +26,8 @@
       },
       {
         "path": "contracts/agent-runtime/public-v1-freeze.schema.json",
-        "sha256": "313b7e933a79bc59206a6315ebb80d5afe863686aa88dc4271f3868542a39423",
-        "bytes": 7441
+        "sha256": "cf622bb112eac457824af194930cb7fcded04a4de693e4b6f1e05242ae88888c",
+        "bytes": 7590
       },
       {
         "path": "scripts/agent-runtime/contracts/contract-evolution.mjs",
@@ -41,11 +41,11 @@
       },
       {
         "path": "scripts/agent-runtime/contracts/public-v1-freeze.mjs",
-        "sha256": "ab05bd85943953a9f014ce9570dfe20a7305d2a35bf672e1ab86ee55717f47a2",
-        "bytes": 23000
+        "sha256": "c1b6b90ddfaa555942bec3232aabba15d3cf2ae93407be9664f31a9ac787af87",
+        "bytes": 22999
       }
     ],
-    "aggregateSha256": "ecd04c229443b86a12b8f3effaca00e26539928c125e6702a97a35da28638ac3"
+    "aggregateSha256": "918037b8ceff05f93233016b0f5ac0ad39ceabb35e30d6a1eeaad4b37d303fb7"
   },
   "runtime": {
     "contractVersion": 1,
@@ -63,16 +63,16 @@
   },
   "cli": {
     "contractVersion": 1,
-    "packageVersion": "1.0.0",
+    "packageVersion": "1.0.1",
     "contractDigest": "d280747a21f46add48d70193205c4dc642b1e0f38447209611174e33beff5927",
     "tarball": {
-      "path": "packages/operon-cli/freeze/operon-cli-1.0.0.tgz",
-      "sha256": "29f13c9fd9575812d6e52130107d0b3fdb9bfea8ea91bbc72e99ea27750ea7c7",
-      "bytes": 213375
+      "path": "packages/operon-cli/freeze/operon-cli-1.0.1.tgz",
+      "sha256": "7ba1e084436ed8d5396780c3364c7e52508fe964301a00610c3d375ffa6dcc0e",
+      "bytes": 213382
     },
     "executable": {
       "path": "packages/operon-cli/dist/operon.mjs",
-      "sha256": "405c44ba509e5d276e50be40395dc320dede5ac69d92e1e7c2f3363b12ae88bf",
+      "sha256": "13c732012cbde6abae893fd0d8ff9d239204e24966fa67a157bc880f7c76b230",
       "bytes": 512706
     },
     "license": {
@@ -82,12 +82,12 @@
     },
     "manifest": {
       "path": "packages/operon-cli/cli-manifest-v1.json",
-      "sha256": "f4eb0001fe0ebdf01197dbd54bfbacfc3d1604a2fdb4d8836ad290238455ca58",
+      "sha256": "f56c223503af52c3f8997150f1b3cbe9100292b6c23e5641eb4e2ff7d8a8c6d0",
       "bytes": 51224
     },
     "packageMetadata": {
       "path": "packages/operon-cli/package.json",
-      "sha256": "c2b1b4b463a7f9085a1dda3981e330db904b22ac045e06b00ee3af75bef89705",
+      "sha256": "873928407044243c81f69c389470835fe7e97a498547635f7a2e61b980cb9019",
       "bytes": 1978
     },
     "readme": {
@@ -110,7 +110,7 @@
       "fileCount": 5,
       "aggregateSha256": "2ecd8a3e0ae2e069bc89a7cd70cdb724f4023f2b306391b21fbbabca07dd12c6"
     },
-    "packageInputAggregateSha256": "5609fe51030eb2396889361f59cc47043924dab8898dc20cb0049a5c12397917"
+    "packageInputAggregateSha256": "4afe5d397b11797748b64d028b507b42d51363bce285fa661527a2fcc2a7ac4c"
   },
   "documentation": {
     "manifest": {
@@ -127,7 +127,7 @@
     "contentAggregateSha256": "9b9cabf8caae5453750637d0e41ef175c55b05dd19a1601dda332b2dbd58f20f"
   },
   "plugin": {
-    "artifactStatus": "provisional-unpublished",
+    "artifactStatus": "local-rebuilt-artifact",
     "pluginId": "operon",
     "version": "3.0.0",
     "main": {
@@ -196,7 +196,7 @@
   "maintainerAcceptance": {
     "status": "accepted",
     "acceptedBy": "Hasan Yilmaz",
-    "acceptedAt": "2026-07-31T21:24:11.486Z"
+    "acceptedAt": "2026-08-01T01:51:45.000Z"
   },
-  "inputsAggregateSha256": "38ca3f93484dbad2a79b29ef09ba3958b597bbbf3dbd4eeda36b74e8abda3d1d"
+  "inputsAggregateSha256": "00cd63c3b852702415b9d92ca578b4ec940d5cf3d3b291f9f300bcaf2b777311"
 }

--- a/contracts/agent-runtime/public-v1-freeze.schema.json
+++ b/contracts/agent-runtime/public-v1-freeze.schema.json
@@ -97,7 +97,10 @@
       "additionalProperties": false,
       "required": ["artifactStatus", "pluginId", "version", "main", "manifest", "styles"],
       "properties": {
-        "artifactStatus": { "const": "provisional-unpublished" },
+        "artifactStatus": {
+          "const": "local-rebuilt-artifact",
+          "description": "Source-rebuilt plugin bytes bound by this local freeze; public release identity is verified separately."
+        },
         "pluginId": { "const": "operon" },
         "version": { "type": "string", "minLength": 1 },
         "main": { "$ref": "#/$defs/file" },

--- a/contracts/agent-runtime/public-v1-scope.md
+++ b/contracts/agent-runtime/public-v1-scope.md
@@ -16,7 +16,7 @@ has passed.
 Public V1 launch versions:
 
 - Operon `3.0.0`
-- `operon-cli@1.0.0`
+- `operon-cli@1.0.1`
 - Runtime API and contract version `1`
 
 The current CLI is a private release candidate and is not publicly installable
@@ -51,10 +51,10 @@ versioned Public V1 integration contract.
 
 | Area | Current implementation truth | Public V1 launch target |
 | --- | --- | --- |
-| Operon release | Operon `2.6.0` is the latest external release; local `3.0.0` release artifacts remain provisional and unpublished | Operon `3.0.0` |
-| CLI package | Local `operon-cli@1.0.0` stable release candidate; not published to public npm | Public stable `operon-cli@1.0.0` |
+| Operon release | Operon `3.0.0` is publicly released with Runtime API V1 | Operon `3.0.0` |
+| CLI package | Local `operon-cli@1.0.1` stable release candidate; not published to public npm | Public stable `operon-cli@1.0.1` |
 | Runtime contract | Runtime API V1 exists and is exposed on the Operon plugin instance | Runtime API V1 is a supported, typed Developer API contract |
-| Public access channels | CLI is the documented integration surface; the in-process facade exists without a complete public consumer contract | CLI and in-process Developer API are both supported public channels |
+| Public access channels | The in-process Developer API ships with Operon `3.0.0`; the CLI remains an unpublished local release candidate | CLI and in-process Developer API are both supported public channels |
 | macOS CLI | Supported by the current beta boundary | Supported |
 | Linux CLI | `acceptance-required` | Public beta and best-effort on native Linux |
 | Windows CLI | `acceptance-required` | Public beta and best-effort on Windows 11 |
@@ -258,8 +258,8 @@ support, documentation, and release acceptance do not depend on that work.
 | Portable transport and platform security | Stage 6 — Cross-platform implementation | Platform-specific path, ownership, ACL/mode, symlink/reparse, IPC, shell, signal, Unicode, and interruption tests |
 | Cross-platform launch boundary, Node support, and beta disclosure | Stage 7 — Cross-platform readiness | Hosted portability and package tests pass on Node 22, 24, and 26 across macOS, Linux, and Windows; platform-specific transport-security, path, lifecycle, interruption, and recovery tests pass; macOS remains `supported`, Linux and Windows remain executable `acceptance-required` public-beta targets, and WSL remains `unsupported` |
 | Public integration guides and examples | Stage 8 — Packaging and documentation | Clean-room CLI and Developer API integration tests using only distributable artifacts and documentation |
-| Stable contract and release candidate | Stage 9 — Hardening and freeze | No launch-blocking contract break, unauthorized access, consent bypass, data loss or corruption, or irrecoverable uncertain outcome remains; all required local contract, security, mutation, Developer API, package, documentation, and release-hardening gates pass; contract, stable manifest, package inputs, types, examples, documentation, provisional unpublished plugin artifact, and development-audit policy are bound by one exact local freeze index; the compatibility baseline has real input/response direction and deprecation coverage; documented maintainer acceptance seals the final local index |
-| Public `operon-cli@1.0.0` | Stage 10 — External release | Before publish, the accepted Stage 9 freeze, final tarball digest, provenance, compatible public Operon artifact, and nine-cell hosted portability evidence pass on the release bytes; after publish, the registry artifact digest equals that tarball and the post-publication audit passes |
+| Stable contract and release candidate | Stage 9 — Hardening and freeze | No launch-blocking contract break, unauthorized access, consent bypass, data loss or corruption, or irrecoverable uncertain outcome remains; all required local contract, security, mutation, Developer API, package, documentation, and release-hardening gates pass; contract, stable manifest, package inputs, types, examples, documentation, source-rebuilt plugin artifact, and development-audit policy are bound by one exact local freeze index; the compatibility baseline has real input/response direction and deprecation coverage; documented maintainer acceptance seals the final local index |
+| Public `operon-cli@1.0.1` | Stage 10 — External release | Before publish, the accepted Stage 9 freeze, final tarball digest, provenance, compatible public Operon artifact, and nine-cell hosted portability evidence pass on the release bytes; after publish, the registry artifact digest equals that tarball and the post-publication audit passes |
 
 Failure of a required gate returns the work to its owning stage. Publication is
 not a substitute for contract, safety, package, or hosted portability evidence.

--- a/packages/operon-cli/cli-manifest-v1.json
+++ b/packages/operon-cli/cli-manifest-v1.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "package": {
     "name": "operon-cli",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "executable": "operon",
     "node": "^22.0.0 || ^24.0.0 || ^26.0.0"
   },

--- a/packages/operon-cli/package.json
+++ b/packages/operon-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "operon-cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Official command-line client for the Operon Agent Runtime in Obsidian.",
   "type": "module",
   "license": "GPL-3.0-or-later",

--- a/scripts/agent-runtime/cli/check-release-routing.mjs
+++ b/scripts/agent-runtime/cli/check-release-routing.mjs
@@ -148,6 +148,15 @@ assert.match(candidateWorkflow, /plugin_release_tag:/u);
 assert.match(candidateWorkflow, /node-version:\s*"24\.18\.0"/u);
 assert.match(candidateWorkflow, /test "\$\(node --version\)" = "v24\.18\.0"/u);
 assert.match(candidateWorkflow, /npm install --global npm@11\.12\.1/u);
+const candidatePackStep = candidateWorkflow.match(
+	/^      - name: Build one isolated candidate tarball\s*\n(?:(?!^      - ).*(?:\n|$))*/mu,
+)?.[0];
+assert.ok(candidatePackStep, 'Candidate workflow must contain the isolated tarball build step.');
+assert.match(candidatePackStep, /^[ \t]+working-directory:[ \t]+packages\/operon-cli[ \t]*$/mu);
+assert.match(candidatePackStep, /^[ \t]+rm -rf release[ \t]*$/mu);
+assert.match(candidatePackStep, /^[ \t]+mkdir -p release[ \t]*$/mu);
+assert.match(candidatePackStep, /^[ \t]+npm pack --pack-destination release[ \t]*$/mu);
+assert.doesNotMatch(candidatePackStep, /packages\/operon-cli\/release/u);
 assert.match(candidateWorkflow, /gh release download "\$PLUGIN_RELEASE_TAG"/u);
 assert.match(candidateWorkflow, /FROZEN_PLUGIN_VERSION/u);
 assert.match(candidateWorkflow, /write-public-plugin-release-evidence\.mjs/u);
@@ -383,7 +392,7 @@ for (const invalidTag of [
 	packageDocument.version,
 	`v${packageDocument.version}`,
 	'cli-v0.0.0',
-	'cli-v1.0.0-beta.1',
+	`cli-v${packageDocument.version}-beta.1`,
 	'cli-v0.1.0-beta.11-extra',
 ]) {
 	const rejected = spawnSync(process.execPath, [checker], {

--- a/scripts/agent-runtime/cli/native-acceptance.test.mjs
+++ b/scripts/agent-runtime/cli/native-acceptance.test.mjs
@@ -61,7 +61,7 @@ test('36 digest-bound native cells produce one promotion-eligible aggregate', as
 			`${JSON.stringify({
 				...nativeEvidence,
 				kind: 'operon-cli-release-candidate',
-				source: { ...nativeEvidence.source, ref: 'cli-v1.0.0' },
+				source: { ...nativeEvidence.source, ref: 'cli-v1.0.1' },
 				compatiblePublicPlugin: {
 					...nativeEvidence.compatiblePublicPlugin,
 					kind: 'operon-public-plugin-release',
@@ -147,7 +147,7 @@ test('offline candidate comparison rejects every critical identity change', asyn
 		const accepted = structuredClone(fixture.binding);
 		const mutations = [
 			current => { current.candidateEvidenceSha256 = '9'.repeat(64); },
-			current => { current.sourceRef = 'cli-v1.0.0'; },
+			current => { current.sourceRef = 'cli-v1.0.1'; },
 			current => { current.cliManifestSha256 = '8'.repeat(64); },
 			current => { current.aggregateContractSha256 = '7'.repeat(64); },
 			current => { current.compatiblePublicPlugin.kind = 'operon-public-plugin-release'; },
@@ -161,7 +161,7 @@ test('offline candidate comparison rejects every critical identity change', asyn
 		const release = structuredClone(accepted);
 		release.candidateKind = 'operon-cli-release-candidate';
 		release.candidateEvidenceSha256 = '9'.repeat(64);
-		release.sourceRef = 'cli-v1.0.0';
+		release.sourceRef = 'cli-v1.0.1';
 		release.compatiblePublicPlugin.kind = 'operon-public-plugin-release';
 		release.compatiblePublicPlugin.releaseTag = '3.0.0';
 		assert.doesNotThrow(() => assertStableCandidateIdentityV1(accepted, release));
@@ -345,7 +345,7 @@ async function createFixture(platforms = {
 	await mkdir(candidateRoot);
 	await mkdir(acceptanceRoot);
 	const tarball = Buffer.from('immutable candidate tarball\n');
-	const tarballName = 'operon-cli-1.0.0.tgz';
+	const tarballName = 'operon-cli-1.0.1.tgz';
 	const tarballSha256 = sha256(tarball);
 	await writeFile(path.join(candidateRoot, tarballName), tarball);
 	const plugin = {
@@ -361,7 +361,7 @@ async function createFixture(platforms = {
 	await writeFile(path.join(candidateRoot, 'candidate-evidence.json'), `${JSON.stringify({
 		evidenceVersion: 1,
 		kind: 'operon-cli-native-candidate',
-		package: 'operon-cli@1.0.0',
+		package: 'operon-cli@1.0.1',
 		tarball: tarballName,
 		sha256: tarballSha256,
 		cliManifestSha256: 'c'.repeat(64),

--- a/scripts/agent-runtime/contracts/public-v1-freeze.mjs
+++ b/scripts/agent-runtime/contracts/public-v1-freeze.mjs
@@ -126,7 +126,7 @@ export async function buildPublicV1FreezeIndex(options = {}) {
 			contentAggregateSha256: docsAggregate.aggregateSha256,
 		},
 		plugin: {
-			artifactStatus: 'provisional-unpublished',
+			artifactStatus: 'local-rebuilt-artifact',
 			pluginId: pluginManifest.id,
 			version: pluginManifest.version,
 			main: await fileRecord(root, 'main.js'),
@@ -428,7 +428,7 @@ async function buildAuditArtifactMetafiles(root) {
 
 function assertAcceptedFreeze(index) {
 	if (
-		index.cli.packageVersion !== '1.0.0'
+		index.cli.packageVersion !== '1.0.1'
 		|| index.plugin.version !== '3.0.0'
 		|| index.audit.validation.status !== 'passed'
 		|| index.audit.validation.result?.status !== 'accepted-clean'

--- a/scripts/agent-runtime/contracts/public-v1-freeze.test.mjs
+++ b/scripts/agent-runtime/contracts/public-v1-freeze.test.mjs
@@ -156,7 +156,7 @@ test('freeze writer binds exact local inputs and check rejects byte drift', asyn
 			generateTarball: false,
 		});
 		assert.equal(written.state, 'provisional');
-		assert.equal(written.plugin.artifactStatus, 'provisional-unpublished');
+		assert.equal(written.plugin.artifactStatus, 'local-rebuilt-artifact');
 		assert.equal(
 			written.cli.tarball.path,
 			'packages/operon-cli/freeze/operon-cli-0.1.0-beta.1.tgz',
@@ -198,10 +198,10 @@ test('accepted freeze requires final versions, passed audit and explicit maintai
 		);
 		await writeJson(path.join(root, 'packages/operon-cli/package.json'), {
 			name: 'operon-cli',
-			version: '1.0.0',
+			version: '1.0.1',
 		});
 		await writeFile(
-			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.0.tgz'),
+			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.1.tgz'),
 			'stable tarball\n',
 		);
 		await writeJson(path.join(root, 'manifest.json'), {
@@ -231,10 +231,10 @@ test('ordinary write clears prior acceptance and audit attestation', async () =>
 	try {
 		await writeJson(path.join(root, 'packages/operon-cli/package.json'), {
 			name: 'operon-cli',
-			version: '1.0.0',
+			version: '1.0.1',
 		});
 		await writeFile(
-			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.0.tgz'),
+			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.1.tgz'),
 			'stable tarball\n',
 		);
 		await writeJson(path.join(root, 'manifest.json'), {


### PR DESCRIPTION
## Summary

- fixes the immutable CLI candidate packaging path
- advances the unpublished CLI package to 1.0.1
- renews and accepts the Public V1 freeze
- preserves Runtime API V1 and CLI contract V1 digests

## Release evidence

- accepted freeze: 36add50aac8dcfe96940bac6d3fb98bd47748085cb3f7e156bced7e94dd25a22
- input aggregate: 00cd63c3b852702415b9d92ca578b4ec940d5cf3d3b291f9f300bcaf2b777311
- canonical tarball: 7ba1e084436ed8d5396780c3364c7e52508fe964301a00610c3d375ffa6dcc0e
- CLI executable: 13c732012cbde6abae893fd0d8ff9d239204e24966fa67a157bc880f7c76b230
- audit: 0 production and 0 development vulnerabilities
- Phase 5: 1517/1517

This PR does not create a tag or publish to npm.