### PR TITLE
Release operon-cli 1.0.2

### DIFF
--- a/.github/workflows/cli-release-ready.yml
+++ b/.github/workflows/cli-release-ready.yml
@@ -176,10 +176,13 @@ jobs:
           cache: npm
       - name: Pin portability npm
         run: npm install --global npm@11.12.1
-      - name: Verify exact source and toolchain
+      - name: Verify exact source identity
         env:
           SOURCE_REF: ${{ inputs.source_ref }}
-        run: node -e "const {execFileSync}=require('node:child_process'); if(process.version!=='v${{ matrix.node }}')throw new Error('Unexpected Node version'); if(execFileSync(process.platform==='win32'?'npm.cmd':'npm',['--version'],{encoding:'utf8'}).trim()!=='11.12.1')throw new Error('Unexpected npm version'); if(execFileSync('git',['rev-parse','HEAD'],{encoding:'utf8'}).trim()!==process.env.GITHUB_SHA)throw new Error('Source commit drift'); if(process.env.GITHUB_REF!=='refs/tags/'+process.env.SOURCE_REF)throw new Error('Source tag drift');"
+        run: node -e "const {execFileSync}=require('node:child_process'); if(process.version!=='v${{ matrix.node }}')throw new Error('Unexpected Node version'); if(execFileSync('git',['rev-parse','HEAD'],{encoding:'utf8'}).trim()!==process.env.GITHUB_SHA)throw new Error('Source commit drift'); if(process.env.GITHUB_REF!=='refs/tags/'+process.env.SOURCE_REF)throw new Error('Source tag drift');"
+      - name: Verify exact npm version
+        shell: bash
+        run: test "$(npm --version)" = "11.12.1"
       - run: npm ci
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:

--- a/contracts/agent-runtime/public-v1-freeze.json
+++ b/contracts/agent-runtime/public-v1-freeze.json
@@ -6,7 +6,7 @@
     "files": [
       {
         "path": "contracts/agent-runtime/public-v1-scope.md",
-        "sha256": "b1889ddb674639c289d13c06b8b45630edd07cfdab7cdb374ed365619c3bd38b",
+        "sha256": "588b639fc5991c4668730dd8fe273d28175ab489179508b17b0fb534bc4642af",
         "bytes": 16951
       },
       {
@@ -41,11 +41,11 @@
       },
       {
         "path": "scripts/agent-runtime/contracts/public-v1-freeze.mjs",
-        "sha256": "c1b6b90ddfaa555942bec3232aabba15d3cf2ae93407be9664f31a9ac787af87",
+        "sha256": "9d6ad83657d166d26d1b3866053ba1858f50721055aa18459dbb8a1db6acf214",
         "bytes": 22999
       }
     ],
-    "aggregateSha256": "918037b8ceff05f93233016b0f5ac0ad39ceabb35e30d6a1eeaad4b37d303fb7"
+    "aggregateSha256": "df4346196d1854e05f09ad84bf2adc554583d3706fbbb113ac5c44534f1e2335"
   },
   "runtime": {
     "contractVersion": 1,
@@ -63,16 +63,16 @@
   },
   "cli": {
     "contractVersion": 1,
-    "packageVersion": "1.0.1",
+    "packageVersion": "1.0.2",
     "contractDigest": "d280747a21f46add48d70193205c4dc642b1e0f38447209611174e33beff5927",
     "tarball": {
-      "path": "packages/operon-cli/freeze/operon-cli-1.0.1.tgz",
-      "sha256": "7ba1e084436ed8d5396780c3364c7e52508fe964301a00610c3d375ffa6dcc0e",
-      "bytes": 213382
+      "path": "packages/operon-cli/freeze/operon-cli-1.0.2.tgz",
+      "sha256": "b369ec7864ac10b86a925e30bd5e3039d703e1bea2fbd9d4cf64f13e33b510fe",
+      "bytes": 213383
     },
     "executable": {
       "path": "packages/operon-cli/dist/operon.mjs",
-      "sha256": "13c732012cbde6abae893fd0d8ff9d239204e24966fa67a157bc880f7c76b230",
+      "sha256": "49f89954cfb3b3829d9a416716cc536257a3e81c657080c063f3227ed1f5abee",
       "bytes": 512706
     },
     "license": {
@@ -82,12 +82,12 @@
     },
     "manifest": {
       "path": "packages/operon-cli/cli-manifest-v1.json",
-      "sha256": "f56c223503af52c3f8997150f1b3cbe9100292b6c23e5641eb4e2ff7d8a8c6d0",
+      "sha256": "3607da4c54098fb79edeaef2cdd8580d0196e1e5d0385bf16f226571ee7cd503",
       "bytes": 51224
     },
     "packageMetadata": {
       "path": "packages/operon-cli/package.json",
-      "sha256": "873928407044243c81f69c389470835fe7e97a498547635f7a2e61b980cb9019",
+      "sha256": "269d12cd15c6e0ca18c1d0a42eba912e29a3fa5c1d640f22f4d617666884921a",
       "bytes": 1978
     },
     "readme": {
@@ -110,7 +110,7 @@
       "fileCount": 5,
       "aggregateSha256": "2ecd8a3e0ae2e069bc89a7cd70cdb724f4023f2b306391b21fbbabca07dd12c6"
     },
-    "packageInputAggregateSha256": "4afe5d397b11797748b64d028b507b42d51363bce285fa661527a2fcc2a7ac4c"
+    "packageInputAggregateSha256": "53be2112bbfc223846281536fb35a4333848504b5c3edc13de5656dd0619aa40"
   },
   "documentation": {
     "manifest": {
@@ -196,7 +196,7 @@
   "maintainerAcceptance": {
     "status": "accepted",
     "acceptedBy": "Hasan Yilmaz",
-    "acceptedAt": "2026-08-01T01:51:45.000Z"
+    "acceptedAt": "2026-08-01T08:24:56.000Z"
   },
-  "inputsAggregateSha256": "00cd63c3b852702415b9d92ca578b4ec940d5cf3d3b291f9f300bcaf2b777311"
+  "inputsAggregateSha256": "cbec2501966171840dde08f6bd92b8bb177ce916e551a449469d5507ee435b14"
 }

--- a/contracts/agent-runtime/public-v1-scope.md
+++ b/contracts/agent-runtime/public-v1-scope.md
@@ -16,7 +16,7 @@ has passed.
 Public V1 launch versions:
 
 - Operon `3.0.0`
-- `operon-cli@1.0.1`
+- `operon-cli@1.0.2`
 - Runtime API and contract version `1`
 
 The current CLI is a private release candidate and is not publicly installable
@@ -52,7 +52,7 @@ versioned Public V1 integration contract.
 | Area | Current implementation truth | Public V1 launch target |
 | --- | --- | --- |
 | Operon release | Operon `3.0.0` is publicly released with Runtime API V1 | Operon `3.0.0` |
-| CLI package | Local `operon-cli@1.0.1` stable release candidate; not published to public npm | Public stable `operon-cli@1.0.1` |
+| CLI package | Local `operon-cli@1.0.2` stable release candidate; not published to public npm | Public stable `operon-cli@1.0.2` |
 | Runtime contract | Runtime API V1 exists and is exposed on the Operon plugin instance | Runtime API V1 is a supported, typed Developer API contract |
 | Public access channels | The in-process Developer API ships with Operon `3.0.0`; the CLI remains an unpublished local release candidate | CLI and in-process Developer API are both supported public channels |
 | macOS CLI | Supported by the current beta boundary | Supported |
@@ -259,7 +259,7 @@ support, documentation, and release acceptance do not depend on that work.
 | Cross-platform launch boundary, Node support, and beta disclosure | Stage 7 — Cross-platform readiness | Hosted portability and package tests pass on Node 22, 24, and 26 across macOS, Linux, and Windows; platform-specific transport-security, path, lifecycle, interruption, and recovery tests pass; macOS remains `supported`, Linux and Windows remain executable `acceptance-required` public-beta targets, and WSL remains `unsupported` |
 | Public integration guides and examples | Stage 8 — Packaging and documentation | Clean-room CLI and Developer API integration tests using only distributable artifacts and documentation |
 | Stable contract and release candidate | Stage 9 — Hardening and freeze | No launch-blocking contract break, unauthorized access, consent bypass, data loss or corruption, or irrecoverable uncertain outcome remains; all required local contract, security, mutation, Developer API, package, documentation, and release-hardening gates pass; contract, stable manifest, package inputs, types, examples, documentation, source-rebuilt plugin artifact, and development-audit policy are bound by one exact local freeze index; the compatibility baseline has real input/response direction and deprecation coverage; documented maintainer acceptance seals the final local index |
-| Public `operon-cli@1.0.1` | Stage 10 — External release | Before publish, the accepted Stage 9 freeze, final tarball digest, provenance, compatible public Operon artifact, and nine-cell hosted portability evidence pass on the release bytes; after publish, the registry artifact digest equals that tarball and the post-publication audit passes |
+| Public `operon-cli@1.0.2` | Stage 10 — External release | Before publish, the accepted Stage 9 freeze, final tarball digest, provenance, compatible public Operon artifact, and nine-cell hosted portability evidence pass on the release bytes; after publish, the registry artifact digest equals that tarball and the post-publication audit passes |
 
 Failure of a required gate returns the work to its owning stage. Publication is
 not a substitute for contract, safety, package, or hosted portability evidence.

--- a/packages/operon-cli/cli-manifest-v1.json
+++ b/packages/operon-cli/cli-manifest-v1.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "package": {
     "name": "operon-cli",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "executable": "operon",
     "node": "^22.0.0 || ^24.0.0 || ^26.0.0"
   },

--- a/packages/operon-cli/package.json
+++ b/packages/operon-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "operon-cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Official command-line client for the Operon Agent Runtime in Obsidian.",
   "type": "module",
   "license": "GPL-3.0-or-later",

--- a/scripts/agent-runtime/cli/native-acceptance.test.mjs
+++ b/scripts/agent-runtime/cli/native-acceptance.test.mjs
@@ -28,6 +28,10 @@ const evidenceSchema = JSON.parse(await readFile(
 	'utf8',
 ));
 const validateEvidence = new Ajv2020({ strict: false }).compile(evidenceSchema);
+const FIXTURE_CLI_VERSION = '1.0.2';
+const FIXTURE_CLI_TAG = `cli-v${FIXTURE_CLI_VERSION}`;
+const FIXTURE_CLI_PACKAGE = `operon-cli@${FIXTURE_CLI_VERSION}`;
+const FIXTURE_CLI_TARBALL = `operon-cli-${FIXTURE_CLI_VERSION}.tgz`;
 
 test('36 digest-bound native cells produce one promotion-eligible aggregate', async () => {
 	const fixture = await createFixture();
@@ -61,7 +65,7 @@ test('36 digest-bound native cells produce one promotion-eligible aggregate', as
 			`${JSON.stringify({
 				...nativeEvidence,
 				kind: 'operon-cli-release-candidate',
-				source: { ...nativeEvidence.source, ref: 'cli-v1.0.1' },
+				source: { ...nativeEvidence.source, ref: FIXTURE_CLI_TAG },
 				compatiblePublicPlugin: {
 					...nativeEvidence.compatiblePublicPlugin,
 					kind: 'operon-public-plugin-release',
@@ -147,7 +151,7 @@ test('offline candidate comparison rejects every critical identity change', asyn
 		const accepted = structuredClone(fixture.binding);
 		const mutations = [
 			current => { current.candidateEvidenceSha256 = '9'.repeat(64); },
-			current => { current.sourceRef = 'cli-v1.0.1'; },
+			current => { current.sourceRef = FIXTURE_CLI_TAG; },
 			current => { current.cliManifestSha256 = '8'.repeat(64); },
 			current => { current.aggregateContractSha256 = '7'.repeat(64); },
 			current => { current.compatiblePublicPlugin.kind = 'operon-public-plugin-release'; },
@@ -161,7 +165,7 @@ test('offline candidate comparison rejects every critical identity change', asyn
 		const release = structuredClone(accepted);
 		release.candidateKind = 'operon-cli-release-candidate';
 		release.candidateEvidenceSha256 = '9'.repeat(64);
-		release.sourceRef = 'cli-v1.0.1';
+	release.sourceRef = FIXTURE_CLI_TAG;
 		release.compatiblePublicPlugin.kind = 'operon-public-plugin-release';
 		release.compatiblePublicPlugin.releaseTag = '3.0.0';
 		assert.doesNotThrow(() => assertStableCandidateIdentityV1(accepted, release));
@@ -345,7 +349,7 @@ async function createFixture(platforms = {
 	await mkdir(candidateRoot);
 	await mkdir(acceptanceRoot);
 	const tarball = Buffer.from('immutable candidate tarball\n');
-	const tarballName = 'operon-cli-1.0.1.tgz';
+	const tarballName = FIXTURE_CLI_TARBALL;
 	const tarballSha256 = sha256(tarball);
 	await writeFile(path.join(candidateRoot, tarballName), tarball);
 	const plugin = {
@@ -361,7 +365,7 @@ async function createFixture(platforms = {
 	await writeFile(path.join(candidateRoot, 'candidate-evidence.json'), `${JSON.stringify({
 		evidenceVersion: 1,
 		kind: 'operon-cli-native-candidate',
-		package: 'operon-cli@1.0.1',
+		package: FIXTURE_CLI_PACKAGE,
 		tarball: tarballName,
 		sha256: tarballSha256,
 		cliManifestSha256: 'c'.repeat(64),

--- a/scripts/agent-runtime/contracts/public-v1-freeze.mjs
+++ b/scripts/agent-runtime/contracts/public-v1-freeze.mjs
@@ -428,7 +428,7 @@ async function buildAuditArtifactMetafiles(root) {
 
 function assertAcceptedFreeze(index) {
 	if (
-		index.cli.packageVersion !== '1.0.1'
+		index.cli.packageVersion !== '1.0.2'
 		|| index.plugin.version !== '3.0.0'
 		|| index.audit.validation.status !== 'passed'
 		|| index.audit.validation.result?.status !== 'accepted-clean'

--- a/scripts/agent-runtime/contracts/public-v1-freeze.test.mjs
+++ b/scripts/agent-runtime/contracts/public-v1-freeze.test.mjs
@@ -198,10 +198,10 @@ test('accepted freeze requires final versions, passed audit and explicit maintai
 		);
 		await writeJson(path.join(root, 'packages/operon-cli/package.json'), {
 			name: 'operon-cli',
-			version: '1.0.1',
+			version: '1.0.2',
 		});
 		await writeFile(
-			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.1.tgz'),
+			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.2.tgz'),
 			'stable tarball\n',
 		);
 		await writeJson(path.join(root, 'manifest.json'), {
@@ -231,10 +231,10 @@ test('ordinary write clears prior acceptance and audit attestation', async () =>
 	try {
 		await writeJson(path.join(root, 'packages/operon-cli/package.json'), {
 			name: 'operon-cli',
-			version: '1.0.1',
+			version: '1.0.2',
 		});
 		await writeFile(
-			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.1.tgz'),
+			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.2.tgz'),
 			'stable tarball\n',
 		);
 		await writeJson(path.join(root, 'manifest.json'), {

--- a/scripts/release-guard.mjs
+++ b/scripts/release-guard.mjs
@@ -662,6 +662,37 @@ function checkWorkflowSecurityPolicy() {
 			fail(`${workflow}: stable candidate must run npm ci, audit policy, and release guard in order`);
 		}
 	}
+	const releaseReadyWorkflow = readText('.github/workflows/cli-release-ready.yml');
+	const hostedJobHeader = '  hosted-portability:\n';
+	const hostedJobStart = releaseReadyWorkflow.indexOf(hostedJobHeader);
+	const hostedJobRemainder = hostedJobStart < 0
+		? ''
+		: releaseReadyWorkflow.slice(hostedJobStart + hostedJobHeader.length);
+	const nextJobOffset = hostedJobRemainder.search(/^  [a-z0-9-]+:\s*$/mu);
+	const hostedJob = nextJobOffset < 0
+		? hostedJobRemainder
+		: hostedJobRemainder.slice(0, nextJobOffset);
+	if (hostedJobStart < 0 || hostedJob === '') {
+		fail('.github/workflows/cli-release-ready.yml: hosted-portability job is missing');
+	}
+	if (/execFileSync\([^\n]*npm(?:\.cmd)?/u.test(hostedJob)) {
+		fail('.github/workflows/cli-release-ready.yml: Windows npm shims must not be launched with execFileSync');
+	}
+	const npmVerification = [
+		'- name: Verify exact npm version',
+		'        shell: bash',
+		'        run: test "$(npm --version)" = "11.12.1"',
+	].join('\n');
+	const pinIndex = hostedJob.indexOf('- name: Pin portability npm');
+	const verificationIndex = hostedJob.indexOf(npmVerification);
+	const installIndex = hostedJob.indexOf('- run: npm ci');
+	if (
+		pinIndex < 0
+		|| verificationIndex < pinIndex
+		|| installIndex < verificationIndex
+	) {
+		fail('.github/workflows/cli-release-ready.yml: hosted portability must verify npm through a portable shell command');
+	}
 }
 
 function checkPublicSourceHygiene() {


### PR DESCRIPTION
## Summary

- fixes the Windows hosted portability verifier so it checks the pinned npm version through the runner shell instead of launching the `npm.cmd` shim with `execFileSync`
- advances the unpublished CLI release candidate to `operon-cli@1.0.2`
- binds the native acceptance fixtures and release guard to the corrected release identity and workflow structure
- records the newly accepted Public V1 freeze

## Root cause

The immutable `cli-v1.0.1` candidate passed macOS and Ubuntu, but all three Windows cells stopped before package testing with `spawnSync npm.cmd EINVAL`. The workflow attempted to execute a Windows command shim as a native executable. The failed tag remains unchanged as release audit history.

## Release evidence

- source base: `657956d19446546fc7cd78e08ef7d7f7a0439d8b`
- accepted freeze: `11add47ea2527237a9eba89d300c77837f18af8bdae4fe588b76b10a5b3e9312`
- freeze input aggregate: `cbec2501966171840dde08f6bd92b8bb177ce916e551a449469d5507ee435b14`
- CLI tarball: `b369ec7864ac10b86a925e30bd5e3039d703e1bea2fbd9d4cf64f13e33b510fe` (`213383` bytes)
- CLI executable: `49f89954cfb3b3829d9a416716cc536257a3e81c657080c063f3227ed1f5abee`
- Runtime contract digest: `d280747a21f46add48d70193205c4dc642b1e0f38447209611174e33beff5927`

## Validation

- canonical Node `24.18.0` and npm `11.12.1`
- live audit policy: 0 production and 0 development vulnerabilities
- `npm run check:local`
- Phase 5 regression: 1517/1517
- clean-room CLI pack, install, rollback, re-upgrade, and uninstall
- NodeNext, Bundler, and `typesVersions` consumer compilation
- release guard, accepted freeze check, documentation parity, and privacy checks
- multi-lens Windows workflow, freeze identity, and package review

This PR does not publish npm, create a CLI tag, create a GitHub Release, or modify generated Operon Docs, changelog, plugin artifacts, or media.
