### PR TITLE
Fix CLI release workflow YAML

### DIFF
--- a/.github/workflows/cli-live-acceptance.yml
+++ b/.github/workflows/cli-live-acceptance.yml
@@ -135,7 +135,8 @@ jobs:
         run: test "$(npm --version)" = "11.12.1"
       - name: Verify exact helper npm identity
         shell: bash
-        run: node --input-type=module -e "import { execNpmV1 } from './scripts/agent-runtime/cli/live-acceptance-platform.mjs'; const version = execNpmV1(['--version'], { encoding: 'utf8' }).trim(); if (version !== '11.12.1') throw new Error('Hosted helper npm identity mismatch');"
+        run: >-
+          node --input-type=module -e "import { execNpmV1 } from './scripts/agent-runtime/cli/live-acceptance-platform.mjs'; const version = execNpmV1(['--version'], { encoding: 'utf8' }).trim(); if (version !== '11.12.1') throw new Error('Hosted helper npm identity mismatch');"
       - run: npm ci
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:

--- a/.github/workflows/cli-release-ready.yml
+++ b/.github/workflows/cli-release-ready.yml
@@ -208,7 +208,8 @@ jobs:
         run: test "$(npm --version)" = "11.12.1"
       - name: Verify exact helper npm identity
         shell: bash
-        run: node --input-type=module -e "import { execNpmV1 } from './scripts/agent-runtime/cli/live-acceptance-platform.mjs'; const version = execNpmV1(['--version'], { encoding: 'utf8' }).trim(); if (version !== '11.12.1') throw new Error('Hosted helper npm identity mismatch');"
+        run: >-
+          node --input-type=module -e "import { execNpmV1 } from './scripts/agent-runtime/cli/live-acceptance-platform.mjs'; const version = execNpmV1(['--version'], { encoding: 'utf8' }).trim(); if (version !== '11.12.1') throw new Error('Hosted helper npm identity mismatch');"
       - run: npm ci
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:


### PR DESCRIPTION
## Summary

- parse the hosted helper npm identity commands as YAML block scalars
- restore compilation of the CLI live-acceptance and release-ready workflows
- preserve the accepted Public V1 freeze and frozen CLI 1.0.4 artifact bytes

## Verification

- all checked-in workflow YAML files parse successfully
- targeted native and hosted acceptance tests: 27/27
- release routing and release guard passed
- accepted freeze checks passed with Node 24.18.0 and npm 11.12.1
- plugin bundle, CLI executable and frozen tarball digests unchanged

This PR does not create a tag, publish npm, change docs, or alter Runtime/CLI contracts.