### PR TITLE
Harden CLI package reproducibility

### DIFF
--- a/contracts/agent-runtime/public-v1-freeze.json
+++ b/contracts/agent-runtime/public-v1-freeze.json
@@ -41,11 +41,11 @@
       },
       {
         "path": "scripts/agent-runtime/contracts/public-v1-freeze.mjs",
-        "sha256": "d075c6eb0a9c6b74a93955ecd9f46fafa38a7264a5c1a9e910a2de0eca835cbe",
-        "bytes": 22999
+        "sha256": "b8ea4b423e906f3e02d8b98b8a2a1c454f4b550e7213c13cdb076f079f7fa1be",
+        "bytes": 23918
       }
     ],
-    "aggregateSha256": "cf5a96e70f7ea7f671aaf3378b254b4d69557507aef13ffc621d0b97c24c1f9e"
+    "aggregateSha256": "fb8218fee623534b3b5d010c8b73bf611f8250be4ec882f4280c86af071501b2"
   },
   "runtime": {
     "contractVersion": 1,
@@ -67,8 +67,8 @@
     "contractDigest": "d280747a21f46add48d70193205c4dc642b1e0f38447209611174e33beff5927",
     "tarball": {
       "path": "packages/operon-cli/freeze/operon-cli-1.0.3.tgz",
-      "sha256": "a1e3b5bece554d1df6fb20e1287d3c9d26a5e1c53c2d861107478010dd63a189",
-      "bytes": 213399
+      "sha256": "cff297d2a45399a84105789423ee713a5c201fd2a1a060a08309d489bba15470",
+      "bytes": 213393
     },
     "executable": {
       "path": "packages/operon-cli/dist/operon.mjs",
@@ -110,7 +110,7 @@
       "fileCount": 5,
       "aggregateSha256": "2ecd8a3e0ae2e069bc89a7cd70cdb724f4023f2b306391b21fbbabca07dd12c6"
     },
-    "packageInputAggregateSha256": "5f31529f8b9c224c462f88509e37cbacbf8ac34358c95ac323a25b7e65bcd045"
+    "packageInputAggregateSha256": "81c567899a2059c5724c8a1cfea04e5e89c8d677b3ef1cce890c84a4b454c46a"
   },
   "documentation": {
     "manifest": {
@@ -196,7 +196,7 @@
   "maintainerAcceptance": {
     "status": "accepted",
     "acceptedBy": "Hasan Yilmaz",
-    "acceptedAt": "2026-08-01T09:53:27.352Z"
+    "acceptedAt": "2026-08-01T10:55:18.169Z"
   },
-  "inputsAggregateSha256": "8522c64d6c128ba6fc0c9bd55e0c6fb9ecc84750c0e6b91c00ad2a7ea49916ca"
+  "inputsAggregateSha256": "869a6a21363b65790a8e34ace73573aa2415ab2ac0d303f533407308a16a2598"
 }

--- a/packages/operon-cli/build.mjs
+++ b/packages/operon-cli/build.mjs
@@ -216,7 +216,12 @@ for (const sourceRoot of [
 			throw new Error(`OPERON_CLI_SCHEMA_FILENAME_COLLISION:${fileName}`);
 		}
 		copiedSchemaFileNames.add(fileName);
-		await copyFile(path.join(sourceRoot, fileName), path.join(schemaTargetRoot, fileName));
+		const schemaTargetPath = path.join(schemaTargetRoot, fileName);
+		await copyFile(path.join(sourceRoot, fileName), schemaTargetPath);
+		await chmod(schemaTargetPath, 0o644);
+		if (process.platform !== 'win32' && ((await stat(schemaTargetPath)).mode & 0o777) !== 0o644) {
+			throw new Error(`OPERON_CLI_SCHEMA_MODE_INVALID:${fileName}`);
+		}
 	}
 }
 

--- a/scripts/agent-runtime/contracts/generate-schema-manifest.mjs
+++ b/scripts/agent-runtime/contracts/generate-schema-manifest.mjs
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { readFile, readdir, rename, writeFile } from 'node:fs/promises';
+import { chmod, readFile, readdir, rename, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -113,6 +113,7 @@ export async function writeRuntimeSchemaManifestV1(options = {}) {
 	const output = await buildRuntimeSchemaManifestV1(options);
 	const temporary = `${target}.${process.pid}.tmp`;
 	await writeFile(temporary, output, { encoding: 'utf8', mode: 0o600 });
+	await chmod(temporary, 0o644);
 	await rename(temporary, target);
 	return output;
 }

--- a/scripts/agent-runtime/contracts/public-v1-freeze.mjs
+++ b/scripts/agent-runtime/contracts/public-v1-freeze.mjs
@@ -250,6 +250,7 @@ export async function writeCanonicalCliTarball(root = defaultPluginRoot) {
 		if (packed[0]?.filename !== expectedFilename) {
 			throw new Error('OPERON_PUBLIC_V1_FREEZE_PACK_FILENAME_INVALID');
 		}
+		assertCanonicalCliTarballModes(packed[0], packageDocument);
 		const freezeRoot = path.join(packageRoot, 'freeze');
 		await mkdir(freezeRoot, { recursive: true });
 		await copyFile(
@@ -259,6 +260,30 @@ export async function writeCanonicalCliTarball(root = defaultPluginRoot) {
 		return path.join(freezeRoot, expectedFilename);
 	} finally {
 		await rm(temporaryRoot, { recursive: true, force: true });
+	}
+}
+
+function assertCanonicalCliTarballModes(packResult, packageDocument) {
+	if (!Array.isArray(packResult.files)) {
+		throw new Error('OPERON_PUBLIC_V1_FREEZE_PACK_FILES_INVALID');
+	}
+	const binValues = typeof packageDocument.bin === 'string'
+		? [packageDocument.bin]
+		: Object.values(packageDocument.bin ?? {});
+	const executablePaths = new Set(binValues.map(value => {
+		if (typeof value !== 'string') {
+			throw new Error('OPERON_PUBLIC_V1_FREEZE_PACKAGE_BIN_INVALID');
+		}
+		return safeRelativePath(value.replace(/^\.\//u, ''));
+	}));
+	for (const file of packResult.files) {
+		const filePath = safeRelativePath(file?.path);
+		const expectedMode = executablePaths.has(filePath) ? 0o755 : 0o644;
+		if (file?.mode !== expectedMode) {
+			throw new Error(
+				`OPERON_PUBLIC_V1_FREEZE_PACK_MODE_INVALID:${filePath}:${file?.mode ?? 'missing'}`,
+			);
+		}
 	}
 }
 

--- a/scripts/agent-runtime/contracts/public-v1-freeze.test.mjs
+++ b/scripts/agent-runtime/contracts/public-v1-freeze.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
 import {
+	chmod,
 	cp,
 	mkdir,
 	mkdtemp,
@@ -286,6 +287,26 @@ test('canonical npm tarball generation is reproducible', async () => {
 		assert.equal(
 			createHash('sha256').update(first).digest('hex'),
 			createHash('sha256').update(second).digest('hex'),
+		);
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+});
+
+test('canonical npm tarball rejects non-public file modes', {
+	skip: process.platform === 'win32',
+}, async () => {
+	const root = await fixtureRoot();
+	try {
+		await writeJson(path.join(root, 'packages/operon-cli/package.json'), {
+			name: 'operon-cli',
+			version: '0.1.0-beta.1',
+			files: ['README.md', 'LICENSE'],
+		});
+		await chmod(path.join(root, 'packages/operon-cli/README.md'), 0o600);
+		await assert.rejects(
+			writeCanonicalCliTarball(root),
+			/OPERON_PUBLIC_V1_FREEZE_PACK_MODE_INVALID:README\.md:384/u,
 		);
 	} finally {
 		await rm(root, { recursive: true, force: true });

--- a/scripts/agent-runtime/contracts/schema-manifest.test.mjs
+++ b/scripts/agent-runtime/contracts/schema-manifest.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { cp, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { cp, mkdtemp, readFile, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -27,6 +27,9 @@ test('runtime schema manifest generation is deterministic and check is read-only
 	assert.equal(first, second);
 	await writeRuntimeSchemaManifestV1({ canonicalRoot: root });
 	const before = await readFile(path.join(root, 'schema-manifest.json'), 'utf8');
+	if (process.platform !== 'win32') {
+		assert.equal((await stat(path.join(root, 'schema-manifest.json'))).mode & 0o777, 0o644);
+	}
 	await checkRuntimeSchemaManifestV1({ canonicalRoot: root });
 	const after = await readFile(path.join(root, 'schema-manifest.json'), 'utf8');
 	assert.equal(after, before);


### PR DESCRIPTION
## Summary

- makes public schema file modes deterministic across dirty worktrees and clean Git checkouts
- enforces `0644` for packaged non-bin files and `0755` for declared CLI binaries
- adds fail-closed tar inventory and regression coverage
- refreshes and re-accepts the Public V1 freeze without changing Runtime or CLI contract behavior

## Release evidence

- Operon: `3.0.1`
- operon-cli: `1.0.3`
- Accepted freeze SHA-256: `5ec50b094aec2c200e7e934c49c29da26eebb3b34fcab65f5a4877e4975e6706`
- Freeze input aggregate: `869a6a21363b65790a8e34ace73573aa2415ab2ac0d303f533407308a16a2598`
- CLI tarball SHA-256: `cff297d2a45399a84105789423ee713a5c201fd2a1a060a08309d489bba15470`
- Audit: 0 production and 0 development vulnerabilities
- Phase 5: 1517/1517
- Privacy scan: 0 findings across the exact 6-file scope

This PR does not create a tag, GitHub Release, or npm publication.
