### PR TITLE
Fix CLI release evidence pipeline

### DIFF
--- a/.github/workflows/cli-release-ready.yml
+++ b/.github/workflows/cli-release-ready.yml
@@ -62,14 +62,10 @@ jobs:
       - run: npm run agent-runtime:cli
       - run: npm run agent-runtime:cli:package
       - run: npm run release:guard
-      - name: Build one isolated candidate tarball
-        env:
-          npm_config_cache: ${{ runner.temp }}/operon-cli-npm-cache
-        run: |
-          rm -rf release
-          mkdir -p release
-          npm pack --pack-destination release
-        working-directory: packages/operon-cli
+      - name: Materialize the accepted frozen candidate tarball
+        run: >-
+          node scripts/agent-runtime/cli/materialize-frozen-candidate.mjs
+          packages/operon-cli/release
       - name: Download and verify the compatible public Operon plugin
         env:
           GH_TOKEN: ${{ github.token }}
@@ -112,6 +108,11 @@ jobs:
             packages/operon-cli/release \
             packages/operon-cli/release/candidate-evidence.json \
             packages/operon-cli/release/plugin-release-evidence.json
+      - name: Verify public plugin evidence round trip before attestation
+        run: |
+          node scripts/agent-runtime/cli/verify-public-plugin-release-evidence.mjs \
+            packages/operon-cli/release/candidate-evidence.json \
+            packages/operon-cli/release/plugin-release
       - uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-path: "packages/operon-cli/release/*.tgz"

--- a/contracts/agent-runtime/native-acceptance-v1.schema.json
+++ b/contracts/agent-runtime/native-acceptance-v1.schema.json
@@ -41,10 +41,11 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "kind", "pluginId", "pluginVersion", "releaseTag",
+        "evidenceVersion", "kind", "pluginId", "pluginVersion", "releaseTag",
         "mainJsSha256", "manifestSha256", "stylesCssSha256"
       ],
       "properties": {
+        "evidenceVersion": { "const": 2 },
         "kind": { "const": "operon-public-plugin-release" },
         "pluginId": { "const": "operon" },
         "pluginVersion": { "$ref": "#/$defs/semver" },

--- a/contracts/agent-runtime/public-v1-freeze.json
+++ b/contracts/agent-runtime/public-v1-freeze.json
@@ -6,7 +6,7 @@
     "files": [
       {
         "path": "contracts/agent-runtime/public-v1-scope.md",
-        "sha256": "202c0df185323230523af9bfcfa61a16437cfc973efd258994ece8ed442a2d46",
+        "sha256": "2ea9fc5753660900f243ab336ea02c5e55a6944b2dc3668ef9db39a0b0ffcdb2",
         "bytes": 17302
       },
       {
@@ -41,11 +41,11 @@
       },
       {
         "path": "scripts/agent-runtime/contracts/public-v1-freeze.mjs",
-        "sha256": "c31fce552a7a57b39826a184e691a5cbcd0402a2b999c8f4edbd33bf8586637e",
-        "bytes": 23918
+        "sha256": "c5879ad57d126ff870f04b43feca8b73cae461cc5761c848c0a5ba99c14a5554",
+        "bytes": 24710
       }
     ],
-    "aggregateSha256": "786e8f574614e9c91f0d80e2ebf39c3ae63bb735fd3b24855ac143975f533438"
+    "aggregateSha256": "d73ae3c2572030495bcedbc97b42ef430d4a2347dfa051dab8a605a0b919a846"
   },
   "runtime": {
     "contractVersion": 1,
@@ -63,16 +63,16 @@
   },
   "cli": {
     "contractVersion": 1,
-    "packageVersion": "1.0.4",
+    "packageVersion": "1.0.5",
     "contractDigest": "d280747a21f46add48d70193205c4dc642b1e0f38447209611174e33beff5927",
     "tarball": {
-      "path": "packages/operon-cli/freeze/operon-cli-1.0.4.tgz",
-      "sha256": "40a76197f6584947d4d27bbd62ab6361c76710c072c911072193c081e9603a77",
+      "path": "packages/operon-cli/freeze/operon-cli-1.0.5.tgz",
+      "sha256": "3ec13cc4af1b008f57e39d92935bafc990889497a63bc85aad3f7f93029408eb",
       "bytes": 213393
     },
     "executable": {
       "path": "packages/operon-cli/dist/operon.mjs",
-      "sha256": "00b4c53a6e5d275a397de03cdd94550db15ab74fe43e01429ff2d0e52de6ae1f",
+      "sha256": "c1dc70f2971882615e54fb96c160d1b785a26fca4372eb95db048df208a099dd",
       "bytes": 512706
     },
     "license": {
@@ -82,12 +82,12 @@
     },
     "manifest": {
       "path": "packages/operon-cli/cli-manifest-v1.json",
-      "sha256": "b2511bcba6fe1e80d549bc73a62192cf9bd48607e85d972dfd7756ece0597abc",
+      "sha256": "813b3154d95c033fcdbdb02eadd6fc4b01ed16e499b9cc08c745b19a96dd9807",
       "bytes": 51224
     },
     "packageMetadata": {
       "path": "packages/operon-cli/package.json",
-      "sha256": "7bff0930a3156c45aab870811b1938c5e0e6d7edbbd54580874e418ba58bb75e",
+      "sha256": "a16765683111a3bb7f802b208fc82b357ce15d2f43e67d194ec050d17ecbbf96",
       "bytes": 1978
     },
     "readme": {
@@ -110,7 +110,7 @@
       "fileCount": 5,
       "aggregateSha256": "2ecd8a3e0ae2e069bc89a7cd70cdb724f4023f2b306391b21fbbabca07dd12c6"
     },
-    "packageInputAggregateSha256": "2fb29eef1a9b5f7fec6f43a8fbc98c0651836a0972708e5febcf6d595e6531c1"
+    "packageInputAggregateSha256": "ce2ff58548caa0e87aea718c156d648cba21c062f146a80263ed2226d6f66b66"
   },
   "documentation": {
     "manifest": {
@@ -164,8 +164,8 @@
     },
     "rootPackage": {
       "path": "package.json",
-      "sha256": "2cb5ec52c3fc0b92bd2c4ced9ef102053f5a1114fd1b17e0798249df25b58577",
-      "bytes": 16364
+      "sha256": "82dc041c1dc705a6644e4382abcf5cf48ee77963977f8f6c9ba4b912f8561abf",
+      "bytes": 16443
     },
     "packageLock": {
       "path": "package-lock.json",
@@ -196,7 +196,7 @@
   "maintainerAcceptance": {
     "status": "accepted",
     "acceptedBy": "Hasan Yilmaz",
-    "acceptedAt": "2026-08-01T12:26:49.000Z"
+    "acceptedAt": "2026-08-01T14:28:02.000Z"
   },
-  "inputsAggregateSha256": "273824d312d8c1eca1695d436880da408e920ed8d3ee6151606b0c46b8765e83"
+  "inputsAggregateSha256": "9ffc90189cc68199fd8674352043724cba0f0138030aaa81bfda283e760fecbc"
 }

--- a/contracts/agent-runtime/public-v1-scope.md
+++ b/contracts/agent-runtime/public-v1-scope.md
@@ -16,7 +16,7 @@ has passed.
 Public V1 launch versions:
 
 - Operon `3.0.1`
-- `operon-cli@1.0.4`
+- `operon-cli@1.0.5`
 - Runtime API and contract version `1`
 
 The current CLI is a private release candidate and is not publicly installable
@@ -52,7 +52,7 @@ versioned Public V1 integration contract.
 | Area | Current implementation truth | Public V1 launch target |
 | --- | --- | --- |
 | Operon release | Operon `3.0.1` is publicly released with Runtime API V1 and the Windows mutation reliability patch | Operon `3.0.1` |
-| CLI package | Local `operon-cli@1.0.4` stable release candidate; not published to public npm | Public stable `operon-cli@1.0.4` |
+| CLI package | Local `operon-cli@1.0.5` stable release candidate; not published to public npm | Public stable `operon-cli@1.0.5` |
 | Runtime contract | Runtime API V1 exists and is exposed on the Operon plugin instance | Runtime API V1 is a supported, typed Developer API contract |
 | Public access channels | The in-process Developer API and Windows mutation reliability patch ship with Operon `3.0.1`; the CLI remains an unpublished local release candidate | CLI and in-process Developer API are both supported public channels |
 | macOS CLI | Supported by the current beta boundary | Supported |
@@ -264,7 +264,7 @@ support, documentation, and release acceptance do not depend on that work.
 | Cross-platform launch boundary, Node support, and beta disclosure | Stage 7 — Cross-platform readiness | Hosted portability and package tests pass on Node 22, 24, and 26 across macOS, Linux, and Windows; platform-specific transport-security, path, lifecycle, interruption, and recovery tests pass; macOS remains `supported`, Linux and Windows remain executable `acceptance-required` public-beta targets, and WSL remains `unsupported` |
 | Public integration guides and examples | Stage 8 — Packaging and documentation | Clean-room CLI and Developer API integration tests using only distributable artifacts and documentation |
 | Stable contract and release candidate | Stage 9 — Hardening and freeze | No launch-blocking contract break, unauthorized access, consent bypass, data loss or corruption, or irrecoverable uncertain outcome remains; all required local contract, security, mutation, Developer API, package, documentation, and release-hardening gates pass; contract, stable manifest, package inputs, types, examples, documentation, source-rebuilt plugin artifact, and development-audit policy are bound by one exact local freeze index; the compatibility baseline has real input/response direction and deprecation coverage; documented maintainer acceptance seals the final local index |
-| Public `operon-cli@1.0.4` | Stage 10 — External release | Before publish, the accepted Stage 9 freeze, final tarball digest, provenance, compatible public Operon artifact, and nine-cell hosted portability evidence pass on the release bytes; after publish, the registry artifact digest equals that tarball and the post-publication audit passes |
+| Public `operon-cli@1.0.5` | Stage 10 — External release | Before publish, the accepted Stage 9 freeze, final tarball digest, provenance, compatible public Operon artifact, and nine-cell hosted portability evidence pass on the release bytes; after publish, the registry artifact digest equals that tarball and the post-publication audit passes |
 
 Failure of a required gate returns the work to its owning stage. Publication is
 not a substitute for contract, safety, package, or hosted portability evidence.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"agent-runtime:cli:native:test": "node --test scripts/agent-runtime/cli/native-acceptance.test.mjs scripts/agent-runtime/cli/live-acceptance-platform.test.mjs",
 		"agent-runtime:cli:hosted-portability:test": "node --test scripts/agent-runtime/cli/hosted-portability.test.mjs",
 		"agent-runtime:cli:meeting": "node scripts/agent-runtime/cli/run-meeting-agent-acceptance.mjs",
-		"agent-runtime:cli:release-tag": "node scripts/agent-runtime/cli/check-release-tag.mjs && node scripts/agent-runtime/cli/check-release-routing.mjs",
+		"agent-runtime:cli:release-tag": "node scripts/agent-runtime/cli/check-release-tag.mjs && node scripts/agent-runtime/cli/check-release-routing.mjs && node --test scripts/agent-runtime/cli/materialize-frozen-candidate.test.mjs",
 		"agent-runtime:cli:candidate-live": "node scripts/agent-runtime/cli/run-candidate-live-acceptance.mjs",
 		"agent-runtime:cli:performance:test": "node --test scripts/agent-runtime/performance/cli-speed-stage1-core.test.mjs scripts/agent-runtime/performance/cli-speed-stage3-core.test.mjs scripts/agent-runtime/performance/cli-speed-stage3-checkpoint-core.test.mjs scripts/agent-runtime/performance/cli-speed-stage4-core.test.mjs scripts/agent-runtime/performance/cli-speed-stage5-core.test.mjs scripts/agent-runtime/performance/cli-speed-stage5-skills.test.mjs scripts/agent-runtime/performance/cli-speed-stage51-core.test.mjs scripts/agent-runtime/performance/cli-speed-stage51-build-gates.test.mjs scripts/agent-runtime/performance/cli-speed-stage6-core.test.mjs scripts/agent-runtime/performance/cli-speed-stage7-core.test.mjs",
 		"agent-runtime:cli:performance:live": "node scripts/agent-runtime/performance/cli-speed-stage1-live.mjs",

--- a/packages/operon-cli/cli-manifest-v1.json
+++ b/packages/operon-cli/cli-manifest-v1.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "package": {
     "name": "operon-cli",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "executable": "operon",
     "node": "^22.0.0 || ^24.0.0 || ^26.0.0"
   },

--- a/packages/operon-cli/package.json
+++ b/packages/operon-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "operon-cli",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Official command-line client for the Operon Agent Runtime in Obsidian.",
   "type": "module",
   "license": "GPL-3.0-or-later",

--- a/scripts/agent-runtime/cli/check-release-routing.mjs
+++ b/scripts/agent-runtime/cli/check-release-routing.mjs
@@ -49,6 +49,10 @@ const liveAcceptanceWorkflow = await readFile(
 	path.join(pluginRoot, '.github/workflows/cli-live-acceptance.yml'),
 	'utf8',
 );
+const candidateEvidenceWriter = await readFile(
+	path.join(pluginRoot, 'scripts/agent-runtime/cli/write-release-candidate-evidence.mjs'),
+	'utf8',
+);
 
 const workflowRoot = path.join(pluginRoot, '.github/workflows');
 const workflowFiles = (await readdir(workflowRoot))
@@ -200,19 +204,26 @@ for (const [workflowName, workflowText, markers] of [
 	}
 }
 const candidatePackStep = candidateWorkflow.match(
-	/^      - name: Build one isolated candidate tarball\s*\n(?:(?!^      - ).*(?:\n|$))*/mu,
+	/^      - name: Materialize the accepted frozen candidate tarball\s*\n(?:(?!^      - ).*(?:\n|$))*/mu,
 )?.[0];
-assert.ok(candidatePackStep, 'Candidate workflow must contain the isolated tarball build step.');
-assert.match(candidatePackStep, /^[ \t]+working-directory:[ \t]+packages\/operon-cli[ \t]*$/mu);
-assert.match(candidatePackStep, /^[ \t]+rm -rf release[ \t]*$/mu);
-assert.match(candidatePackStep, /^[ \t]+mkdir -p release[ \t]*$/mu);
-assert.match(candidatePackStep, /^[ \t]+npm pack --pack-destination release[ \t]*$/mu);
-assert.doesNotMatch(candidatePackStep, /packages\/operon-cli\/release/u);
+assert.ok(candidatePackStep, 'Candidate workflow must materialize the accepted frozen tarball.');
+assert.match(candidatePackStep, /materialize-frozen-candidate\.mjs/u);
+assert.match(candidatePackStep, /packages\/operon-cli\/release/u);
+assert.doesNotMatch(candidatePackStep, /npm pack|rm -rf/u);
 assert.match(candidateWorkflow, /gh release download "\$PLUGIN_RELEASE_TAG"/u);
 assert.match(candidateWorkflow, /FROZEN_PLUGIN_VERSION/u);
 assert.match(candidateWorkflow, /write-public-plugin-release-evidence\.mjs/u);
 assert.match(candidateWorkflow, /REQUIRE_PUBLIC_PLUGIN_RELEASE:\s*"1"/u);
 assert.match(candidateWorkflow, /subject-path:\s*"packages\/operon-cli\/release\/candidate-evidence\.json"/u);
+assert.match(
+	candidateWorkflow,
+	/Verify public plugin evidence round trip before attestation[\s\S]+verify-public-plugin-release-evidence\.mjs/u,
+);
+assert.match(
+	candidateEvidenceWriter,
+	/evidenceVersion:\s*pluginReleaseEvidence\.evidenceVersion/u,
+	'Candidate evidence must preserve the public plugin evidence version.',
+);
 assert.match(candidateWorkflow, /packages\/operon-cli\/release\/plugin-release\/main\.js/u);
 assert.match(candidateWorkflow, /Build the canonical 9-cell hosted portability matrix/u);
 assert.match(candidateWorkflow, /hostedPortabilityCellsV1/u);
@@ -495,6 +506,46 @@ try {
 		assert.deepEqual(evidence.publicV1Freeze.runtimeApi, { min: 1, max: 1 });
 		assert.match(evidence.mainJsSha256, /^[a-f0-9]{64}$/u);
 		assert.match(evidence.stylesCssSha256, /^[a-f0-9]{64}$/u);
+		const projectedCandidatePath = path.join(pluginEvidenceRoot, 'candidate-evidence.json');
+		const projectedPlugin = {
+			evidenceVersion: evidence.evidenceVersion,
+			kind: evidence.kind,
+			releaseTag: evidence.releaseTag,
+			pluginId: evidence.pluginId,
+			pluginVersion: evidence.pluginVersion,
+			mainJsSha256: evidence.mainJsSha256,
+			manifestSha256: evidence.manifestSha256,
+			stylesCssSha256: evidence.stylesCssSha256,
+		};
+		await writeFile(projectedCandidatePath, `${JSON.stringify({
+			compatiblePublicPlugin: projectedPlugin,
+			publicV1Freeze: evidence.publicV1Freeze,
+		}, null, 2)}\n`, 'utf8');
+		const pluginVerifier = path.join(
+			scriptDirectory,
+			'verify-public-plugin-release-evidence.mjs',
+		);
+		const verifiedProjection = spawnSync(
+			process.execPath,
+			[pluginVerifier, projectedCandidatePath, pluginArtifacts],
+			{ cwd: pluginRoot, encoding: 'utf8' },
+		);
+		assert.equal(verifiedProjection.status, 0, verifiedProjection.stderr);
+		delete projectedPlugin.evidenceVersion;
+		await writeFile(projectedCandidatePath, `${JSON.stringify({
+			compatiblePublicPlugin: projectedPlugin,
+			publicV1Freeze: evidence.publicV1Freeze,
+		}, null, 2)}\n`, 'utf8');
+		const missingEvidenceVersion = spawnSync(
+			process.execPath,
+			[pluginVerifier, projectedCandidatePath, pluginArtifacts],
+			{ cwd: pluginRoot, encoding: 'utf8' },
+		);
+		assert.notEqual(
+			missingEvidenceVersion.status,
+			0,
+			'Plugin release verifier accepted a compact binding without evidenceVersion.',
+		);
 	} else {
 		assert.notEqual(
 			written.status,

--- a/scripts/agent-runtime/cli/hosted-portability.test.mjs
+++ b/scripts/agent-runtime/cli/hosted-portability.test.mjs
@@ -88,6 +88,7 @@ async function createFixture() {
 			trackedTreeClean: true,
 		},
 		compatiblePublicPlugin: {
+			evidenceVersion: 2,
 			kind: 'operon-public-plugin-release',
 			pluginId: 'operon',
 			pluginVersion: '9.8.7',

--- a/scripts/agent-runtime/cli/materialize-frozen-candidate.mjs
+++ b/scripts/agent-runtime/cli/materialize-frozen-candidate.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { COPYFILE_EXCL } from 'node:constants';
+import { createHash } from 'node:crypto';
+import { copyFile, lstat, mkdir, readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { readAcceptedPublicV1Freeze } from './release-contract.mjs';
+
+export async function materializeFrozenCandidate({ repositoryRoot, outputRoot }) {
+	const root = path.resolve(repositoryRoot);
+	const output = path.resolve(outputRoot);
+	assert.equal(
+		output,
+		path.join(root, 'packages/operon-cli/release'),
+		'Candidate output directory must be the canonical release directory.',
+	);
+	const { freeze } = await readAcceptedPublicV1Freeze(root);
+	const packageDocument = JSON.parse(await readFile(
+		path.join(root, 'packages/operon-cli/package.json'),
+		'utf8',
+	));
+	assert.equal(freeze.state, 'accepted', 'Public V1 freeze must be accepted.');
+	assert.equal(
+		freeze.cli?.packageVersion,
+		packageDocument.version,
+		'Frozen CLI version does not match package metadata.',
+	);
+	const fileName = `operon-cli-${packageDocument.version}.tgz`;
+	const relativeSource = `packages/operon-cli/freeze/${fileName}`;
+	assert.equal(
+		freeze.cli?.tarball?.path,
+		relativeSource,
+		'Frozen CLI tarball path is not canonical.',
+	);
+	const source = path.join(root, relativeSource);
+	const sourceStat = await lstat(source);
+	assert.equal(sourceStat.isSymbolicLink(), false, 'Frozen CLI tarball cannot be a symlink.');
+	assert.equal(sourceStat.isFile(), true, 'Frozen CLI tarball must be a regular file.');
+	const bytes = await readFile(source);
+	assert.equal(bytes.length, freeze.cli.tarball.bytes, 'Frozen CLI tarball size drifted.');
+	assert.equal(sha256(bytes), freeze.cli.tarball.sha256, 'Frozen CLI tarball digest drifted.');
+	try {
+		await mkdir(output);
+	} catch (error) {
+		if (error?.code !== 'EEXIST') throw error;
+		const outputStat = await lstat(output);
+		assert.equal(outputStat.isSymbolicLink(), false, 'Candidate output cannot be a symlink.');
+		assert.equal(outputStat.isDirectory(), true, 'Candidate output must be a directory.');
+		assert.deepEqual(
+			await readdir(output),
+			[],
+			'Candidate output directory must be empty.',
+		);
+	}
+	const destination = path.join(output, fileName);
+	await copyFile(source, destination, COPYFILE_EXCL);
+	const copied = await readFile(destination);
+	const destinationStat = await lstat(destination);
+	assert.equal(destinationStat.isSymbolicLink(), false);
+	assert.equal(destinationStat.isFile(), true);
+	assert.equal(copied.length, freeze.cli.tarball.bytes);
+	assert.equal(sha256(copied), freeze.cli.tarball.sha256);
+	return {
+		fileName,
+		path: destination,
+		bytes: copied.length,
+		sha256: freeze.cli.tarball.sha256,
+	};
+}
+
+function sha256(bytes) {
+	return createHash('sha256').update(bytes).digest('hex');
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+	const outputArgument = process.argv[2];
+	assert.ok(outputArgument, 'Candidate output directory is required.');
+	const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+	const result = await materializeFrozenCandidate({
+		repositoryRoot: path.resolve(scriptDirectory, '../../..'),
+		outputRoot: outputArgument,
+	});
+	process.stdout.write(`${JSON.stringify({ status: 'ok', ...result }, null, 2)}\n`);
+}

--- a/scripts/agent-runtime/cli/materialize-frozen-candidate.test.mjs
+++ b/scripts/agent-runtime/cli/materialize-frozen-candidate.test.mjs
@@ -1,0 +1,163 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { materializeFrozenCandidate } from './materialize-frozen-candidate.mjs';
+
+test('materializes the accepted canonical tarball without rebuilding it', async () => {
+	const fixture = await createFixture();
+	try {
+		const output = path.join(fixture.root, 'packages/operon-cli/release');
+		const result = await materializeFrozenCandidate({ repositoryRoot: fixture.root, outputRoot: output });
+		assert.equal(result.fileName, 'operon-cli-1.0.5.tgz');
+		assert.deepEqual(await readFile(result.path), fixture.bytes);
+		assert.equal(result.sha256, digest(fixture.bytes));
+	} finally {
+		await rm(fixture.root, { recursive: true, force: true });
+	}
+});
+
+for (const [name, mutate, message] of [
+	['version mismatch', freeze => { freeze.cli.packageVersion = '1.0.4'; }, /version does not match/u],
+	['path mismatch', freeze => { freeze.cli.tarball.path = 'packages/operon-cli/freeze/other.tgz'; }, /path is not canonical/u],
+	['size mismatch', freeze => { freeze.cli.tarball.bytes += 1; }, /size drifted/u],
+	['digest mismatch', freeze => { freeze.cli.tarball.sha256 = '0'.repeat(64); }, /digest drifted/u],
+]) {
+	test(`rejects ${name}`, async () => {
+		const fixture = await createFixture(mutate);
+		try {
+			await assert.rejects(
+				materializeFrozenCandidate({
+					repositoryRoot: fixture.root,
+					outputRoot: path.join(fixture.root, 'packages/operon-cli/release'),
+				}),
+				message,
+			);
+		} finally {
+			await rm(fixture.root, { recursive: true, force: true });
+		}
+	});
+}
+
+test('rejects a missing frozen tarball and a non-empty output directory', async () => {
+	const missing = await createFixture();
+	try {
+		await rm(missing.source);
+		await assert.rejects(
+			materializeFrozenCandidate({
+				repositoryRoot: missing.root,
+				outputRoot: path.join(missing.root, 'packages/operon-cli/release'),
+			}),
+			/ENOENT/u,
+		);
+	} finally {
+		await rm(missing.root, { recursive: true, force: true });
+	}
+	const occupied = await createFixture();
+	try {
+		const output = path.join(occupied.root, 'packages/operon-cli/release');
+		await mkdir(output);
+		await writeFile(path.join(output, 'unexpected.tgz'), 'unexpected\n', 'utf8');
+		await assert.rejects(
+			materializeFrozenCandidate({ repositoryRoot: occupied.root, outputRoot: output }),
+			/output directory must be empty/u,
+		);
+	} finally {
+		await rm(occupied.root, { recursive: true, force: true });
+	}
+});
+
+test('rejects symlinked source and output paths', {
+	skip: process.platform === 'win32' ? 'Symlink creation is not portable on Windows CI.' : false,
+}, async () => {
+	const sourceLink = await createFixture();
+	try {
+		const external = path.join(sourceLink.root, 'external.tgz');
+		await writeFile(external, sourceLink.bytes);
+		await rm(sourceLink.source);
+		await symlink(external, sourceLink.source);
+		await assert.rejects(
+			materializeFrozenCandidate({
+				repositoryRoot: sourceLink.root,
+				outputRoot: path.join(sourceLink.root, 'packages/operon-cli/release'),
+			}),
+			/cannot be a symlink/u,
+		);
+	} finally {
+		await rm(sourceLink.root, { recursive: true, force: true });
+	}
+	const outputLink = await createFixture();
+	try {
+		const external = path.join(outputLink.root, 'external-release');
+		await mkdir(external);
+		await symlink(external, path.join(outputLink.root, 'packages/operon-cli/release'));
+		await assert.rejects(
+			materializeFrozenCandidate({
+				repositoryRoot: outputLink.root,
+				outputRoot: path.join(outputLink.root, 'packages/operon-cli/release'),
+			}),
+			/cannot be a symlink/u,
+		);
+	} finally {
+		await rm(outputLink.root, { recursive: true, force: true });
+	}
+});
+
+async function createFixture(mutate) {
+	const root = await mkdtemp(path.join(tmpdir(), 'operon-frozen-candidate-'));
+	const bytes = Buffer.from('immutable candidate tarball\n');
+	const source = path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.5.tgz');
+	await mkdir(path.dirname(source), { recursive: true });
+	await mkdir(path.join(root, 'contracts/agent-runtime'), { recursive: true });
+	await writeFile(path.join(root, 'packages/operon-cli/package.json'), `${JSON.stringify({
+		name: 'operon-cli',
+		version: '1.0.5',
+	}, null, 2)}\n`, 'utf8');
+	await writeFile(source, bytes);
+	const freeze = {
+		freezeVersion: 1,
+		kind: 'operon-public-v1-local-freeze',
+		state: 'accepted',
+		runtime: {
+			contractVersion: 1,
+			schemaAggregateSha256: '1'.repeat(64),
+		},
+		cli: {
+			contractVersion: 1,
+			contractDigest: '2'.repeat(64),
+			packageVersion: '1.0.5',
+			tarball: {
+				path: 'packages/operon-cli/freeze/operon-cli-1.0.5.tgz',
+				bytes: bytes.length,
+				sha256: digest(bytes),
+			},
+		},
+		plugin: {
+			pluginId: 'operon',
+			version: '3.0.1',
+			main: { sha256: '3'.repeat(64) },
+			manifest: { sha256: '4'.repeat(64) },
+			styles: { sha256: '5'.repeat(64) },
+		},
+		audit: { validation: { status: 'passed' } },
+		maintainerAcceptance: {
+			status: 'accepted',
+			acceptedAt: '2026-08-01T00:00:00.000Z',
+		},
+	};
+	mutate?.(freeze);
+	freeze.inputsAggregateSha256 = digest(Buffer.from(JSON.stringify(freeze), 'utf8'));
+	await writeFile(
+		path.join(root, 'contracts/agent-runtime/public-v1-freeze.json'),
+		`${JSON.stringify(freeze, null, 2)}\n`,
+		'utf8',
+	);
+	return { root, source, bytes };
+}
+
+function digest(bytes) {
+	return createHash('sha256').update(bytes).digest('hex');
+}

--- a/scripts/agent-runtime/cli/native-acceptance-lib.mjs
+++ b/scripts/agent-runtime/cli/native-acceptance-lib.mjs
@@ -193,6 +193,9 @@ export async function loadCandidateBindingV1(candidateRoot) {
 			|| evidence.compatiblePublicPlugin?.kind === 'operon-plugin-native-candidate',
 	);
 	assert.equal(evidence.compatiblePublicPlugin.pluginId, 'operon');
+	if (evidence.compatiblePublicPlugin.kind === 'operon-public-plugin-release') {
+		assert.equal(evidence.compatiblePublicPlugin.evidenceVersion, 2);
+	}
 	for (const key of ['mainJsSha256', 'manifestSha256', 'stylesCssSha256']) {
 		assert.match(evidence.compatiblePublicPlugin[key] ?? '', DIGEST);
 	}

--- a/scripts/agent-runtime/cli/native-acceptance.test.mjs
+++ b/scripts/agent-runtime/cli/native-acceptance.test.mjs
@@ -28,7 +28,7 @@ const evidenceSchema = JSON.parse(await readFile(
 	'utf8',
 ));
 const validateEvidence = new Ajv2020({ strict: false }).compile(evidenceSchema);
-const FIXTURE_CLI_VERSION = '1.0.4';
+const FIXTURE_CLI_VERSION = '1.0.5';
 const FIXTURE_CLI_TAG = `cli-v${FIXTURE_CLI_VERSION}`;
 const FIXTURE_CLI_PACKAGE = `operon-cli@${FIXTURE_CLI_VERSION}`;
 const FIXTURE_CLI_TARBALL = `operon-cli-${FIXTURE_CLI_VERSION}.tgz`;
@@ -69,6 +69,7 @@ test('36 digest-bound native cells produce one promotion-eligible aggregate', as
 				source: { ...nativeEvidence.source, ref: FIXTURE_CLI_TAG },
 				compatiblePublicPlugin: {
 					...nativeEvidence.compatiblePublicPlugin,
+					evidenceVersion: 2,
 					kind: 'operon-public-plugin-release',
 					releaseTag: FIXTURE_PLUGIN_VERSION,
 				},
@@ -79,6 +80,22 @@ test('36 digest-bound native cells produce one promotion-eligible aggregate', as
 			index,
 			'The explicit byte-identical native-to-tagged-release transition must retain acceptance.',
 		);
+		const publicIndex = structuredClone(index);
+		publicIndex.candidate.candidateKind = 'operon-cli-release-candidate';
+		publicIndex.candidate.sourceRef = FIXTURE_CLI_TAG;
+		publicIndex.candidate.compatiblePublicPlugin = {
+			evidenceVersion: 2,
+			kind: 'operon-public-plugin-release',
+			pluginId: 'operon',
+			pluginVersion: FIXTURE_PLUGIN_VERSION,
+			releaseTag: FIXTURE_PLUGIN_VERSION,
+			mainJsSha256: '1'.repeat(64),
+			manifestSha256: '2'.repeat(64),
+			stylesCssSha256: '3'.repeat(64),
+		};
+		assert.equal(validateEvidence(publicIndex), true, JSON.stringify(validateEvidence.errors));
+		delete publicIndex.candidate.compatiblePublicPlugin.evidenceVersion;
+		assert.equal(validateEvidence(publicIndex), false);
 	} finally {
 		await rm(fixture.root, { recursive: true, force: true });
 	}

--- a/scripts/agent-runtime/cli/verify-release-candidate.mjs
+++ b/scripts/agent-runtime/cli/verify-release-candidate.mjs
@@ -63,6 +63,7 @@ assert.deepEqual(evidence.releaseAcceptance, {
 	nativeDesktopCertification: 'optional-post-release',
 });
 if (process.env.REQUIRE_PUBLIC_PLUGIN_RELEASE === '1') {
+	assert.equal(evidence.compatiblePublicPlugin?.evidenceVersion, 2);
 	assert.equal(evidence.compatiblePublicPlugin?.kind, 'operon-public-plugin-release');
 	assert.equal(evidence.compatiblePublicPlugin?.pluginId, 'operon');
 	assert.equal(

--- a/scripts/agent-runtime/cli/write-release-candidate-evidence.mjs
+++ b/scripts/agent-runtime/cli/write-release-candidate-evidence.mjs
@@ -32,6 +32,7 @@ const pluginReleaseEvidence = pluginEvidenceArgument
 	: null;
 const pluginRelease = pluginReleaseEvidence
 	? {
+		evidenceVersion: pluginReleaseEvidence.evidenceVersion,
 		kind: pluginReleaseEvidence.kind,
 		releaseTag: pluginReleaseEvidence.releaseTag,
 		pluginId: pluginReleaseEvidence.pluginId,

--- a/scripts/agent-runtime/contracts/public-v1-freeze.mjs
+++ b/scripts/agent-runtime/contracts/public-v1-freeze.mjs
@@ -24,6 +24,7 @@ const FREEZE_RELATIVE_PATH = 'contracts/agent-runtime/public-v1-freeze.json';
 const FREEZE_SCHEMA_RELATIVE_PATH = 'contracts/agent-runtime/public-v1-freeze.schema.json';
 const AUDIT_POLICY_RELATIVE_PATH = 'contracts/release/dev-audit-policy-v1.json';
 const HOSTED_SCHEMA_RELATIVE_PATH = 'contracts/agent-runtime/hosted-portability-v1.schema.json';
+const CANONICAL_NPM_VERSION = '11.12.1';
 const CONTRACT_FILES = [
 	'contracts/agent-runtime/public-v1-scope.md',
 	'contracts/agent-runtime/contract-evolution-v1.md',
@@ -200,6 +201,32 @@ export function resolveNpmPackInvocation({
 	return { command: 'npm', argumentPrefix: [] };
 }
 
+export function assertCanonicalNpmPackToolchain(
+	invocation,
+	{ runner = spawnSync } = {},
+) {
+	const result = runner(
+		invocation.command,
+		[...invocation.argumentPrefix, '--version'],
+		{ encoding: 'utf8', env: process.env },
+	);
+	if (result?.error || result?.status !== 0) {
+		throw new Error(
+			`OPERON_PUBLIC_V1_FREEZE_NPM_VERSION_CHECK_FAILED:${
+				result?.error?.message
+				|| result?.stderr?.trim()
+				|| `exit ${result?.status ?? 'unknown'}`
+			}`,
+		);
+	}
+	const actualVersion = result.stdout?.trim();
+	if (actualVersion !== CANONICAL_NPM_VERSION) {
+		throw new Error(
+			`OPERON_PUBLIC_V1_FREEZE_NPM_VERSION_MISMATCH:${actualVersion || 'missing'}:${CANONICAL_NPM_VERSION}`,
+		);
+	}
+}
+
 export async function writeCanonicalCliTarball(root = defaultPluginRoot) {
 	const packageRoot = path.join(root, 'packages/operon-cli');
 	const packageDocument = JSON.parse(await readFile(
@@ -207,9 +234,10 @@ export async function writeCanonicalCliTarball(root = defaultPluginRoot) {
 		'utf8',
 	));
 	assertCliPackageIdentity(packageDocument);
+	const npmInvocation = resolveNpmPackInvocation();
+	assertCanonicalNpmPackToolchain(npmInvocation);
 	const temporaryRoot = await mkdtemp(path.join(tmpdir(), 'operon-public-v1-pack-'));
 	try {
-		const npmInvocation = resolveNpmPackInvocation();
 		const npmArguments = [
 			...npmInvocation.argumentPrefix,
 			'pack',
@@ -453,7 +481,7 @@ async function buildAuditArtifactMetafiles(root) {
 
 function assertAcceptedFreeze(index) {
 	if (
-		index.cli.packageVersion !== '1.0.4'
+		index.cli.packageVersion !== '1.0.5'
 		|| index.plugin.version !== '3.0.1'
 		|| index.audit.validation.status !== 'passed'
 		|| index.audit.validation.result?.status !== 'accepted-clean'

--- a/scripts/agent-runtime/contracts/public-v1-freeze.test.mjs
+++ b/scripts/agent-runtime/contracts/public-v1-freeze.test.mjs
@@ -18,6 +18,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
 	acceptedFreezeControl,
+	assertCanonicalNpmPackToolchain,
 	checkPublicV1FreezeIndex,
 	preparePublicV1FreezeArtifacts,
 	resolveNpmPackInvocation,
@@ -199,10 +200,10 @@ test('accepted freeze requires final versions, passed audit and explicit maintai
 		);
 		await writeJson(path.join(root, 'packages/operon-cli/package.json'), {
 			name: 'operon-cli',
-			version: '1.0.4',
+			version: '1.0.5',
 		});
 		await writeFile(
-			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.4.tgz'),
+			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.5.tgz'),
 			'stable tarball\n',
 		);
 		await writeJson(path.join(root, 'manifest.json'), {
@@ -232,10 +233,10 @@ test('ordinary write clears prior acceptance and audit attestation', async () =>
 	try {
 		await writeJson(path.join(root, 'packages/operon-cli/package.json'), {
 			name: 'operon-cli',
-			version: '1.0.4',
+			version: '1.0.5',
 		});
 		await writeFile(
-			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.4.tgz'),
+			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.5.tgz'),
 			'stable tarball\n',
 		);
 		await writeJson(path.join(root, 'manifest.json'), {
@@ -291,6 +292,29 @@ test('canonical npm tarball generation is reproducible', async () => {
 	} finally {
 		await rm(root, { recursive: true, force: true });
 	}
+});
+
+test('canonical npm tarball generation rejects a different npm version', () => {
+	assert.throws(
+		() => assertCanonicalNpmPackToolchain(
+			{ command: 'npm', argumentPrefix: [] },
+			{ runner: () => ({ status: 0, stdout: '11.13.0\n', stderr: '' }) },
+		),
+		/OPERON_PUBLIC_V1_FREEZE_NPM_VERSION_MISMATCH:11\.13\.0:11\.12\.1/u,
+	);
+});
+
+test('canonical npm tarball generation accepts npm 11.12.1', () => {
+	assert.doesNotThrow(() => assertCanonicalNpmPackToolchain(
+		{ command: process.execPath, argumentPrefix: ['/tmp/npm-cli.js'] },
+		{
+			runner: (command, arguments_) => {
+				assert.equal(command, process.execPath);
+				assert.deepEqual(arguments_, ['/tmp/npm-cli.js', '--version']);
+				return { status: 0, stdout: '11.12.1\n', stderr: '' };
+			},
+		},
+	));
 });
 
 test('canonical npm tarball rejects non-public file modes', {


### PR DESCRIPTION
## What changed

- Bumps the unpublished CLI candidate to `operon-cli@1.0.5`.
- Preserves public plugin evidence versioning through candidate evidence and verifies it before expensive portability jobs.
- Materializes the already accepted frozen tarball instead of repacking at the end of candidate preparation.
- Extends native acceptance schema and tests for the evidence projection.
- Pins freeze tarball generation to canonical npm `11.12.1` and fails closed on toolchain drift.

## Root cause

The 1.0.4 publish workflow safely stopped before npm publication because candidate evidence omitted `compatiblePublicPlugin.evidenceVersion`. A second local check then exposed that npm 11.12.1 and 11.13.0 produce different tarball bytes, so freeze generation also needed an explicit npm identity gate.

## Validation

- Public V1 freeze accepted and reproducible
- Freeze tests: 22/22
- Phase 5 regression: 1517/1517
- Public docs tests: 14/14
- Strict lint, release guard, audit policy and package checks passed
- Production and development audit findings: 0
- Frozen tarball SHA-256: `3ec13cc4af1b008f57e39d92935bafc990889497a63bc85aad3f7f93029408eb`
- Accepted freeze SHA-256: `55f7140a0eaaadac4b9a05b578758cd00e775b263a2578b39ee729e606064b08`

No CLI tag or npm publication is performed by this PR.