### PR TITLE
Prepare operon-cli 1.0.6 publication

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -169,7 +169,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           test -n "$NODE_AUTH_TOKEN"
-          npm publish candidate/*.tgz \
+          npm publish ./candidate/*.tgz \
             --registry https://registry.npmjs.org/ \
             --access public \
             --tag latest \
@@ -180,7 +180,7 @@ jobs:
       - name: Publish approved stable release through npm trusted publishing
         if: inputs.authentication_mode == 'trusted-publisher'
         run: |
-          npm publish candidate/*.tgz \
+          npm publish ./candidate/*.tgz \
             --registry https://registry.npmjs.org/ \
             --access public \
             --tag latest \

--- a/contracts/agent-runtime/public-v1-freeze.json
+++ b/contracts/agent-runtime/public-v1-freeze.json
@@ -6,7 +6,7 @@
     "files": [
       {
         "path": "contracts/agent-runtime/public-v1-scope.md",
-        "sha256": "2ea9fc5753660900f243ab336ea02c5e55a6944b2dc3668ef9db39a0b0ffcdb2",
+        "sha256": "dfefdba1431286861f32a3ab19eb9acffd9ba163afc214ef145e3a727164134e",
         "bytes": 17302
       },
       {
@@ -41,11 +41,11 @@
       },
       {
         "path": "scripts/agent-runtime/contracts/public-v1-freeze.mjs",
-        "sha256": "c5879ad57d126ff870f04b43feca8b73cae461cc5761c848c0a5ba99c14a5554",
+        "sha256": "4d5dfac789b2fc62caa3ce6b8809e2745fc3ad28ab71cf1d20fee946d44b9bf0",
         "bytes": 24710
       }
     ],
-    "aggregateSha256": "d73ae3c2572030495bcedbc97b42ef430d4a2347dfa051dab8a605a0b919a846"
+    "aggregateSha256": "fd0e9cf8ff78a7894136c721d2f42db003b9e83d2c60fde2d52df28b64d08a15"
   },
   "runtime": {
     "contractVersion": 1,
@@ -63,16 +63,16 @@
   },
   "cli": {
     "contractVersion": 1,
-    "packageVersion": "1.0.5",
+    "packageVersion": "1.0.6",
     "contractDigest": "d280747a21f46add48d70193205c4dc642b1e0f38447209611174e33beff5927",
     "tarball": {
-      "path": "packages/operon-cli/freeze/operon-cli-1.0.5.tgz",
-      "sha256": "3ec13cc4af1b008f57e39d92935bafc990889497a63bc85aad3f7f93029408eb",
+      "path": "packages/operon-cli/freeze/operon-cli-1.0.6.tgz",
+      "sha256": "cdacb087231a085074f328023fc28bc70a7ea1ddd2925821875a67152411e8a6",
       "bytes": 213393
     },
     "executable": {
       "path": "packages/operon-cli/dist/operon.mjs",
-      "sha256": "c1dc70f2971882615e54fb96c160d1b785a26fca4372eb95db048df208a099dd",
+      "sha256": "f116dfa086bf64c0837b8b3236c24f0438a1157a038d88af20fe81c866eb72fc",
       "bytes": 512706
     },
     "license": {
@@ -82,12 +82,12 @@
     },
     "manifest": {
       "path": "packages/operon-cli/cli-manifest-v1.json",
-      "sha256": "813b3154d95c033fcdbdb02eadd6fc4b01ed16e499b9cc08c745b19a96dd9807",
+      "sha256": "bc4db21496ebfb4b6fcb2c442c96089b01a572931478e533a3eb4b19993ed075",
       "bytes": 51224
     },
     "packageMetadata": {
       "path": "packages/operon-cli/package.json",
-      "sha256": "a16765683111a3bb7f802b208fc82b357ce15d2f43e67d194ec050d17ecbbf96",
+      "sha256": "03ffbf12af0bc5ddf8f33b8bd0e30c32a151615fe1815976ad3d4f6258ec3bb6",
       "bytes": 1978
     },
     "readme": {
@@ -110,7 +110,7 @@
       "fileCount": 5,
       "aggregateSha256": "2ecd8a3e0ae2e069bc89a7cd70cdb724f4023f2b306391b21fbbabca07dd12c6"
     },
-    "packageInputAggregateSha256": "ce2ff58548caa0e87aea718c156d648cba21c062f146a80263ed2226d6f66b66"
+    "packageInputAggregateSha256": "d8eb1ae8f8c3779483e30e31affad23452a589cd37ee60b70536450d9ce3a6bd"
   },
   "documentation": {
     "manifest": {
@@ -196,7 +196,7 @@
   "maintainerAcceptance": {
     "status": "accepted",
     "acceptedBy": "Hasan Yilmaz",
-    "acceptedAt": "2026-08-01T14:28:02.000Z"
+    "acceptedAt": "2026-08-01T15:48:12.000Z"
   },
-  "inputsAggregateSha256": "9ffc90189cc68199fd8674352043724cba0f0138030aaa81bfda283e760fecbc"
+  "inputsAggregateSha256": "716eb04d5f4b747fa7b34411f2220fd92c0dcb31b8db656c5368e845235d2142"
 }

--- a/contracts/agent-runtime/public-v1-scope.md
+++ b/contracts/agent-runtime/public-v1-scope.md
@@ -16,7 +16,7 @@ has passed.
 Public V1 launch versions:
 
 - Operon `3.0.1`
-- `operon-cli@1.0.5`
+- `operon-cli@1.0.6`
 - Runtime API and contract version `1`
 
 The current CLI is a private release candidate and is not publicly installable
@@ -52,7 +52,7 @@ versioned Public V1 integration contract.
 | Area | Current implementation truth | Public V1 launch target |
 | --- | --- | --- |
 | Operon release | Operon `3.0.1` is publicly released with Runtime API V1 and the Windows mutation reliability patch | Operon `3.0.1` |
-| CLI package | Local `operon-cli@1.0.5` stable release candidate; not published to public npm | Public stable `operon-cli@1.0.5` |
+| CLI package | Local `operon-cli@1.0.6` stable release candidate; not published to public npm | Public stable `operon-cli@1.0.6` |
 | Runtime contract | Runtime API V1 exists and is exposed on the Operon plugin instance | Runtime API V1 is a supported, typed Developer API contract |
 | Public access channels | The in-process Developer API and Windows mutation reliability patch ship with Operon `3.0.1`; the CLI remains an unpublished local release candidate | CLI and in-process Developer API are both supported public channels |
 | macOS CLI | Supported by the current beta boundary | Supported |
@@ -264,7 +264,7 @@ support, documentation, and release acceptance do not depend on that work.
 | Cross-platform launch boundary, Node support, and beta disclosure | Stage 7 — Cross-platform readiness | Hosted portability and package tests pass on Node 22, 24, and 26 across macOS, Linux, and Windows; platform-specific transport-security, path, lifecycle, interruption, and recovery tests pass; macOS remains `supported`, Linux and Windows remain executable `acceptance-required` public-beta targets, and WSL remains `unsupported` |
 | Public integration guides and examples | Stage 8 — Packaging and documentation | Clean-room CLI and Developer API integration tests using only distributable artifacts and documentation |
 | Stable contract and release candidate | Stage 9 — Hardening and freeze | No launch-blocking contract break, unauthorized access, consent bypass, data loss or corruption, or irrecoverable uncertain outcome remains; all required local contract, security, mutation, Developer API, package, documentation, and release-hardening gates pass; contract, stable manifest, package inputs, types, examples, documentation, source-rebuilt plugin artifact, and development-audit policy are bound by one exact local freeze index; the compatibility baseline has real input/response direction and deprecation coverage; documented maintainer acceptance seals the final local index |
-| Public `operon-cli@1.0.5` | Stage 10 — External release | Before publish, the accepted Stage 9 freeze, final tarball digest, provenance, compatible public Operon artifact, and nine-cell hosted portability evidence pass on the release bytes; after publish, the registry artifact digest equals that tarball and the post-publication audit passes |
+| Public `operon-cli@1.0.6` | Stage 10 — External release | Before publish, the accepted Stage 9 freeze, final tarball digest, provenance, compatible public Operon artifact, and nine-cell hosted portability evidence pass on the release bytes; after publish, the registry artifact digest equals that tarball and the post-publication audit passes |
 
 Failure of a required gate returns the work to its owning stage. Publication is
 not a substitute for contract, safety, package, or hosted portability evidence.

--- a/packages/operon-cli/cli-manifest-v1.json
+++ b/packages/operon-cli/cli-manifest-v1.json
@@ -2,7 +2,7 @@
   "manifestVersion": 1,
   "package": {
     "name": "operon-cli",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "executable": "operon",
     "node": "^22.0.0 || ^24.0.0 || ^26.0.0"
   },

--- a/packages/operon-cli/package.json
+++ b/packages/operon-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "operon-cli",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Official command-line client for the Operon Agent Runtime in Obsidian.",
   "type": "module",
   "license": "GPL-3.0-or-later",

--- a/scripts/agent-runtime/cli/check-release-routing.mjs
+++ b/scripts/agent-runtime/cli/check-release-routing.mjs
@@ -298,9 +298,28 @@ assert.match(publishWorkflow, /test "\$\(node --version\)" = "v24\.18\.0"/u);
 assert.match(publishWorkflow, /npm install --global npm@11\.12\.1/u);
 assert.match(publishWorkflow, /test "\$GITHUB_REF" = "refs\/tags\/\$SOURCE_REF"/u);
 assert.match(publishWorkflow, /ref:\s+refs\/tags\/\$\{\{\s*inputs\.source_ref\s*\}\}/u);
-assert.match(
+const publishStepPattern = /npm publish \.\/candidate\/\*\.tgz[\s\S]+--access public[\s\S]+--tag latest[\s\S]+--provenance/u;
+for (const [stepName, authenticationMode] of [
+	['Publish first approved stable release with temporary token and provenance', 'bootstrap-token'],
+	['Publish approved stable release through npm trusted publishing', 'trusted-publisher'],
+]) {
+	const escapedStepName = stepName.replace(/[.*+?^\${}()|[\]\\]/gu, '\\$&');
+	const stepBlock = publishWorkflow.match(
+		new RegExp(`- name: ${escapedStepName}\\n[\\s\\S]*?(?=\\n\\s+- name: )`, 'u'),
+	)?.[0];
+	assert.ok(stepBlock, `Missing ${authenticationMode} publish step.`);
+	assert.match(stepBlock, new RegExp(`if: inputs\\.authentication_mode == '${authenticationMode}'`, 'u'));
+	assert.match(stepBlock, publishStepPattern);
+	assert.equal(
+		stepBlock.match(/npm publish \.\/candidate\/\*\.tgz/gu)?.length,
+		1,
+		`The ${authenticationMode} step must publish exactly one explicit local tarball path.`,
+	);
+}
+assert.doesNotMatch(
 	publishWorkflow,
-	/npm publish candidate\/\*\.tgz[\s\S]+--access public[\s\S]+--tag latest[\s\S]+--provenance/u,
+	/npm publish candidate\/\*\.tgz/u,
+	'Bare relative tarball paths can be misinterpreted as GitHub shorthand by npm.',
 );
 assert.match(publishWorkflow, /secrets\.NPM_TOKEN/u);
 assert.match(publishWorkflow, /bootstrap-token is only allowed while operon-cli is unpublished/u);
@@ -323,7 +342,7 @@ for (const commandPattern of [
 	/npm view operon-cli version --json --registry https:\/\/registry\.npmjs\.org\//u,
 	/npm view operon-cli@latest version --registry https:\/\/registry\.npmjs\.org\//u,
 	/npm view operon-cli dist-tags --json --registry https:\/\/registry\.npmjs\.org\//u,
-	/npm publish candidate\/\*\.tgz[\s\S]+--registry https:\/\/registry\.npmjs\.org\//u,
+	/npm publish \.\/candidate\/\*\.tgz[\s\S]+--registry https:\/\/registry\.npmjs\.org\//u,
 ]) {
 	assert.match(publishWorkflow, commandPattern);
 }

--- a/scripts/agent-runtime/cli/materialize-frozen-candidate.test.mjs
+++ b/scripts/agent-runtime/cli/materialize-frozen-candidate.test.mjs
@@ -12,7 +12,7 @@ test('materializes the accepted canonical tarball without rebuilding it', async 
 	try {
 		const output = path.join(fixture.root, 'packages/operon-cli/release');
 		const result = await materializeFrozenCandidate({ repositoryRoot: fixture.root, outputRoot: output });
-		assert.equal(result.fileName, 'operon-cli-1.0.5.tgz');
+		assert.equal(result.fileName, 'operon-cli-1.0.6.tgz');
 		assert.deepEqual(await readFile(result.path), fixture.bytes);
 		assert.equal(result.sha256, digest(fixture.bytes));
 	} finally {
@@ -109,12 +109,12 @@ test('rejects symlinked source and output paths', {
 async function createFixture(mutate) {
 	const root = await mkdtemp(path.join(tmpdir(), 'operon-frozen-candidate-'));
 	const bytes = Buffer.from('immutable candidate tarball\n');
-	const source = path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.5.tgz');
+	const source = path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.6.tgz');
 	await mkdir(path.dirname(source), { recursive: true });
 	await mkdir(path.join(root, 'contracts/agent-runtime'), { recursive: true });
 	await writeFile(path.join(root, 'packages/operon-cli/package.json'), `${JSON.stringify({
 		name: 'operon-cli',
-		version: '1.0.5',
+		version: '1.0.6',
 	}, null, 2)}\n`, 'utf8');
 	await writeFile(source, bytes);
 	const freeze = {
@@ -128,9 +128,9 @@ async function createFixture(mutate) {
 		cli: {
 			contractVersion: 1,
 			contractDigest: '2'.repeat(64),
-			packageVersion: '1.0.5',
+			packageVersion: '1.0.6',
 			tarball: {
-				path: 'packages/operon-cli/freeze/operon-cli-1.0.5.tgz',
+				path: 'packages/operon-cli/freeze/operon-cli-1.0.6.tgz',
 				bytes: bytes.length,
 				sha256: digest(bytes),
 			},

--- a/scripts/agent-runtime/cli/native-acceptance.test.mjs
+++ b/scripts/agent-runtime/cli/native-acceptance.test.mjs
@@ -28,7 +28,7 @@ const evidenceSchema = JSON.parse(await readFile(
 	'utf8',
 ));
 const validateEvidence = new Ajv2020({ strict: false }).compile(evidenceSchema);
-const FIXTURE_CLI_VERSION = '1.0.5';
+const FIXTURE_CLI_VERSION = '1.0.6';
 const FIXTURE_CLI_TAG = `cli-v${FIXTURE_CLI_VERSION}`;
 const FIXTURE_CLI_PACKAGE = `operon-cli@${FIXTURE_CLI_VERSION}`;
 const FIXTURE_CLI_TARBALL = `operon-cli-${FIXTURE_CLI_VERSION}.tgz`;

--- a/scripts/agent-runtime/contracts/public-v1-freeze.mjs
+++ b/scripts/agent-runtime/contracts/public-v1-freeze.mjs
@@ -481,7 +481,7 @@ async function buildAuditArtifactMetafiles(root) {
 
 function assertAcceptedFreeze(index) {
 	if (
-		index.cli.packageVersion !== '1.0.5'
+		index.cli.packageVersion !== '1.0.6'
 		|| index.plugin.version !== '3.0.1'
 		|| index.audit.validation.status !== 'passed'
 		|| index.audit.validation.result?.status !== 'accepted-clean'

--- a/scripts/agent-runtime/contracts/public-v1-freeze.test.mjs
+++ b/scripts/agent-runtime/contracts/public-v1-freeze.test.mjs
@@ -200,10 +200,10 @@ test('accepted freeze requires final versions, passed audit and explicit maintai
 		);
 		await writeJson(path.join(root, 'packages/operon-cli/package.json'), {
 			name: 'operon-cli',
-			version: '1.0.5',
+			version: '1.0.6',
 		});
 		await writeFile(
-			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.5.tgz'),
+			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.6.tgz'),
 			'stable tarball\n',
 		);
 		await writeJson(path.join(root, 'manifest.json'), {
@@ -233,10 +233,10 @@ test('ordinary write clears prior acceptance and audit attestation', async () =>
 	try {
 		await writeJson(path.join(root, 'packages/operon-cli/package.json'), {
 			name: 'operon-cli',
-			version: '1.0.5',
+			version: '1.0.6',
 		});
 		await writeFile(
-			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.5.tgz'),
+			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.6.tgz'),
 			'stable tarball\n',
 		);
 		await writeJson(path.join(root, 'manifest.json'), {

--- a/scripts/release-guard.mjs
+++ b/scripts/release-guard.mjs
@@ -649,6 +649,33 @@ function checkWorkflowSecurityPolicy() {
 	if (!/^permissions:\s*\n\s{2}contents:\s+read\s*$/mu.test(readText('.github/workflows/cli-ci.yml'))) {
 		fail('.github/workflows/cli-ci.yml: workflow must explicitly grant only contents: read');
 	}
+	const publishWorkflow = readText('.github/workflows/cli-publish.yml');
+	const publishCommandPattern = /npm publish \.\/candidate\/\*\.tgz[\s\S]+--access public[\s\S]+--tag latest[\s\S]+--provenance/u;
+	for (const [stepName, authenticationMode] of [
+		['Publish first approved stable release with temporary token and provenance', 'bootstrap-token'],
+		['Publish approved stable release through npm trusted publishing', 'trusted-publisher'],
+	]) {
+		const escapedStepName = stepName.replace(/[.*+?^\${}()|[\]\\]/gu, '\\$&');
+		const stepBlock = publishWorkflow.match(
+			new RegExp(`- name: ${escapedStepName}\\n[\\s\\S]*?(?=\\n\\s+- name: )`, 'u'),
+		)?.[0];
+		if (!stepBlock) {
+			fail(`.github/workflows/cli-publish.yml: missing ${authenticationMode} publish step`);
+			continue;
+		}
+		if (!new RegExp(`if: inputs\\.authentication_mode == '${authenticationMode}'`, 'u').test(stepBlock)) {
+			fail(`.github/workflows/cli-publish.yml: ${authenticationMode} publish step must be gated by its exact authentication mode`);
+		}
+		if (!publishCommandPattern.test(stepBlock)) {
+			fail(`.github/workflows/cli-publish.yml: ${authenticationMode} must publish the explicit ./candidate/*.tgz local path with stable flags`);
+		}
+		if ((stepBlock.match(/npm publish \.\/candidate\/\*\.tgz/gu)?.length ?? 0) !== 1) {
+			fail(`.github/workflows/cli-publish.yml: ${authenticationMode} must contain exactly one local tarball publish command`);
+		}
+	}
+	if (/npm publish candidate\/\*\.tgz/u.test(publishWorkflow)) {
+		fail('.github/workflows/cli-publish.yml: bare candidate/*.tgz can be parsed as GitHub shorthand by npm');
+	}
 
 	for (const workflow of [
 		'.github/workflows/cli-native-candidate.yml',


### PR DESCRIPTION
## Summary\n\n- bumps the frozen CLI candidate to operon-cli 1.0.6\n- publishes the candidate through the explicit local ./candidate/*.tgz package spec in both npm authentication modes\n- adds fail-closed per-branch routing and release-guard coverage for the publish path\n- refreshes and accepts the Public V1 freeze without changing Runtime V1 or CLI contract semantics\n\n## Release evidence\n\n- accepted freeze SHA-256: ab22176140af79b512c4e4d9c5d77f6f9d330ce9667d1bed187c03725442d935\n- freeze input aggregate: 716eb04d5f4b747fa7b34411f2220fd92c0dcb31b8db656c5368e845235d2142\n- frozen tarball SHA-256: cdacb087231a085074f328023fc28bc70a7ea1ddd2925821875a67152411e8a6\n- frozen tarball size: 213,393 bytes\n- production and development audit findings: 0\n- check:local passed; Phase 5: 1517/1517\n- npm 11.12.1 publish dry-run passed\n\n## Scope\n\nExactly 11 tracked files. No generated docs, local Phase 5 harness, plugin artifact, private acceptance data, tag, candidate workflow dispatch, or npm publication is included.\n\nThe previous 1.0.5 publish attempt stopped before registry publication; npm still had no released operon-cli package at that point.