### PR TITLE
Route all read-only CLI commands over persistent Windows transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Routed every read-only public CLI command through the authenticated persistent
+  Runtime transport, including Windows capability, diagnostics, catalog, entity,
+  finder, relationship, context, and timer reads; mutation preview and apply
+  remain on their one-shot safety path.
+
 ### Validation
 
 ## [3.0.1] - 2026-08-01

--- a/packages/operon-cli/README.md
+++ b/packages/operon-cli/README.md
@@ -26,6 +26,12 @@ portability tests, but they have not completed the optional native desktop
 certification matrix. Please report real-environment results using the feedback
 checklist below.
 
+All read-only Runtime commands use the authenticated persistent transport when
+the desktop server is available, including capability, diagnostics, catalog,
+entity, task, finder, relationship, context, and timer reads. Mutation preview
+and apply remain on the one-shot path so their consent, dispatch, and recovery
+semantics stay separate from read batching.
+
 ## Install
 
 ```bash

--- a/packages/operon-cli/src/client.ts
+++ b/packages/operon-cli/src/client.ts
@@ -44,6 +44,7 @@ import {
 	type PersistentReadTransportV1,
 	createWindowsBrokerClientV1,
 } from './persistent-read-client';
+import { isPersistentReadCommandV1 as isPersistentReadPolicyCommandV1 } from '../../../src/agent-runtime/transport/persistent-read-commands';
 import {
 	resolveObsidianExecutableV1,
 	terminateProcessTreeV1,
@@ -665,10 +666,7 @@ async function mutationDispatchMayHaveStartedV1(
 }
 
 export function isPersistentReadCommandV1(command: CliCommandV1): boolean {
-	return command === 'health'
-		|| command === 'task.get'
-		|| command === 'tasks.query'
-		|| command === 'context.build';
+	return isPersistentReadPolicyCommandV1(command);
 }
 
 function runSpawnTransport(

--- a/packages/operon-cli/src/persistent-read-client.ts
+++ b/packages/operon-cli/src/persistent-read-client.ts
@@ -13,6 +13,7 @@ import path from 'node:path';
 
 import { CONTRACT_LIMITS_V1 } from '../../../src/agent-runtime/contracts/v1/primitives';
 import type { CliInvocationV1 } from '../../../src/agent-runtime/contracts/v1/cli';
+import { PERSISTENT_READ_COMMANDS_V1 } from '../../../src/agent-runtime/transport/persistent-read-commands';
 import {
 	type CanonicalVaultFenceV1,
 	assertCanonicalVaultFenceV1,
@@ -30,7 +31,7 @@ const PROTOCOL_VERSION = 1;
 const HEX_64 = /^[a-f0-9]{64}$/u;
 const UNIX_SOCKET_BASENAME = /^read-[a-f0-9]{48}\.sock$/u;
 const WINDOWS_PIPE = /^\\\\\.\\pipe\\operon-[a-f0-9]{64}$/u;
-const READ_COMMANDS = new Set(['health', 'task.get', 'tasks.query', 'context.build']);
+const READ_COMMANDS = new Set<string>(PERSISTENT_READ_COMMANDS_V1);
 
 interface PersistentDescriptorV1 {
 	protocolVersion: 1;

--- a/scripts/agent-runtime/cli-transport/native-transport.test.ts
+++ b/scripts/agent-runtime/cli-transport/native-transport.test.ts
@@ -504,7 +504,7 @@ test('persistent read server dispatches allowlisted tokens and rejects mutation 
 		const batchInvocations = ['batch-one', 'batch-two'].map((requestId, index) => ({
 			...invocation,
 			requestId,
-			command: 'health' as const,
+			command: index === 0 ? 'health' as const : 'capabilities' as const,
 			requestToken: String.fromCharCode(108 + index).repeat(32),
 		}));
 		for (const batchInvocation of batchInvocations) {

--- a/scripts/agent-runtime/cli/cli.test.ts
+++ b/scripts/agent-runtime/cli/cli.test.ts
@@ -103,6 +103,7 @@ import type {
 	CliInvocationV1,
 	CliResultEnvelopeV1,
 } from '../../../src/agent-runtime/contracts/v1/cli';
+import { PERSISTENT_READ_COMMANDS_V1 } from '../../../src/agent-runtime/transport/persistent-read-commands';
 import type {
 	ContextRevisionV1,
 	OperonCatalogV1,
@@ -134,6 +135,7 @@ async function run(): Promise<void> {
 	testWindowsPowerShellResolutionSecurity();
 	testContractDecoders();
 	testProductionInvocationValidatorParity();
+	testPersistentReadCommandPolicy();
 	if (process.platform !== 'win32') testSecureRequestFile();
 	await testInvocationConstruction();
 	await testOneShotExecutionAndCleanup();
@@ -1891,13 +1893,6 @@ async function testOneShotExecutionAndCleanup(): Promise<void> {
 }
 
 async function testOneShotPersistentReadRouting(): Promise<void> {
-	assert.equal(isPersistentReadCommandV1('health'), true);
-	assert.equal(isPersistentReadCommandV1('task.get'), true);
-	assert.equal(isPersistentReadCommandV1('tasks.query'), true);
-	assert.equal(isPersistentReadCommandV1('context.build'), true);
-	assert.equal(isPersistentReadCommandV1('capabilities'), false);
-	assert.equal(isPersistentReadCommandV1('mutation.apply'), false);
-
 	const vault = mkdtempSync(path.join(tmpdir(), 'operon-cli-persistent-routing-vault-'));
 	const requestRoot = path.join(tmpdir(), `operon-cli-persistent-routing-${Date.now()}`);
 	const configRoot = path.join(tmpdir(), `operon-cli-persistent-config-${Date.now()}`);
@@ -1968,32 +1963,16 @@ async function testOneShotPersistentReadRouting(): Promise<void> {
 				factoryCalls += 1;
 				return transport;
 			},
-			runProcess: async (_executable, args) => {
+			runProcess: async () => {
 				processCalls += 1;
-				const token = args.find(value => value.startsWith('requestToken='))
-					?.slice('requestToken='.length);
-				assert.ok(token);
-				const requestPath = requestPathForTokenV1(token, requestRoot);
-				const request = JSON.parse(readFileSync(requestPath, 'utf8')) as CliInvocationV1;
-				return {
-					exitCode: 0,
-					signal: null,
-					stdout: Buffer.from(JSON.stringify(capabilitiesSuccessEnvelope(
-						request,
-						lstatSync(requestPath).size,
-					))),
-					stderr: Buffer.alloc(0),
-					totalMs: 1,
-					timedOut: false,
-					overflow: false,
-				};
+				throw new Error('eligible read must use the persistent transport first');
 			},
 		});
-		assert.equal(capabilities.exitCode, 0, capabilities.human);
-		assert.equal(factoryCalls, 1);
-		assert.equal(persistentCalls, 1);
-		assert.equal(processCalls, 1);
-		assert.equal(closeCalls, 1);
+		assert.equal(capabilities.exitCode, 3, capabilities.human);
+		assert.equal(factoryCalls, 2);
+		assert.equal(persistentCalls, 2);
+		assert.equal(processCalls, 0);
+		assert.equal(closeCalls, 2);
 
 		const doctor = await runPublicCommandLineV1([
 			'doctor',
@@ -2025,6 +2004,14 @@ async function testOneShotPersistentReadRouting(): Promise<void> {
 		rmSync(requestRoot, { recursive: true, force: true });
 		rmSync(configRoot, { recursive: true, force: true });
 	}
+}
+
+function testPersistentReadCommandPolicy(): void {
+	for (const command of PERSISTENT_READ_COMMANDS_V1) {
+		assert.equal(isPersistentReadCommandV1(command), true, `${command} must use persistent read transport`);
+	}
+	assert.equal(isPersistentReadCommandV1('mutation.preview'), false);
+	assert.equal(isPersistentReadCommandV1('mutation.apply'), false);
 }
 
 async function testAbortTransportGuards(): Promise<void> {

--- a/scripts/agent-runtime/cli/session-jsonl.test.ts
+++ b/scripts/agent-runtime/cli/session-jsonl.test.ts
@@ -903,15 +903,15 @@ test('persistent read client handshakes, preserves request identity, and rejects
 				vaultFence,
 			}),
 			client.invoke({
-				requestId: 'batch-query',
-				command: 'tasks.query',
+				requestId: 'batch-capabilities',
+				command: 'capabilities',
 				requestToken: 'D'.repeat(32),
 				vaultFence,
 			}),
 		]);
 		assert.equal(seen[4]?.type, 'batch');
 		assert.equal((seen[4]?.requests as unknown[]).length, 2);
-		assert.equal(JSON.parse(batch[1]!.result.toString('utf8')).requestId, 'batch-query');
+		assert.equal(JSON.parse(batch[1]!.result.toString('utf8')).requestId, 'batch-capabilities');
 		client.beginBatch(2);
 		const disconnected = await Promise.allSettled([
 			client.invoke({

--- a/src/agent-runtime/transport/persistent-read-commands.ts
+++ b/src/agent-runtime/transport/persistent-read-commands.ts
@@ -1,0 +1,24 @@
+import type { CliCommandV1 } from '../contracts/v1/cli';
+
+/**
+ * Runtime commands that are read-only and may use the authenticated
+ * persistent transport. Mutation preview/apply deliberately stay on the
+ * one-shot path so their safety and recovery semantics remain unchanged.
+ */
+export const PERSISTENT_READ_COMMANDS_V1 = [
+	'health',
+	'capabilities',
+	'diagnostics',
+	'catalog',
+	'entity.resolve',
+	'task.get',
+	'tasks.query',
+	'tasks.finder',
+	'relationships.get',
+	'context.build',
+	'timers.read',
+] as const satisfies readonly CliCommandV1[];
+
+export function isPersistentReadCommandV1(command: CliCommandV1): boolean {
+	return (PERSISTENT_READ_COMMANDS_V1 as readonly string[]).includes(command);
+}

--- a/src/agent-runtime/transport/persistent-read-server.ts
+++ b/src/agent-runtime/transport/persistent-read-server.ts
@@ -21,6 +21,7 @@ import {
 	unregisterWindowsBrokerScopeV1,
 	type WindowsBrokerScopeV1,
 } from './windows-broker-state';
+import { PERSISTENT_READ_COMMANDS_V1 } from './persistent-read-commands';
 
 const PROTOCOL_VERSION_V1 = 1;
 const MAX_CONNECTIONS_V1 = 4;
@@ -29,10 +30,7 @@ const AUTHENTICATED_FRAME_OVERHEAD_BYTES_V1 = 16 * 1024;
 const MAX_FRAME_BYTES_V1 = CONTRACT_LIMITS_V1.transportInputBytes
 	+ AUTHENTICATED_FRAME_OVERHEAD_BYTES_V1;
 const READ_COMMANDS_V1 = new Set<CliCommandV1>([
-	'health',
-	'task.get',
-	'tasks.query',
-	'context.build',
+	...PERSISTENT_READ_COMMANDS_V1,
 ]);
 const HEX_256_PATTERN_V1 = /^[a-f0-9]{64}$/u;
 const REQUEST_TOKEN_PATTERN_V1 = /^[A-Za-z0-9_-]{32}$/u;


### PR DESCRIPTION
## Summary

- centralize the read-only command policy for the authenticated persistent transport
- route capabilities, diagnostics, catalog, entity resolution, task finder, relationships, and timer reads through that transport on Windows as well as the existing health/task/query/context reads
- keep mutation.preview and mutation.apply out of the persistent path
- add routing, client, server, documentation, and changelog coverage

This fixes the Windows read-only CLI transport failures tracked in #103. The V1 wire contract is unchanged; the plugin and CLI must be released together because the allowlist is enforced on both ends. This is separate from #99.

## Validation

Passed:

- npm --prefix packages/operon-cli run build
- npm run build
- npm run agent-runtime:types:check
- node scripts/agent-runtime/cli-transport/run-native-transport-tests.mjs (12/12)
- npm run docs:public-v1:test (14/14)
- package lifecycle, type-consumer, and release-tag checks inside npm run agent-runtime:cli:package
- live Windows smoke against the official 3.0.1 plugin: existing four persistent reads still pass, while newly routed reads reach the persistent channel and are rejected by the old server as expected

Known local acceptance boundaries:

- the full repository check currently stops on a Windows permission test that reports a missing path instead of a read error
- npm run agent-runtime:cli:package then stops at the existing public-freeze routing gate because this branch intentionally changes the candidate plugin bundle; the freeze hash must be updated only when upstream accepts the fix

The V1 wire contract is unchanged and mutation preview/apply remain outside this transport.

Fixes #103