### PR TITLE
Prepare operon-cli 1.0.4 release candidate

### DIFF
--- a/.github/workflows/cli-live-acceptance.yml
+++ b/.github/workflows/cli-live-acceptance.yml
@@ -105,9 +105,37 @@ jobs:
           cache: npm
       - name: Pin acceptance npm
         run: npm install --global npm@11.12.1
+      - name: Bind pinned Windows npm CLI
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $npmPrefix = (npm prefix --global).Trim()
+          if ($LASTEXITCODE -ne 0) {
+            throw "Pinned npm prefix lookup failed with exit code $LASTEXITCODE."
+          }
+          $npmCli = Join-Path $npmPrefix 'node_modules\npm\bin\npm-cli.js'
+          if (-not [System.IO.Path]::IsPathFullyQualified($npmCli)) {
+            throw 'Pinned npm CLI path must be absolute.'
+          }
+          if (-not (Test-Path -LiteralPath $npmCli -PathType Leaf)) {
+            throw 'Pinned npm CLI file is unavailable.'
+          }
+          $npmVersion = (& node $npmCli --version).Trim()
+          if ($LASTEXITCODE -ne 0) {
+            throw "Pinned npm CLI execution failed with exit code $LASTEXITCODE."
+          }
+          if ($npmVersion -ne '11.12.1') {
+            throw "Pinned npm CLI version mismatch: $npmVersion"
+          }
+          Add-Content -LiteralPath $env:GITHUB_ENV -Value "OPERON_ACCEPTANCE_NPM_CLI_JS=$npmCli"
       - name: Verify acceptance toolchain
         run: node -e "if (process.version !== 'v${{ matrix.node }}') throw new Error('Unexpected frozen Node version.');"
-      - run: npm --version
+      - name: Verify exact npm version
+        shell: bash
+        run: test "$(npm --version)" = "11.12.1"
+      - name: Verify exact helper npm identity
+        shell: bash
+        run: node --input-type=module -e "import { execNpmV1 } from './scripts/agent-runtime/cli/live-acceptance-platform.mjs'; const version = execNpmV1(['--version'], { encoding: 'utf8' }).trim(); if (version !== '11.12.1') throw new Error('Hosted helper npm identity mismatch');"
       - run: npm ci
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:

--- a/.github/workflows/cli-release-ready.yml
+++ b/.github/workflows/cli-release-ready.yml
@@ -176,6 +176,29 @@ jobs:
           cache: npm
       - name: Pin portability npm
         run: npm install --global npm@11.12.1
+      - name: Bind pinned Windows npm CLI
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $npmPrefix = (npm prefix --global).Trim()
+          if ($LASTEXITCODE -ne 0) {
+            throw "Pinned npm prefix lookup failed with exit code $LASTEXITCODE."
+          }
+          $npmCli = Join-Path $npmPrefix 'node_modules\npm\bin\npm-cli.js'
+          if (-not [System.IO.Path]::IsPathFullyQualified($npmCli)) {
+            throw 'Pinned npm CLI path must be absolute.'
+          }
+          if (-not (Test-Path -LiteralPath $npmCli -PathType Leaf)) {
+            throw 'Pinned npm CLI file is unavailable.'
+          }
+          $npmVersion = (& node $npmCli --version).Trim()
+          if ($LASTEXITCODE -ne 0) {
+            throw "Pinned npm CLI execution failed with exit code $LASTEXITCODE."
+          }
+          if ($npmVersion -ne '11.12.1') {
+            throw "Pinned npm CLI version mismatch: $npmVersion"
+          }
+          Add-Content -LiteralPath $env:GITHUB_ENV -Value "OPERON_ACCEPTANCE_NPM_CLI_JS=$npmCli"
       - name: Verify exact source identity
         env:
           SOURCE_REF: ${{ inputs.source_ref }}
@@ -183,6 +206,9 @@ jobs:
       - name: Verify exact npm version
         shell: bash
         run: test "$(npm --version)" = "11.12.1"
+      - name: Verify exact helper npm identity
+        shell: bash
+        run: node --input-type=module -e "import { execNpmV1 } from './scripts/agent-runtime/cli/live-acceptance-platform.mjs'; const version = execNpmV1(['--version'], { encoding: 'utf8' }).trim(); if (version !== '11.12.1') throw new Error('Hosted helper npm identity mismatch');"
       - run: npm ci
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:

--- a/contracts/agent-runtime/public-v1-freeze.json
+++ b/contracts/agent-runtime/public-v1-freeze.json
@@ -6,8 +6,8 @@
     "files": [
       {
         "path": "contracts/agent-runtime/public-v1-scope.md",
-        "sha256": "71d582ce97ef9be3aca0696c268a4785ad5b3d73adc667cf6205802d0a7710e8",
-        "bytes": 17316
+        "sha256": "202c0df185323230523af9bfcfa61a16437cfc973efd258994ece8ed442a2d46",
+        "bytes": 17302
       },
       {
         "path": "contracts/agent-runtime/contract-evolution-v1.md",
@@ -41,11 +41,11 @@
       },
       {
         "path": "scripts/agent-runtime/contracts/public-v1-freeze.mjs",
-        "sha256": "b8ea4b423e906f3e02d8b98b8a2a1c454f4b550e7213c13cdb076f079f7fa1be",
+        "sha256": "c31fce552a7a57b39826a184e691a5cbcd0402a2b999c8f4edbd33bf8586637e",
         "bytes": 23918
       }
     ],
-    "aggregateSha256": "fb8218fee623534b3b5d010c8b73bf611f8250be4ec882f4280c86af071501b2"
+    "aggregateSha256": "786e8f574614e9c91f0d80e2ebf39c3ae63bb735fd3b24855ac143975f533438"
   },
   "runtime": {
     "contractVersion": 1,
@@ -63,16 +63,16 @@
   },
   "cli": {
     "contractVersion": 1,
-    "packageVersion": "1.0.3",
+    "packageVersion": "1.0.4",
     "contractDigest": "d280747a21f46add48d70193205c4dc642b1e0f38447209611174e33beff5927",
     "tarball": {
-      "path": "packages/operon-cli/freeze/operon-cli-1.0.3.tgz",
-      "sha256": "cff297d2a45399a84105789423ee713a5c201fd2a1a060a08309d489bba15470",
+      "path": "packages/operon-cli/freeze/operon-cli-1.0.4.tgz",
+      "sha256": "40a76197f6584947d4d27bbd62ab6361c76710c072c911072193c081e9603a77",
       "bytes": 213393
     },
     "executable": {
       "path": "packages/operon-cli/dist/operon.mjs",
-      "sha256": "21a015817a25c516321c861ea8adb268fe7ce30e63f24e243a25bf65904d54ae",
+      "sha256": "00b4c53a6e5d275a397de03cdd94550db15ab74fe43e01429ff2d0e52de6ae1f",
       "bytes": 512706
     },
     "license": {
@@ -82,12 +82,12 @@
     },
     "manifest": {
       "path": "packages/operon-cli/cli-manifest-v1.json",
-      "sha256": "f75071e955e376d40855b2554a37c88bae470aa439cb2ea1060c1c3c45fed860",
+      "sha256": "b2511bcba6fe1e80d549bc73a62192cf9bd48607e85d972dfd7756ece0597abc",
       "bytes": 51224
     },
     "packageMetadata": {
       "path": "packages/operon-cli/package.json",
-      "sha256": "a9b9ee2f9b0ec623545ffda34b2a94bc8beb7c1f7e3bd45941886fbba439bc1e",
+      "sha256": "7bff0930a3156c45aab870811b1938c5e0e6d7edbbd54580874e418ba58bb75e",
       "bytes": 1978
     },
     "readme": {
@@ -110,7 +110,7 @@
       "fileCount": 5,
       "aggregateSha256": "2ecd8a3e0ae2e069bc89a7cd70cdb724f4023f2b306391b21fbbabca07dd12c6"
     },
-    "packageInputAggregateSha256": "81c567899a2059c5724c8a1cfea04e5e89c8d677b3ef1cce890c84a4b454c46a"
+    "packageInputAggregateSha256": "2fb29eef1a9b5f7fec6f43a8fbc98c0651836a0972708e5febcf6d595e6531c1"
   },
   "documentation": {
     "manifest": {
@@ -196,7 +196,7 @@
   "maintainerAcceptance": {
     "status": "accepted",
     "acceptedBy": "Hasan Yilmaz",
-    "acceptedAt": "2026-08-01T10:55:18.169Z"
+    "acceptedAt": "2026-08-01T12:26:49.000Z"
   },
-  "inputsAggregateSha256": "869a6a21363b65790a8e34ace73573aa2415ab2ac0d303f533407308a16a2598"
+  "inputsAggregateSha256": "273824d312d8c1eca1695d436880da408e920ed8d3ee6151606b0c46b8765e83"
 }

--- a/contracts/agent-runtime/public-v1-scope.md
+++ b/contracts/agent-runtime/public-v1-scope.md
@@ -16,7 +16,7 @@ has passed.
 Public V1 launch versions:
 
 - Operon `3.0.1`
-- `operon-cli@1.0.3`
+- `operon-cli@1.0.4`
 - Runtime API and contract version `1`
 
 The current CLI is a private release candidate and is not publicly installable
@@ -51,10 +51,10 @@ versioned Public V1 integration contract.
 
 | Area | Current implementation truth | Public V1 launch target |
 | --- | --- | --- |
-| Operon release | Operon `3.0.0` is publicly released with Runtime API V1; Operon `3.0.1` is the local Public V1 patch candidate | Operon `3.0.1` |
-| CLI package | Local `operon-cli@1.0.3` stable release candidate; not published to public npm | Public stable `operon-cli@1.0.3` |
+| Operon release | Operon `3.0.1` is publicly released with Runtime API V1 and the Windows mutation reliability patch | Operon `3.0.1` |
+| CLI package | Local `operon-cli@1.0.4` stable release candidate; not published to public npm | Public stable `operon-cli@1.0.4` |
 | Runtime contract | Runtime API V1 exists and is exposed on the Operon plugin instance | Runtime API V1 is a supported, typed Developer API contract |
-| Public access channels | The in-process Developer API ships with Operon `3.0.0`; the CLI and the Windows mutation reliability patch remain unpublished local release candidates | CLI and in-process Developer API are both supported public channels |
+| Public access channels | The in-process Developer API and Windows mutation reliability patch ship with Operon `3.0.1`; the CLI remains an unpublished local release candidate | CLI and in-process Developer API are both supported public channels |
 | macOS CLI | Supported by the current beta boundary | Supported |
 | Linux CLI | `acceptance-required` | Public beta and best-effort on native Linux |
 | Windows CLI | `acceptance-required` | Public beta and best-effort on Windows 11 |
@@ -264,7 +264,7 @@ support, documentation, and release acceptance do not depend on that work.
 | Cross-platform launch boundary, Node support, and beta disclosure | Stage 7 — Cross-platform readiness | Hosted portability and package tests pass on Node 22, 24, and 26 across macOS, Linux, and Windows; platform-specific transport-security, path, lifecycle, interruption, and recovery tests pass; macOS remains `supported`, Linux and Windows remain executable `acceptance-required` public-beta targets, and WSL remains `unsupported` |
 | Public integration guides and examples | Stage 8 — Packaging and documentation | Clean-room CLI and Developer API integration tests using only distributable artifacts and documentation |
 | Stable contract and release candidate | Stage 9 — Hardening and freeze | No launch-blocking contract break, unauthorized access, consent bypass, data loss or corruption, or irrecoverable uncertain outcome remains; all required local contract, security, mutation, Developer API, package, documentation, and release-hardening gates pass; contract, stable manifest, package inputs, types, examples, documentation, source-rebuilt plugin artifact, and development-audit policy are bound by one exact local freeze index; the compatibility baseline has real input/response direction and deprecation coverage; documented maintainer acceptance seals the final local index |
-| Public `operon-cli@1.0.3` | Stage 10 — External release | Before publish, the accepted Stage 9 freeze, final tarball digest, provenance, compatible public Operon artifact, and nine-cell hosted portability evidence pass on the release bytes; after publish, the registry artifact digest equals that tarball and the post-publication audit passes |
+| Public `operon-cli@1.0.4` | Stage 10 — External release | Before publish, the accepted Stage 9 freeze, final tarball digest, provenance, compatible public Operon artifact, and nine-cell hosted portability evidence pass on the release bytes; after publish, the registry artifact digest equals that tarball and the post-publication audit passes |
 
 Failure of a required gate returns the work to its owning stage. Publication is
 not a substitute for contract, safety, package, or hosted portability evidence.

--- a/packages/operon-cli/cli-manifest-v1.json
+++ b/packages/operon-cli/cli-manifest-v1.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "package": {
     "name": "operon-cli",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "executable": "operon",
     "node": "^22.0.0 || ^24.0.0 || ^26.0.0"
   },

--- a/packages/operon-cli/package.json
+++ b/packages/operon-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "operon-cli",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Official command-line client for the Operon Agent Runtime in Obsidian.",
   "type": "module",
   "license": "GPL-3.0-or-later",

--- a/scripts/agent-runtime/cli/check-release-routing.mjs
+++ b/scripts/agent-runtime/cli/check-release-routing.mjs
@@ -148,6 +148,57 @@ assert.match(candidateWorkflow, /plugin_release_tag:/u);
 assert.match(candidateWorkflow, /node-version:\s*"24\.18\.0"/u);
 assert.match(candidateWorkflow, /test "\$\(node --version\)" = "v24\.18\.0"/u);
 assert.match(candidateWorkflow, /npm install --global npm@11\.12\.1/u);
+assert.match(candidateWorkflow, /name:\s+Bind pinned Windows npm CLI/u);
+assert.match(candidateWorkflow, /OPERON_ACCEPTANCE_NPM_CLI_JS=\$npmCli/u);
+assert.match(candidateWorkflow, /Pinned npm prefix lookup failed with exit code/u);
+assert.match(candidateWorkflow, /Pinned npm CLI execution failed with exit code/u);
+assert.match(candidateWorkflow, /name:\s+Verify exact helper npm identity/u);
+assert.match(candidateWorkflow, /execNpmV1\(\['--version'\], \{ encoding: 'utf8' \}\)/u);
+assert.match(liveAcceptanceWorkflow, /name:\s+Bind pinned Windows npm CLI/u);
+assert.match(liveAcceptanceWorkflow, /OPERON_ACCEPTANCE_NPM_CLI_JS=\$npmCli/u);
+assert.match(liveAcceptanceWorkflow, /Pinned npm prefix lookup failed with exit code/u);
+assert.match(liveAcceptanceWorkflow, /Pinned npm CLI execution failed with exit code/u);
+assert.match(liveAcceptanceWorkflow, /name:\s+Verify exact npm version/u);
+assert.match(liveAcceptanceWorkflow, /test "\$\(npm --version\)" = "11\.12\.1"/u);
+assert.match(liveAcceptanceWorkflow, /name:\s+Verify exact helper npm identity/u);
+for (const [workflowName, workflowText, markers] of [
+	[
+		'candidate',
+		candidateWorkflow,
+		[
+			'Pin portability npm',
+			'Bind pinned Windows npm CLI',
+			'OPERON_ACCEPTANCE_NPM_CLI_JS=$npmCli',
+			'Verify exact npm version',
+			'Verify exact helper npm identity',
+			"execNpmV1(['--version'], { encoding: 'utf8' })",
+			'- run: npm ci',
+		],
+	],
+	[
+		'live acceptance',
+		liveAcceptanceWorkflow,
+		[
+			'Pin acceptance npm',
+			'Bind pinned Windows npm CLI',
+			'OPERON_ACCEPTANCE_NPM_CLI_JS=$npmCli',
+			'Verify exact npm version',
+			'Verify exact helper npm identity',
+			"execNpmV1(['--version'], { encoding: 'utf8' })",
+			'- run: npm ci',
+		],
+	],
+]) {
+	let previousIndex = -1;
+	for (const marker of markers) {
+		const markerIndex = workflowText.indexOf(marker, previousIndex + 1);
+		assert.ok(
+			markerIndex > previousIndex,
+			`${workflowName} npm identity step is missing or out of order: ${marker}`,
+		);
+		previousIndex = markerIndex;
+	}
+}
 const candidatePackStep = candidateWorkflow.match(
 	/^      - name: Build one isolated candidate tarball\s*\n(?:(?!^      - ).*(?:\n|$))*/mu,
 )?.[0];

--- a/scripts/agent-runtime/cli/live-acceptance-platform.mjs
+++ b/scripts/agent-runtime/cli/live-acceptance-platform.mjs
@@ -238,19 +238,25 @@ export function resolveNpmInvocationV1(
 	args,
 	platform = process.platform,
 	nodeExecutable = process.execPath,
+	pinnedNpmCliPath,
 ) {
 	const pathApi = platform === 'win32' ? path.win32 : path;
+	if (
+		platform === 'win32'
+		&& (
+			typeof pinnedNpmCliPath !== 'string'
+			|| !pathApi.isAbsolute(pinnedNpmCliPath)
+			|| /[\0\r\n]/u.test(pinnedNpmCliPath)
+			|| pathApi.basename(pinnedNpmCliPath).toLowerCase() !== 'npm-cli.js'
+		)
+	) {
+		throw new Error('OPERON_ACCEPTANCE_NPM_CLI_INVALID');
+	}
 	return platform === 'win32'
 		? {
 			executable: nodeExecutable,
 			args: [
-				pathApi.join(
-					pathApi.dirname(nodeExecutable),
-					'node_modules',
-					'npm',
-					'bin',
-					'npm-cli.js',
-				),
+				pinnedNpmCliPath,
 				...args,
 			],
 		}
@@ -258,7 +264,12 @@ export function resolveNpmInvocationV1(
 }
 
 export function execNpmV1(args, options = {}, runner = execFileSync) {
-	const invocation = resolveNpmInvocationV1(args);
+	const invocation = resolveNpmInvocationV1(
+		args,
+		process.platform,
+		process.execPath,
+		(options.env ?? process.env).OPERON_ACCEPTANCE_NPM_CLI_JS,
+	);
 	return runner(invocation.executable, invocation.args, {
 		...options,
 		shell: false,

--- a/scripts/agent-runtime/cli/live-acceptance-platform.test.mjs
+++ b/scripts/agent-runtime/cli/live-acceptance-platform.test.mjs
@@ -16,20 +16,14 @@ import {
 	windowsAuthenticodeIdentityV1,
 } from './live-acceptance-platform.mjs';
 
-test('npm invocation bypasses Windows command shims through the current Node runtime', () => {
-	assert.deepEqual(
-		resolveNpmInvocationV1(
+test('npm invocation requires an explicit Windows npm CLI and leaves POSIX behavior unchanged', () => {
+	assert.throws(
+		() => resolveNpmInvocationV1(
 			['--version'],
 			'win32',
 			'C:\\Program Files\\nodejs\\node.exe',
 		),
-		{
-			executable: 'C:\\Program Files\\nodejs\\node.exe',
-			args: [
-				'C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js',
-				'--version',
-			],
-		},
+		/OPERON_ACCEPTANCE_NPM_CLI_INVALID/u,
 	);
 	assert.deepEqual(
 		resolveNpmInvocationV1(['--version'], 'linux', '/usr/bin/node'),
@@ -37,11 +31,62 @@ test('npm invocation bypasses Windows command shims through the current Node run
 	);
 });
 
+test('npm invocation prefers an explicit pinned Windows npm CLI without enabling shell shims', () => {
+	assert.deepEqual(
+		resolveNpmInvocationV1(
+			['--version'],
+			'win32',
+			'C:\\Program Files\\nodejs\\node.exe',
+			'D:\\npm global\\ünicode\\node_modules\\npm\\bin\\npm-cli.js',
+		),
+		{
+			executable: 'C:\\Program Files\\nodejs\\node.exe',
+			args: [
+				'D:\\npm global\\ünicode\\node_modules\\npm\\bin\\npm-cli.js',
+				'--version',
+			],
+		},
+	);
+	assert.throws(
+		() => resolveNpmInvocationV1(
+			['--version'],
+			'win32',
+			'C:\\Program Files\\nodejs\\node.exe',
+			'node_modules\\npm\\bin\\npm-cli.js',
+		),
+		/OPERON_ACCEPTANCE_NPM_CLI_INVALID/u,
+	);
+	assert.throws(
+		() => resolveNpmInvocationV1(
+			['--version'],
+			'win32',
+			'C:\\Program Files\\nodejs\\node.exe',
+			'D:\\npm-global\\npm.cmd',
+		),
+		/OPERON_ACCEPTANCE_NPM_CLI_INVALID/u,
+	);
+	assert.throws(
+		() => resolveNpmInvocationV1(
+			['--version'],
+			'win32',
+			'C:\\Program Files\\nodejs\\node.exe',
+			'D:\\npm-global\\node_modules\\npm\\bin\\npm-cli.js\n',
+		),
+		/OPERON_ACCEPTANCE_NPM_CLI_INVALID/u,
+	);
+});
+
 test('npm execution keeps shell mode disabled when caller options request a shell', () => {
 	let captured;
+	const env = process.platform === 'win32'
+		? {
+			...process.env,
+			OPERON_ACCEPTANCE_NPM_CLI_JS: 'D:\\npm-global\\node_modules\\npm\\bin\\npm-cli.js',
+		}
+		: process.env;
 	const result = execNpmV1(
 		['--version'],
-		{ encoding: 'utf8', shell: true },
+		{ encoding: 'utf8', env, shell: true },
 		(...arguments_) => {
 			captured = arguments_;
 			return '11.12.1\n';

--- a/scripts/agent-runtime/cli/native-acceptance.test.mjs
+++ b/scripts/agent-runtime/cli/native-acceptance.test.mjs
@@ -28,7 +28,7 @@ const evidenceSchema = JSON.parse(await readFile(
 	'utf8',
 ));
 const validateEvidence = new Ajv2020({ strict: false }).compile(evidenceSchema);
-const FIXTURE_CLI_VERSION = '1.0.3';
+const FIXTURE_CLI_VERSION = '1.0.4';
 const FIXTURE_CLI_TAG = `cli-v${FIXTURE_CLI_VERSION}`;
 const FIXTURE_CLI_PACKAGE = `operon-cli@${FIXTURE_CLI_VERSION}`;
 const FIXTURE_CLI_TARBALL = `operon-cli-${FIXTURE_CLI_VERSION}.tgz`;

--- a/scripts/agent-runtime/contracts/public-v1-freeze.mjs
+++ b/scripts/agent-runtime/contracts/public-v1-freeze.mjs
@@ -453,7 +453,7 @@ async function buildAuditArtifactMetafiles(root) {
 
 function assertAcceptedFreeze(index) {
 	if (
-		index.cli.packageVersion !== '1.0.3'
+		index.cli.packageVersion !== '1.0.4'
 		|| index.plugin.version !== '3.0.1'
 		|| index.audit.validation.status !== 'passed'
 		|| index.audit.validation.result?.status !== 'accepted-clean'

--- a/scripts/agent-runtime/contracts/public-v1-freeze.test.mjs
+++ b/scripts/agent-runtime/contracts/public-v1-freeze.test.mjs
@@ -199,10 +199,10 @@ test('accepted freeze requires final versions, passed audit and explicit maintai
 		);
 		await writeJson(path.join(root, 'packages/operon-cli/package.json'), {
 			name: 'operon-cli',
-			version: '1.0.3',
+			version: '1.0.4',
 		});
 		await writeFile(
-			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.3.tgz'),
+			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.4.tgz'),
 			'stable tarball\n',
 		);
 		await writeJson(path.join(root, 'manifest.json'), {
@@ -232,10 +232,10 @@ test('ordinary write clears prior acceptance and audit attestation', async () =>
 	try {
 		await writeJson(path.join(root, 'packages/operon-cli/package.json'), {
 			name: 'operon-cli',
-			version: '1.0.3',
+			version: '1.0.4',
 		});
 		await writeFile(
-			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.3.tgz'),
+			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.4.tgz'),
 			'stable tarball\n',
 		);
 		await writeJson(path.join(root, 'manifest.json'), {

--- a/scripts/release-guard.mjs
+++ b/scripts/release-guard.mjs
@@ -684,14 +684,55 @@ function checkWorkflowSecurityPolicy() {
 		'        run: test "$(npm --version)" = "11.12.1"',
 	].join('\n');
 	const pinIndex = hostedJob.indexOf('- name: Pin portability npm');
+	const bindingIndex = hostedJob.indexOf('- name: Bind pinned Windows npm CLI');
+	const bindingEnvironmentIndex = hostedJob.indexOf('OPERON_ACCEPTANCE_NPM_CLI_JS=$npmCli');
 	const verificationIndex = hostedJob.indexOf(npmVerification);
+	const helperVerificationIndex = hostedJob.indexOf('- name: Verify exact helper npm identity');
+	const helperCallIndex = hostedJob.indexOf("execNpmV1(['--version'], { encoding: 'utf8' })");
 	const installIndex = hostedJob.indexOf('- run: npm ci');
 	if (
 		pinIndex < 0
-		|| verificationIndex < pinIndex
-		|| installIndex < verificationIndex
+		|| bindingIndex < pinIndex
+		|| bindingEnvironmentIndex < bindingIndex
+		|| verificationIndex < bindingEnvironmentIndex
+		|| helperVerificationIndex < verificationIndex
+		|| helperCallIndex < helperVerificationIndex
+		|| installIndex < helperCallIndex
 	) {
-		fail('.github/workflows/cli-release-ready.yml: hosted portability must verify npm through a portable shell command');
+		fail('.github/workflows/cli-release-ready.yml: hosted portability must bind and verify the pinned npm CLI before install');
+	}
+	const liveAcceptanceWorkflow = readText('.github/workflows/cli-live-acceptance.yml');
+	for (const expected of [
+		'- name: Bind pinned Windows npm CLI',
+		'OPERON_ACCEPTANCE_NPM_CLI_JS=$npmCli',
+		'Pinned npm prefix lookup failed with exit code',
+		'Pinned npm CLI execution failed with exit code',
+		'- name: Verify exact npm version',
+		'run: test "$(npm --version)" = "11.12.1"',
+		'- name: Verify exact helper npm identity',
+		"execNpmV1(['--version'], { encoding: 'utf8' })",
+	]) {
+		if (!liveAcceptanceWorkflow.includes(expected)) {
+			fail(`.github/workflows/cli-live-acceptance.yml: missing pinned npm identity guard ${JSON.stringify(expected)}`);
+		}
+	}
+	const livePinIndex = liveAcceptanceWorkflow.indexOf('- name: Pin acceptance npm');
+	const liveBindingIndex = liveAcceptanceWorkflow.indexOf('- name: Bind pinned Windows npm CLI');
+	const liveBindingEnvironmentIndex = liveAcceptanceWorkflow.indexOf('OPERON_ACCEPTANCE_NPM_CLI_JS=$npmCli');
+	const liveVerificationIndex = liveAcceptanceWorkflow.indexOf(npmVerification);
+	const liveHelperVerificationIndex = liveAcceptanceWorkflow.indexOf('- name: Verify exact helper npm identity');
+	const liveHelperCallIndex = liveAcceptanceWorkflow.indexOf("execNpmV1(['--version'], { encoding: 'utf8' })");
+	const liveInstallIndex = liveAcceptanceWorkflow.indexOf('- run: npm ci');
+	if (
+		livePinIndex < 0
+		|| liveBindingIndex < livePinIndex
+		|| liveBindingEnvironmentIndex < liveBindingIndex
+		|| liveVerificationIndex < liveBindingEnvironmentIndex
+		|| liveHelperVerificationIndex < liveVerificationIndex
+		|| liveHelperCallIndex < liveHelperVerificationIndex
+		|| liveInstallIndex < liveHelperCallIndex
+	) {
+		fail('.github/workflows/cli-live-acceptance.yml: acceptance must bind and verify the pinned npm CLI before install');
 	}
 	for (const [candidateScript, expectedCalls] of [
 		[


### PR DESCRIPTION
## Summary

- fixes Windows hosted acceptance so package helpers use the exact pinned npm 11.12.1 CLI instead of setup-node's bundled npm
- keeps Windows invocation shell-free and rejects command shims or implicit fallbacks
- adds fail-fast PATH/helper identity, native exit-code, and workflow-order guards
- advances the unpublished CLI candidate to `operon-cli@1.0.4`
- seals a new maintainer-accepted Public V1 freeze

## Evidence

- source base: `9bc59279de7679fabb967fbb57a1c61999476bbc`
- accepted freeze SHA-256: `c24d597e56673838181a680c079943cac8c41dc44311a7a4001e3ded5ecc555b`
- freeze input aggregate: `273824d312d8c1eca1695d436880da408e920ed8d3ee6151606b0c46b8765e83`
- CLI tarball: 213,393 bytes, SHA-256 `40a76197f6584947d4d27bbd62ab6361c76710c072c911072193c081e9603a77`
- CLI executable: 512,706 bytes, SHA-256 `00b4c53a6e5d275a397de03cdd94550db15ab74fe43e01429ff2d0e52de6ae1f`
- Runtime contract digest unchanged: `d280747a21f46add48d70193205c4dc642b1e0f38447209611174e33beff5927`
- audit policy: 0 production and 0 development vulnerabilities
- full local validation: Phase 5 `1517/1517`
- clean-room package lifecycle and TypeScript consumer modes passed
- independent correctness/security and package/freeze reviews found no remaining blocker

## Scope

- 13 exact files
- no docs, changelog, media, plugin artifact, Runtime contract, tag, GitHub Release, or npm publication changes
- immutable failed tag `cli-v1.0.3` is not changed

This PR prepares the corrected immutable `cli-v1.0.4` candidate. It does not publish the package.
