### PR TITLE
Prepare scoped operon-cli 1.0.7 publication

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -139,10 +139,10 @@ jobs:
       - name: Verify first-publish bootstrap admission
         if: inputs.authentication_mode == 'bootstrap-token'
         run: |
-          if npm view operon-cli version --json \
+          if npm view @stratejya/operon-cli version --json \
             --registry https://registry.npmjs.org/ \
             >"$RUNNER_TEMP/npm-view.stdout" 2>"$RUNNER_TEMP/npm-view.stderr"; then
-            echo "bootstrap-token is only allowed while operon-cli is unpublished" >&2
+            echo "bootstrap-token is only allowed while @stratejya/operon-cli is unpublished" >&2
             exit 1
           fi
           grep -q "E404" "$RUNNER_TEMP/npm-view.stderr" \
@@ -153,8 +153,8 @@ jobs:
           AUTHENTICATION_MODE: ${{ inputs.authentication_mode }}
         run: |
           if test "$AUTHENTICATION_MODE" = "trusted-publisher"; then
-            DIST_TAGS="$(npm view operon-cli dist-tags --json --registry https://registry.npmjs.org/)"
-          elif ! DIST_TAGS="$(npm view operon-cli dist-tags --json \
+            DIST_TAGS="$(npm view @stratejya/operon-cli dist-tags --json --registry https://registry.npmjs.org/)"
+          elif ! DIST_TAGS="$(npm view @stratejya/operon-cli dist-tags --json \
             --registry https://registry.npmjs.org/ \
             2>"$RUNNER_TEMP/npm-dist-tags.stderr")"; then
             grep -q "E404" "$RUNNER_TEMP/npm-dist-tags.stderr" \
@@ -176,7 +176,7 @@ jobs:
             --provenance
       - name: Verify trusted-publisher admission
         if: inputs.authentication_mode == 'trusted-publisher'
-        run: npm view operon-cli version --json --registry https://registry.npmjs.org/ >/dev/null
+        run: npm view @stratejya/operon-cli version --json --registry https://registry.npmjs.org/ >/dev/null
       - name: Publish approved stable release through npm trusted publishing
         if: inputs.authentication_mode == 'trusted-publisher'
         run: |
@@ -195,7 +195,7 @@ jobs:
             || { echo "Expected stable package version is invalid" >&2; exit 1; }
           VERIFIED=0
           for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
-            if test "$(npm view operon-cli@latest version --registry https://registry.npmjs.org/ 2>/dev/null)" = "$EXPECTED_VERSION"; then
+            if test "$(npm view @stratejya/operon-cli@latest version --registry https://registry.npmjs.org/ 2>/dev/null)" = "$EXPECTED_VERSION"; then
               VERIFIED=1
               break
             fi
@@ -203,7 +203,7 @@ jobs:
           done
           test "$VERIFIED" = "1" \
             || { echo "Registry verification failed after publish; do not rerun publish, inspect this exact version first" >&2; exit 1; }
-          DIST_TAGS="$(npm view operon-cli dist-tags --json --registry https://registry.npmjs.org/)"
+          DIST_TAGS="$(npm view @stratejya/operon-cli dist-tags --json --registry https://registry.npmjs.org/)"
           node -e 'const d=JSON.parse(process.argv[1]); process.exit(d.latest===process.argv[2] ? 0 : 1)' "$DIST_TAGS" "$EXPECTED_VERSION"
           node -e 'const d=JSON.parse(process.argv[1]); const beta=typeof d.beta==="string"?d.beta:""; process.exit(beta===process.argv[2] ? 0 : 1)' "$DIST_TAGS" "${{ steps.beta_before.outputs.version }}"
           echo "version=$EXPECTED_VERSION" >> "$GITHUB_OUTPUT"
@@ -214,7 +214,7 @@ jobs:
         run: |
           test -n "$EXPECTED_VERSION"
           mkdir -p "$RUNNER_TEMP/registry-roundtrip"
-          npm pack operon-cli@latest \
+          npm pack @stratejya/operon-cli@latest \
             --pack-destination "$RUNNER_TEMP/registry-roundtrip" \
             --ignore-scripts \
             --registry https://registry.npmjs.org/
@@ -229,7 +229,7 @@ jobs:
           mkdir -p "$RUNNER_TEMP/npm-signature-audit"
           cd "$RUNNER_TEMP/npm-signature-audit"
           npm init --yes >/dev/null
-          npm install "operon-cli@$EXPECTED_VERSION" \
+          npm install "@stratejya/operon-cli@$EXPECTED_VERSION" \
             --ignore-scripts \
             --no-audit \
             --no-fund \

--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ Operon also provides public desktop integration surfaces for terminal workflows,
 `operon-cli` is the public gateway for terminal use and external processes:
 
 ```bash
-npm install --global operon-cli
+npm install --global @stratejya/operon-cli
 operon setup
 operon doctor --live
 ```

--- a/contracts/agent-runtime/contract-evolution-v1.md
+++ b/contracts/agent-runtime/contract-evolution-v1.md
@@ -6,7 +6,7 @@ This document is the normative evolution policy for Runtime API V1 and CLI
 contract V1. The Public V1 scope remains authoritative for product and platform
 commitments.
 
-Operon `3.x` maintains Runtime API V1. `operon-cli` `1.x` maintains CLI
+Operon `3.x` maintains Runtime API V1. `@stratejya/operon-cli` `1.x` maintains CLI
 contract V1. Runtime and CLI compatibility are negotiated by advertised
 contract ranges and capabilities, never by assuming that Operon and CLI
 package versions are equal.
@@ -132,6 +132,22 @@ disclosing the absence of native-environment certification.
 This correction changes a pre-public support promise and release process. It
 does not change request or response DTOs, capability identifiers, error or exit
 semantics, sealed-plan safety, authorization, receipt, or same-plan recovery.
+
+## Pre-public npm namespace correction
+
+The first public npm publication uses the user-scoped package identity
+`@stratejya/operon-cli`. The earlier unscoped `operon-cli` candidate was never
+published, and npm refused that global-registry name before accepting package
+bytes. The executable remains `operon`; CLI commands, Runtime API V1, CLI
+contract V1, exit meanings, recovery behavior, and type shapes are unchanged.
+
+The manifest schema continues to recognize the unpublished legacy package name
+for compatibility inspection, while canonical generators, installation
+instructions, type-only imports, release evidence, and update discovery emit
+the scoped identity. This correction replaces the unpublished compatibility
+baseline and exact local freeze before a new immutable release tag is created.
+After public publication, the scoped package identity follows the normal V1
+breaking-change rules without this exception.
 
 ## Pre-public trust-boundary correction
 

--- a/contracts/agent-runtime/public-v1-baseline.json
+++ b/contracts/agent-runtime/public-v1-baseline.json
@@ -14041,7 +14041,10 @@
           ],
           "properties": {
             "name": {
-              "const": "operon-cli"
+              "enum": [
+                "operon-cli",
+                "@stratejya/operon-cli"
+              ]
             },
             "version": {
               "type": "string",

--- a/contracts/agent-runtime/public-v1-freeze.json
+++ b/contracts/agent-runtime/public-v1-freeze.json
@@ -6,13 +6,13 @@
     "files": [
       {
         "path": "contracts/agent-runtime/public-v1-scope.md",
-        "sha256": "dfefdba1431286861f32a3ab19eb9acffd9ba163afc214ef145e3a727164134e",
-        "bytes": 17302
+        "sha256": "0ccf4fcd685ea7a7d12b14bbc0739dd9413aec2fd5ab26999ca34ff1db07826e",
+        "bytes": 17346
       },
       {
         "path": "contracts/agent-runtime/contract-evolution-v1.md",
-        "sha256": "2f84437e309516d0b37b17439d941c2eecf957c3b1bf16d3c8111cc6c7a90a6e",
-        "bytes": 10029
+        "sha256": "3db221df8f66f63989943044f48b423b530139a37ce899b77ec9917e5c914a6a",
+        "bytes": 10966
       },
       {
         "path": "contracts/agent-runtime/developer-api-v1.md",
@@ -21,8 +21,8 @@
       },
       {
         "path": "contracts/agent-runtime/public-v1-baseline.json",
-        "sha256": "72a2592d6224573069580d25a27c93e285d07abed3a036bd811174eec1f9bbbc",
-        "bytes": 545444
+        "sha256": "bac2f97bab10e5b4664102914ec960382130513ad66f1cfc4d67848fde79b792",
+        "bytes": 545518
       },
       {
         "path": "contracts/agent-runtime/public-v1-freeze.schema.json",
@@ -41,11 +41,11 @@
       },
       {
         "path": "scripts/agent-runtime/contracts/public-v1-freeze.mjs",
-        "sha256": "4d5dfac789b2fc62caa3ce6b8809e2745fc3ad28ab71cf1d20fee946d44b9bf0",
-        "bytes": 24710
+        "sha256": "6e27158ec369a732bd68626023bfabba574e444ee1390822e98de93069736d0e",
+        "bytes": 24717
       }
     ],
-    "aggregateSha256": "fd0e9cf8ff78a7894136c721d2f42db003b9e83d2c60fde2d52df28b64d08a15"
+    "aggregateSha256": "7edece5582759fc7d2cc1703e3a4693b31e987c34309e28c7e2c04b30fb4f108"
   },
   "runtime": {
     "contractVersion": 1,
@@ -63,17 +63,17 @@
   },
   "cli": {
     "contractVersion": 1,
-    "packageVersion": "1.0.6",
-    "contractDigest": "d280747a21f46add48d70193205c4dc642b1e0f38447209611174e33beff5927",
+    "packageVersion": "1.0.7",
+    "contractDigest": "407f3a222f8c59a9622038e99e9345d0d34882fd358149b38bce5354ae0ca92b",
     "tarball": {
-      "path": "packages/operon-cli/freeze/operon-cli-1.0.6.tgz",
-      "sha256": "cdacb087231a085074f328023fc28bc70a7ea1ddd2925821875a67152411e8a6",
-      "bytes": 213393
+      "path": "packages/operon-cli/freeze/stratejya-operon-cli-1.0.7.tgz",
+      "sha256": "f03c360ec83663d730d76a5e53e27e4544c82f6c6f1ecfbbc0fba1538cd980a8",
+      "bytes": 213485
     },
     "executable": {
       "path": "packages/operon-cli/dist/operon.mjs",
-      "sha256": "f116dfa086bf64c0837b8b3236c24f0438a1157a038d88af20fe81c866eb72fc",
-      "bytes": 512706
+      "sha256": "6e6b99082d2354faa59aedf7ffcbecef77512989c5b594ed104d47650caeb174",
+      "bytes": 512727
     },
     "license": {
       "path": "packages/operon-cli/LICENSE",
@@ -82,23 +82,23 @@
     },
     "manifest": {
       "path": "packages/operon-cli/cli-manifest-v1.json",
-      "sha256": "bc4db21496ebfb4b6fcb2c442c96089b01a572931478e533a3eb4b19993ed075",
-      "bytes": 51224
+      "sha256": "6cc0ee85e8cd65607e7e8682161d79e4e3e971d12d312e199c2c86651f553805",
+      "bytes": 51235
     },
     "packageMetadata": {
       "path": "packages/operon-cli/package.json",
-      "sha256": "03ffbf12af0bc5ddf8f33b8bd0e30c32a151615fe1815976ad3d4f6258ec3bb6",
-      "bytes": 1978
+      "sha256": "3daee021ff18f7ee389e05aec31e6e625f6f6b80b747a29ed4de771401db8444",
+      "bytes": 1989
     },
     "readme": {
       "path": "packages/operon-cli/README.md",
-      "sha256": "5a905089c3bf70f5602d51de70dea6b1321e385439f0632141880df2bf11aeb3",
-      "bytes": 5704
+      "sha256": "7369af52cbff6f9dd32f436b6b26bbbe6262e6b81222662d2d378e94102e42f6",
+      "bytes": 5737
     },
     "schemas": {
       "root": "packages/operon-cli/schemas/v1",
       "fileCount": 16,
-      "aggregateSha256": "72c12e77474e0f1dcb6eda4cd800f8442926333827dfac94018e00054ae9f72e"
+      "aggregateSha256": "4822e8e47073ba1e6bbce6c2902d6f9cf37556492cdeee452cc0576e0e609272"
     },
     "declarations": {
       "root": "packages/operon-cli/types",
@@ -108,23 +108,23 @@
     "developerExample": {
       "root": "packages/operon-cli/examples/developer-api-consumer",
       "fileCount": 5,
-      "aggregateSha256": "2ecd8a3e0ae2e069bc89a7cd70cdb724f4023f2b306391b21fbbabca07dd12c6"
+      "aggregateSha256": "7b307e0293c91e6591b482e871c645cb088798f7da2c57e24424517d2b005ff2"
     },
-    "packageInputAggregateSha256": "d8eb1ae8f8c3779483e30e31affad23452a589cd37ee60b70536450d9ce3a6bd"
+    "packageInputAggregateSha256": "ac9f097e2acbb4832393e720c2ca4c0ffb3fa28c3d6bce18f8c70880374a9018"
   },
   "documentation": {
     "manifest": {
       "path": "docs/operon-docs/manifest.json",
-      "sha256": "6a1ce4aeb69b9b32c1f47dcd51a38bb407f45a8edb5e90f67217baa7c2a07d7a",
+      "sha256": "6db83ec4633e731e71d76bc70870af53460018ed0c5384a50c731e2de60c2b17",
       "bytes": 22798
     },
     "tree": {
       "root": "docs/operon-docs",
       "fileCount": 134,
-      "aggregateSha256": "7b0bb897763912ae6c03340fbb2c35b5544b910abef9e2b73a581d9df6745535"
+      "aggregateSha256": "f78bb16b7406cf51b06bf4e7484ae80406654129d61235e492b6833a1d1ed972"
     },
     "fileCount": 133,
-    "contentAggregateSha256": "9b9cabf8caae5453750637d0e41ef175c55b05dd19a1601dda332b2dbd58f20f"
+    "contentAggregateSha256": "efc03bda78c1969ec262132fd612438cfdae4f25c40d3de50ee21574cdf35ec5"
   },
   "plugin": {
     "artifactStatus": "local-rebuilt-artifact",
@@ -196,7 +196,7 @@
   "maintainerAcceptance": {
     "status": "accepted",
     "acceptedBy": "Hasan Yilmaz",
-    "acceptedAt": "2026-08-01T15:48:12.000Z"
+    "acceptedAt": "2026-08-01T18:09:48.000Z"
   },
-  "inputsAggregateSha256": "716eb04d5f4b747fa7b34411f2220fd92c0dcb31b8db656c5368e845235d2142"
+  "inputsAggregateSha256": "48414244ab4ea8f3de289c2f2709cc0b9e11690c8d5c54d6724f6a5d6ee94f67"
 }

--- a/contracts/agent-runtime/public-v1-scope.md
+++ b/contracts/agent-runtime/public-v1-scope.md
@@ -16,7 +16,7 @@ has passed.
 Public V1 launch versions:
 
 - Operon `3.0.1`
-- `operon-cli@1.0.6`
+- `@stratejya/operon-cli@1.0.7`
 - Runtime API and contract version `1`
 
 The current CLI is a private release candidate and is not publicly installable
@@ -52,7 +52,7 @@ versioned Public V1 integration contract.
 | Area | Current implementation truth | Public V1 launch target |
 | --- | --- | --- |
 | Operon release | Operon `3.0.1` is publicly released with Runtime API V1 and the Windows mutation reliability patch | Operon `3.0.1` |
-| CLI package | Local `operon-cli@1.0.6` stable release candidate; not published to public npm | Public stable `operon-cli@1.0.6` |
+| CLI package | Local `@stratejya/operon-cli@1.0.7` stable release candidate; not published to public npm | Public stable `@stratejya/operon-cli@1.0.7` |
 | Runtime contract | Runtime API V1 exists and is exposed on the Operon plugin instance | Runtime API V1 is a supported, typed Developer API contract |
 | Public access channels | The in-process Developer API and Windows mutation reliability patch ship with Operon `3.0.1`; the CLI remains an unpublished local release candidate | CLI and in-process Developer API are both supported public channels |
 | macOS CLI | Supported by the current beta boundary | Supported |
@@ -264,7 +264,7 @@ support, documentation, and release acceptance do not depend on that work.
 | Cross-platform launch boundary, Node support, and beta disclosure | Stage 7 — Cross-platform readiness | Hosted portability and package tests pass on Node 22, 24, and 26 across macOS, Linux, and Windows; platform-specific transport-security, path, lifecycle, interruption, and recovery tests pass; macOS remains `supported`, Linux and Windows remain executable `acceptance-required` public-beta targets, and WSL remains `unsupported` |
 | Public integration guides and examples | Stage 8 — Packaging and documentation | Clean-room CLI and Developer API integration tests using only distributable artifacts and documentation |
 | Stable contract and release candidate | Stage 9 — Hardening and freeze | No launch-blocking contract break, unauthorized access, consent bypass, data loss or corruption, or irrecoverable uncertain outcome remains; all required local contract, security, mutation, Developer API, package, documentation, and release-hardening gates pass; contract, stable manifest, package inputs, types, examples, documentation, source-rebuilt plugin artifact, and development-audit policy are bound by one exact local freeze index; the compatibility baseline has real input/response direction and deprecation coverage; documented maintainer acceptance seals the final local index |
-| Public `operon-cli@1.0.6` | Stage 10 — External release | Before publish, the accepted Stage 9 freeze, final tarball digest, provenance, compatible public Operon artifact, and nine-cell hosted portability evidence pass on the release bytes; after publish, the registry artifact digest equals that tarball and the post-publication audit passes |
+| Public `@stratejya/operon-cli@1.0.7` | Stage 10 — External release | Before publish, the accepted Stage 9 freeze, final tarball digest, provenance, compatible public Operon artifact, and nine-cell hosted portability evidence pass on the release bytes; after publish, the registry artifact digest equals that tarball and the post-publication audit passes |
 
 Failure of a required gate returns the work to its owning stage. Publication is
 not a substitute for contract, safety, package, or hosted portability evidence.

--- a/docs/operon-docs/DOCS-119 Install and verify Operon CLI.md
+++ b/docs/operon-docs/DOCS-119 Install and verify Operon CLI.md
@@ -29,7 +29,7 @@ The client depends on Obsidian's own command-line interface being active. If it 
 Install globally:
 
 ```bash
-npm install --global operon-cli
+npm install --global @stratejya/operon-cli
 ```
 
 Confirm the install and your Node version in one step:

--- a/docs/operon-docs/DOCS-129 In-process Developer API overview.md
+++ b/docs/operon-docs/DOCS-129 In-process Developer API overview.md
@@ -21,7 +21,7 @@ The package exposes type-only TypeScript entrypoints:
 import type {
   OperonDeveloperApiAccessorV1,
   OperonDeveloperApiV1,
-} from "operon-cli/contracts/v1/developer-api";
+} from "@stratejya/operon-cli/contracts/v1/developer-api";
 ```
 
 These imports provide declarations only. They do not include a JavaScript SDK, validators, storage helpers, transports, or Runtime code. Your plugin already runs inside Obsidian, so it obtains the active Operon plugin instance from the host and calls the accessor on that instance.

--- a/docs/operon-docs/manifest.json
+++ b/docs/operon-docs/manifest.json
@@ -600,8 +600,8 @@
     },
     {
       "path": "DOCS-119 Install and verify Operon CLI.md",
-      "sha256": "32a009a8570d3ae3ec351b6f7cf98bb77ee72dbcdc6abbd4d661b2a7766a8e74",
-      "bytes": 8598
+      "sha256": "c10fc93a642000eda724eb7905644ed696562114ffe49d571ba2d19ad616f059",
+      "bytes": 8609
     },
     {
       "path": "DOCS-120 Your first safe task read.md",
@@ -650,8 +650,8 @@
     },
     {
       "path": "DOCS-129 In-process Developer API overview.md",
-      "sha256": "bd0b117b087afd28c502d0362735a109789e139fa48218bd403af373df26a8eb",
-      "bytes": 6439
+      "sha256": "e45bb7d5a83ad0c42367a8e70cfa3939c2be280d022e585d981476915a10dc40",
+      "bytes": 6450
     },
     {
       "path": "DOCS-130 Developer API identity and capability grants.md",

--- a/packages/operon-cli/README.md
+++ b/packages/operon-cli/README.md
@@ -29,7 +29,7 @@ checklist below.
 ## Install
 
 ```bash
-npm install --global operon-cli
+npm install --global @stratejya/operon-cli
 ```
 
 Public npm installation becomes available only after the package is published.
@@ -115,7 +115,7 @@ Install the CLI package as a development dependency in an Obsidian consumer
 plugin:
 
 ```bash
-npm install --save-dev operon-cli
+npm install --save-dev @stratejya/operon-cli
 ```
 
 Import only public types:
@@ -124,7 +124,7 @@ Import only public types:
 import type {
 	OperonDeveloperApiAccessorV1,
 	OperonDeveloperApiV1,
-} from 'operon-cli/contracts/v1/developer-api';
+} from '@stratejya/operon-cli/contracts/v1/developer-api';
 ```
 
 These entrypoints export declarations only. Runtime imports, `require()`, raw

--- a/packages/operon-cli/build.mjs
+++ b/packages/operon-cli/build.mjs
@@ -29,6 +29,7 @@ import {
 	CLI_SCHEMA_ENTRYPOINTS_V1,
 } from './contract-manifest.mjs';
 import { buildContractTypesV1 } from './type-build.mjs';
+import { assertOperonCliPackageDocumentV1 } from './package-identity.mjs';
 
 const packageRoot = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
@@ -36,10 +37,9 @@ const pluginRoot = path.resolve(packageRoot, '../..');
 const distRoot = path.join(packageRoot, 'dist');
 await rm(distRoot, { recursive: true, force: true });
 await mkdir(distRoot, { recursive: true });
-const packageDocument = JSON.parse(await readFile(path.join(packageRoot, 'package.json'), 'utf8'));
-if (packageDocument.name !== 'operon-cli' || typeof packageDocument.version !== 'string') {
-	throw new Error('OPERON_CLI_PACKAGE_METADATA_INVALID');
-}
+const packageDocument = assertOperonCliPackageDocumentV1(
+	JSON.parse(await readFile(path.join(packageRoot, 'package.json'), 'utf8')),
+);
 const frameTimingBuild = process.env.OPERON_CLI_FRAME_TIMING_BUILD === '1';
 const persistentReadOverride = process.env.OPERON_CLI_PERSISTENT_READ_BUILD;
 if (
@@ -129,6 +129,7 @@ const buildResult = await build({
 	metafile: true,
 	banner: { js: '#!/usr/bin/env node' },
 	define: {
+		__OPERON_CLI_PACKAGE_NAME__: JSON.stringify(packageDocument.name),
 		__OPERON_CLI_VERSION__: JSON.stringify(packageDocument.version),
 		__OPERON_CLI_FRAME_TIMING__: frameTimingBuild ? 'true' : 'false',
 		__OPERON_CLI_PERSISTENT_READ__: persistentReadBuild ? 'true' : 'false',

--- a/packages/operon-cli/cli-manifest-v1.json
+++ b/packages/operon-cli/cli-manifest-v1.json
@@ -1,8 +1,8 @@
 {
   "manifestVersion": 1,
   "package": {
-    "name": "operon-cli",
-    "version": "1.0.6",
+    "name": "@stratejya/operon-cli",
+    "version": "1.0.7",
     "executable": "operon",
     "node": "^22.0.0 || ^24.0.0 || ^26.0.0"
   },
@@ -1047,7 +1047,7 @@
     {
       "file": "cli-manifest.schema.json",
       "id": "urn:operon:schema:cli:v1:cli-manifest.schema.json",
-      "sha256": "19eba2fd7be65db0e6f60199cd051f3fc2b7c37a6a64f4aa70e343ed5d625f7e"
+      "sha256": "fe04c04a33f28a063c14546c92da6ea74df354cb1f767cd7b033de1b312f570e"
     },
     {
       "file": "cli.schema.json",
@@ -1592,5 +1592,5 @@
       "stability": "stable"
     }
   ],
-  "contractDigest": "d280747a21f46add48d70193205c4dc642b1e0f38447209611174e33beff5927"
+  "contractDigest": "407f3a222f8c59a9622038e99e9345d0d34882fd358149b38bce5354ae0ca92b"
 }

--- a/packages/operon-cli/examples/developer-api-consumer/README.md
+++ b/packages/operon-cli/examples/developer-api-consumer/README.md
@@ -2,7 +2,7 @@
 
 This minimal Obsidian plugin demonstrates the public, in-process Operon
 Developer API V1. It imports only type declarations from
-`operon-cli/contracts/v1/developer-api`; `operon-cli` is not a runtime SDK.
+`@stratejya/operon-cli/contracts/v1/developer-api`; `@stratejya/operon-cli` is not a runtime SDK.
 
 ## Try it
 

--- a/packages/operon-cli/examples/developer-api-consumer/main.ts
+++ b/packages/operon-cli/examples/developer-api-consumer/main.ts
@@ -6,7 +6,7 @@ import type {
 	OperonDeveloperApiAccessRequestV1,
 	OperonDeveloperApiAccessorV1,
 	OperonDeveloperApiV1,
-} from 'operon-cli/contracts/v1/developer-api';
+} from '@stratejya/operon-cli/contracts/v1/developer-api';
 
 const REQUESTED_CAPABILITIES = [
 	'system.health',

--- a/packages/operon-cli/examples/developer-api-consumer/package.json
+++ b/packages/operon-cli/examples/developer-api-consumer/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "obsidian": "latest",
-    "operon-cli": "*",
+    "@stratejya/operon-cli": "*",
     "typescript": "latest"
   }
 }

--- a/packages/operon-cli/package-identity.mjs
+++ b/packages/operon-cli/package-identity.mjs
@@ -1,0 +1,22 @@
+export const OPERON_CLI_NPM_PACKAGE_NAME = '@stratejya/operon-cli';
+export const OPERON_CLI_NPM_PACKAGE_PATH = Object.freeze(['@stratejya', 'operon-cli']);
+
+const SEMVER_V1 = /^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/u;
+
+export function assertOperonCliPackageDocumentV1(packageDocument, errorCode = 'OPERON_CLI_PACKAGE_METADATA_INVALID') {
+	if (
+		packageDocument?.name !== OPERON_CLI_NPM_PACKAGE_NAME
+		|| typeof packageDocument.version !== 'string'
+		|| !SEMVER_V1.test(packageDocument.version)
+	) {
+		throw new Error(errorCode);
+	}
+	return packageDocument;
+}
+
+export function operonCliTarballFileNameV1(version) {
+	if (typeof version !== 'string' || !SEMVER_V1.test(version)) {
+		throw new Error('OPERON_CLI_PACKAGE_VERSION_INVALID');
+	}
+	return `stratejya-operon-cli-${version}.tgz`;
+}

--- a/packages/operon-cli/package.json
+++ b/packages/operon-cli/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "operon-cli",
-  "version": "1.0.6",
+  "name": "@stratejya/operon-cli",
+  "version": "1.0.7",
   "description": "Official command-line client for the Operon Agent Runtime in Obsidian.",
   "type": "module",
   "license": "GPL-3.0-or-later",

--- a/packages/operon-cli/schema-source/cli-manifest.schema.json
+++ b/packages/operon-cli/schema-source/cli-manifest.schema.json
@@ -42,7 +42,10 @@
       ],
       "properties": {
         "name": {
-          "const": "operon-cli"
+          "enum": [
+            "operon-cli",
+            "@stratejya/operon-cli"
+          ]
         },
         "version": {
           "type": "string",

--- a/packages/operon-cli/schemas/v1/cli-manifest.schema.json
+++ b/packages/operon-cli/schemas/v1/cli-manifest.schema.json
@@ -42,7 +42,10 @@
       ],
       "properties": {
         "name": {
-          "const": "operon-cli"
+          "enum": [
+            "operon-cli",
+            "@stratejya/operon-cli"
+          ]
         },
         "version": {
           "type": "string",

--- a/packages/operon-cli/src/manifest-data.ts
+++ b/packages/operon-cli/src/manifest-data.ts
@@ -14,6 +14,7 @@ import {
 	CONTRACT_LIMITS_V1,
 	ERROR_REGISTRY_V1,
 } from '../../../src/agent-runtime/contracts/v1/primitives';
+import { OPERON_CLI_PACKAGE_NAME } from './package-identity';
 
 export const OPERON_CLI_MANIFEST_VERSION_V1 = 1 as const;
 export const COMPACT_UPDATE_FEATURES_V1 = Object.freeze([
@@ -355,7 +356,7 @@ export function createCliManifestBaseV1(version: string) {
 	return {
 		manifestVersion: OPERON_CLI_MANIFEST_VERSION_V1,
 		package: {
-			name: 'operon-cli',
+			name: OPERON_CLI_PACKAGE_NAME,
 			version,
 			executable: 'operon',
 			node: '^22.0.0 || ^24.0.0 || ^26.0.0',

--- a/packages/operon-cli/src/package-identity.ts
+++ b/packages/operon-cli/src/package-identity.ts
@@ -1,0 +1,5 @@
+declare const __OPERON_CLI_PACKAGE_NAME__: string;
+
+export const OPERON_CLI_PACKAGE_NAME = typeof __OPERON_CLI_PACKAGE_NAME__ === 'string'
+	? __OPERON_CLI_PACKAGE_NAME__
+	: '@stratejya/operon-cli';

--- a/packages/operon-cli/src/update-check.ts
+++ b/packages/operon-cli/src/update-check.ts
@@ -11,6 +11,7 @@ import {
 	isValidOperonVersion,
 } from '../../../src/systems/release-check';
 import { OPERON_CLI_VERSION } from './client';
+import { OPERON_CLI_PACKAGE_NAME } from './package-identity';
 import {
 	operonCliConfigRootV1,
 	writeJsonAtomic,
@@ -18,7 +19,7 @@ import {
 import { assertSecureFileV1 } from './secure-storage';
 
 export const OPERON_CLI_DIST_TAGS_URL =
-	'https://registry.npmjs.org/-/package/operon-cli/dist-tags';
+	`https://registry.npmjs.org/-/package/${encodeURIComponent(OPERON_CLI_PACKAGE_NAME)}/dist-tags`;
 
 const UPDATE_CACHE_FILE_V1 = 'update-check-v1.json';
 const SUCCESS_CACHE_TTL_MS = 24 * 60 * 60 * 1_000;
@@ -190,9 +191,9 @@ function createNotice(
 		availableVersion,
 		channel,
 		updateCommand: channel === 'latest'
-			? 'npm install --global operon-cli'
-			: 'npm install --global operon-cli@beta',
-		releaseUrl: `https://www.npmjs.com/package/operon-cli/v/${availableVersion}`,
+			? `npm install --global ${OPERON_CLI_PACKAGE_NAME}`
+			: `npm install --global ${OPERON_CLI_PACKAGE_NAME}@beta`,
+		releaseUrl: `https://www.npmjs.com/package/${OPERON_CLI_PACKAGE_NAME}/v/${availableVersion}`,
 	};
 }
 

--- a/packages/operon-cli/type-consumer.test.mjs
+++ b/packages/operon-cli/type-consumer.test.mjs
@@ -44,7 +44,7 @@ try {
 		[npmExecPath, 'pack', '--json', '--pack-destination', packRoot],
 		{ cwd: packageRoot },
 	)[0];
-	assert.equal(packResult.name, 'operon-cli');
+	assert.equal(packResult.name, '@stratejya/operon-cli');
 
 	const sourceTypes = await snapshotDeclarationTree(path.join(packageRoot, 'types'));
 	const packedTypePaths = packResult.files
@@ -101,7 +101,7 @@ try {
 		{ cwd: consumerRoot },
 	);
 
-	const installedPackageRoot = path.join(consumerRoot, 'node_modules', 'operon-cli');
+	const installedPackageRoot = path.join(consumerRoot, 'node_modules', '@stratejya', 'operon-cli');
 	assert.deepEqual(
 		await snapshotDeclarationTree(path.join(installedPackageRoot, 'types')),
 		sourceTypes,
@@ -116,10 +116,10 @@ try {
 	const installedExampleSource = await readFile(installedExampleMain, 'utf8');
 	const packageImports = [
 		...installedExampleSource.matchAll(/from\s+['"]([^'"]+)['"]/gu),
-	].map(match => match[1]).filter(specifier => specifier.startsWith('operon-cli'));
+	].map(match => match[1]).filter(specifier => specifier.startsWith('@stratejya/operon-cli'));
 	assert.deepEqual(
 		packageImports,
-		['operon-cli/contracts/v1/developer-api'],
+		['@stratejya/operon-cli/contracts/v1/developer-api'],
 		'Example may import only the public type-only Developer API entrypoint.',
 	);
 	assert.doesNotMatch(installedExampleSource, /\b(import|require)\s*\(\s*['"]/u);
@@ -151,7 +151,7 @@ try {
 		'utf8',
 	));
 	assert.equal(installedExamplePackage.private, true);
-	assert.equal(installedExamplePackage.devDependencies['operon-cli'], '*');
+	assert.equal(installedExamplePackage.devDependencies['@stratejya/operon-cli'], '*');
 
 	await writeFile(path.join(consumerRoot, 'obsidian-stub.d.ts'), `
 declare module 'obsidian' {
@@ -197,17 +197,17 @@ import type {
 	StructuredErrorV1,
 	TaskGetRequestV1,
 	TaskGetResultV1,
-} from 'operon-cli/contracts/v1';
+} from '@stratejya/operon-cli/contracts/v1';
 import type {
 	DeveloperMutationPreviewInputV1,
 	OperonDeveloperApiAccessRequestV1,
 	OperonDeveloperApiAccessResultV1,
 	OperonDeveloperApiV1,
-} from 'operon-cli/contracts/v1/developer-api';
+} from '@stratejya/operon-cli/contracts/v1/developer-api';
 import type {
 	CliInvocationV1,
 	CliResultEnvelopeV1,
-} from 'operon-cli/contracts/v1/cli';
+} from '@stratejya/operon-cli/contracts/v1/cli';
 
 declare const health: RuntimeHealthV1;
 declare const request: TaskGetRequestV1;
@@ -216,9 +216,9 @@ declare const error: StructuredErrorV1;
 declare const accessRequest: OperonDeveloperApiAccessRequestV1;
 declare const accessResult: OperonDeveloperApiAccessResultV1;
 declare const api: OperonDeveloperApiV1;
-declare const target: import('operon-cli/contracts/v1').ExactMutationTargetV1;
-declare const inlineTarget: import('operon-cli/contracts/v1').ExactMutationTargetV1 & {
-	locator: import('operon-cli/contracts/v1').InlineTaskSourceLocatorV1;
+declare const target: import('@stratejya/operon-cli/contracts/v1').ExactMutationTargetV1;
+declare const inlineTarget: import('@stratejya/operon-cli/contracts/v1').ExactMutationTargetV1 & {
+	locator: import('@stratejya/operon-cli/contracts/v1').InlineTaskSourceLocatorV1;
 };
 const mutationPreviews: DeveloperMutationPreviewInputV1[] = [
 	{ capability: 'tasks.create.preview', mutationKind: 'task.create', spec: { operation: 'create', items: [] } },
@@ -265,57 +265,57 @@ void [
 	const negativeCases = [
 		{
 			name: 'developer-capability-kind-mismatch',
-			source: "import type { DeveloperMutationPreviewInputV1 } from 'operon-cli/contracts/v1/developer-api';\nconst value: DeveloperMutationPreviewInputV1 = { capability: 'tasks.delete.preview', mutationKind: 'task.update', spec: { operation: 'update-batch', items: [] } };\nvoid value;\n",
+			source: "import type { DeveloperMutationPreviewInputV1 } from '@stratejya/operon-cli/contracts/v1/developer-api';\nconst value: DeveloperMutationPreviewInputV1 = { capability: 'tasks.delete.preview', mutationKind: 'task.update', spec: { operation: 'update-batch', items: [] } };\nvoid value;\n",
 			marker: 'DeveloperMutationPreviewInputV1',
 		},
 		{
 			name: 'developer-target-required',
-			source: "import type { DeveloperMutationPreviewInputV1 } from 'operon-cli/contracts/v1/developer-api';\nconst value: DeveloperMutationPreviewInputV1 = { capability: 'tasks.update.preview', mutationKind: 'task.update', spec: { operation: 'update', changes: [] } };\nvoid value;\n",
+			source: "import type { DeveloperMutationPreviewInputV1 } from '@stratejya/operon-cli/contracts/v1/developer-api';\nconst value: DeveloperMutationPreviewInputV1 = { capability: 'tasks.update.preview', mutationKind: 'task.update', spec: { operation: 'update', changes: [] } };\nvoid value;\n",
 			marker: 'DeveloperMutationPreviewInputV1',
 		},
 		{
 			name: 'developer-spec-kind-mismatch',
-			source: "import type { DeveloperMutationPreviewInputV1 } from 'operon-cli/contracts/v1/developer-api';\ndeclare const target: import('operon-cli/contracts/v1').ExactMutationTargetV1;\nconst value: DeveloperMutationPreviewInputV1 = { capability: 'tasks.update.preview', mutationKind: 'task.update', target, spec: { operation: 'transition', targetStatusId: 'done' } };\nvoid value;\n",
+			source: "import type { DeveloperMutationPreviewInputV1 } from '@stratejya/operon-cli/contracts/v1/developer-api';\ndeclare const target: import('@stratejya/operon-cli/contracts/v1').ExactMutationTargetV1;\nconst value: DeveloperMutationPreviewInputV1 = { capability: 'tasks.update.preview', mutationKind: 'task.update', target, spec: { operation: 'transition', targetStatusId: 'done' } };\nvoid value;\n",
 			marker: 'DeveloperMutationPreviewInputV1',
 		},
 		{
 			name: 'developer-create-target-forbidden',
-			source: "import type { DeveloperMutationPreviewInputV1 } from 'operon-cli/contracts/v1/developer-api';\ndeclare const target: import('operon-cli/contracts/v1').ExactMutationTargetV1;\nconst value: DeveloperMutationPreviewInputV1 = { capability: 'tasks.create.preview', mutationKind: 'task.create', target, spec: { operation: 'create', items: [] } };\nvoid value;\n",
+			source: "import type { DeveloperMutationPreviewInputV1 } from '@stratejya/operon-cli/contracts/v1/developer-api';\ndeclare const target: import('@stratejya/operon-cli/contracts/v1').ExactMutationTargetV1;\nconst value: DeveloperMutationPreviewInputV1 = { capability: 'tasks.create.preview', mutationKind: 'task.create', target, spec: { operation: 'create', items: [] } };\nvoid value;\n",
 			marker: 'DeveloperMutationPreviewInputV1',
 		},
 		{
 			name: 'developer-batch-target-forbidden',
-			source: "import type { DeveloperMutationPreviewInputV1 } from 'operon-cli/contracts/v1/developer-api';\ndeclare const target: import('operon-cli/contracts/v1').ExactMutationTargetV1;\nconst value: DeveloperMutationPreviewInputV1 = { capability: 'tasks.update.preview', mutationKind: 'task.update', target, spec: { operation: 'update-batch', items: [] } };\nvoid value;\n",
+			source: "import type { DeveloperMutationPreviewInputV1 } from '@stratejya/operon-cli/contracts/v1/developer-api';\ndeclare const target: import('@stratejya/operon-cli/contracts/v1').ExactMutationTargetV1;\nconst value: DeveloperMutationPreviewInputV1 = { capability: 'tasks.update.preview', mutationKind: 'task.update', target, spec: { operation: 'update-batch', items: [] } };\nvoid value;\n",
 			marker: 'DeveloperMutationPreviewInputV1',
 		},
 		{
 			name: 'runtime-value-contract',
-			source: "import { CONTRACT_VERSION_V1 } from 'operon-cli/contracts/v1';\nvoid CONTRACT_VERSION_V1;\n",
+			source: "import { CONTRACT_VERSION_V1 } from '@stratejya/operon-cli/contracts/v1';\nvoid CONTRACT_VERSION_V1;\n",
 			marker: 'CONTRACT_VERSION_V1',
 		},
 		{
 			name: 'runtime-value-cli',
-			source: "import { CLI_EXIT_CODES_V1 } from 'operon-cli/contracts/v1/cli';\nvoid CLI_EXIT_CODES_V1;\n",
+			source: "import { CLI_EXIT_CODES_V1 } from '@stratejya/operon-cli/contracts/v1/cli';\nvoid CLI_EXIT_CODES_V1;\n",
 			marker: 'CLI_EXIT_CODES_V1',
 		},
 		{
 			name: 'removed-capture-contract',
-			source: "import type { CaptureAgentRequestV1 } from 'operon-cli/contracts/v1/capture-agent';\ndeclare const value: CaptureAgentRequestV1;\nvoid value;\n",
+			source: "import type { CaptureAgentRequestV1 } from '@stratejya/operon-cli/contracts/v1/capture-agent';\ndeclare const value: CaptureAgentRequestV1;\nvoid value;\n",
 			marker: 'capture-agent',
 		},
 		{
 			name: 'private-source',
-			source: "import type { JsonValue } from 'operon-cli/src/agent-runtime/contracts/v1/primitives';\ndeclare const value: JsonValue;\nvoid value;\n",
-			marker: 'operon-cli/src/agent-runtime/contracts/v1/primitives',
+			source: "import type { JsonValue } from '@stratejya/operon-cli/src/agent-runtime/contracts/v1/primitives';\ndeclare const value: JsonValue;\nvoid value;\n",
+			marker: '@stratejya/operon-cli/src/agent-runtime/contracts/v1/primitives',
 		},
 		{
 			name: 'private-declaration',
-			source: "import type { JsonValue } from 'operon-cli/types/src/agent-runtime/contracts/v1/primitives';\ndeclare const value: JsonValue;\nvoid value;\n",
-			marker: 'operon-cli/types/src/agent-runtime/contracts/v1/primitives',
+			source: "import type { JsonValue } from '@stratejya/operon-cli/types/src/agent-runtime/contracts/v1/primitives';\ndeclare const value: JsonValue;\nvoid value;\n",
+			marker: '@stratejya/operon-cli/types/src/agent-runtime/contracts/v1/primitives',
 		},
 		{
 			name: 'package-root',
-			source: "import type { RuntimeHealthV1 } from 'operon-cli';\ndeclare const value: RuntimeHealthV1;\nvoid value;\n",
+			source: "import type { RuntimeHealthV1 } from '@stratejya/operon-cli';\ndeclare const value: RuntimeHealthV1;\nvoid value;\n",
 			marker: 'operon-cli',
 		},
 	];
@@ -339,12 +339,12 @@ void [
 	}
 
 	for (const specifier of [
-		'operon-cli',
-		'operon-cli/contracts/v1',
-		'operon-cli/contracts/v1/developer-api',
-		'operon-cli/contracts/v1/cli',
-		'operon-cli/contracts/v1/capture-agent',
-		'operon-cli/src/agent-runtime/contracts/v1/primitives',
+		'@stratejya/operon-cli',
+		'@stratejya/operon-cli/contracts/v1',
+		'@stratejya/operon-cli/contracts/v1/developer-api',
+		'@stratejya/operon-cli/contracts/v1/cli',
+		'@stratejya/operon-cli/contracts/v1/capture-agent',
+		'@stratejya/operon-cli/src/agent-runtime/contracts/v1/primitives',
 	]) {
 		const importResult = run(
 			process.execPath,

--- a/scripts/agent-runtime/cli/check-release-routing.mjs
+++ b/scripts/agent-runtime/cli/check-release-routing.mjs
@@ -322,26 +322,26 @@ assert.doesNotMatch(
 	'Bare relative tarball paths can be misinterpreted as GitHub shorthand by npm.',
 );
 assert.match(publishWorkflow, /secrets\.NPM_TOKEN/u);
-assert.match(publishWorkflow, /bootstrap-token is only allowed while operon-cli is unpublished/u);
-assert.match(publishWorkflow, /npm view operon-cli@latest version/u);
+assert.match(publishWorkflow, /bootstrap-token is only allowed while @stratejya\/operon-cli is unpublished/u);
+assert.match(publishWorkflow, /npm view @stratejya\/operon-cli@latest version/u);
 assert.match(publishWorkflow, /d\.latest===process\.argv\[2\]/u);
 assert.match(publishWorkflow, /Capture the isolated beta channel before stable publication/u);
 assert.match(
 	publishWorkflow,
-	/if test "\$AUTHENTICATION_MODE" = "trusted-publisher"; then[\s\S]+DIST_TAGS="\$\(npm view operon-cli dist-tags/u,
+	/if test "\$AUTHENTICATION_MODE" = "trusted-publisher"; then[\s\S]+DIST_TAGS="\$\(npm view @stratejya\/operon-cli dist-tags/u,
 );
 assert.match(publishWorkflow, /npm dist-tags could not be verified before bootstrap publication/u);
 assert.match(publishWorkflow, /beta===process\.argv\[2\]/u);
-assert.match(publishWorkflow, /npm pack operon-cli@latest/u);
+assert.match(publishWorkflow, /npm pack @stratejya\/operon-cli@latest/u);
 assert.match(publishWorkflow, /verify-published-release\.mjs/u);
 assert.match(publishWorkflow, /npm audit signatures --registry https:\/\/registry\.npmjs\.org\//u);
 assert.match(publishWorkflow, /id:\s+registry_version/u);
 assert.match(publishWorkflow, /steps\.registry_version\.outputs\.version/u);
 assert.doesNotMatch(publishWorkflow, /env\.EXPECTED_PACKAGE_VERSION/u);
 for (const commandPattern of [
-	/npm view operon-cli version --json --registry https:\/\/registry\.npmjs\.org\//u,
-	/npm view operon-cli@latest version --registry https:\/\/registry\.npmjs\.org\//u,
-	/npm view operon-cli dist-tags --json --registry https:\/\/registry\.npmjs\.org\//u,
+	/npm view @stratejya\/operon-cli version --json --registry https:\/\/registry\.npmjs\.org\//u,
+	/npm view @stratejya\/operon-cli@latest version --registry https:\/\/registry\.npmjs\.org\//u,
+	/npm view @stratejya\/operon-cli dist-tags --json --registry https:\/\/registry\.npmjs\.org\//u,
 	/npm publish \.\/candidate\/\*\.tgz[\s\S]+--registry https:\/\/registry\.npmjs\.org\//u,
 ]) {
 	assert.match(publishWorkflow, commandPattern);
@@ -628,7 +628,7 @@ try {
 	const registryRoot = path.join(registryRoundTripRoot, 'registry');
 	await mkdir(candidateRoot);
 	await mkdir(registryRoot);
-	const tarballName = 'operon-cli-9.8.7.tgz';
+	const tarballName = 'stratejya-operon-cli-9.8.7.tgz';
 	const candidateTarball = path.join(candidateRoot, tarballName);
 	const registryTarball = path.join(registryRoot, tarballName);
 	await writeFile(candidateTarball, 'accepted-registry-tarball\n', 'utf8');
@@ -640,7 +640,7 @@ try {
 		path.join(candidateRoot, 'candidate-evidence.json'),
 		`${JSON.stringify({
 			kind: 'operon-cli-release-candidate',
-			package: 'operon-cli@9.8.7',
+			package: '@stratejya/operon-cli@9.8.7',
 			tarball: tarballName,
 			sha256: candidateSha256,
 		}, null, 2)}\n`,

--- a/scripts/agent-runtime/cli/check-release-tag.mjs
+++ b/scripts/agent-runtime/cli/check-release-tag.mjs
@@ -4,14 +4,15 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { assertOperonCliPackageDocumentV1 } from '../../../packages/operon-cli/package-identity.mjs';
+
 const pluginRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
-const packageDocument = JSON.parse(
+const packageDocument = assertOperonCliPackageDocumentV1(JSON.parse(
 	await readFile(path.join(pluginRoot, 'packages', 'operon-cli', 'package.json'), 'utf8'),
-);
+));
 const pluginManifest = JSON.parse(
 	await readFile(path.join(pluginRoot, 'manifest.json'), 'utf8'),
 );
-assert.equal(packageDocument.name, 'operon-cli');
 assert.match(packageDocument.version, /^[0-9]+\.[0-9]+\.[0-9]+$/u);
 assert.equal(pluginManifest.id, 'operon');
 assert.match(pluginManifest.version, /^[0-9]+\.[0-9]+\.[0-9]+$/u);

--- a/scripts/agent-runtime/cli/cli.test.ts
+++ b/scripts/agent-runtime/cli/cli.test.ts
@@ -61,6 +61,7 @@ import {
 } from '../../../packages/operon-cli/src/interactive-shell';
 import {
 	checkForCliUpdateV1,
+	OPERON_CLI_DIST_TAGS_URL,
 	selectCliUpdateNoticeV1,
 } from '../../../packages/operon-cli/src/update-check';
 import {
@@ -949,8 +950,8 @@ async function testInteractiveShellState(): Promise<void> {
 				currentVersion: '0.1.0-beta.23',
 				availableVersion: '0.1.0',
 				channel: 'latest',
-				updateCommand: 'npm install --global operon-cli',
-				releaseUrl: 'https://www.npmjs.com/package/operon-cli/v/0.1.0',
+				updateCommand: 'npm install --global @stratejya/operon-cli',
+				releaseUrl: 'https://www.npmjs.com/package/@stratejya/operon-cli/v/0.1.0',
 			},
 			runCommand: async tokens => {
 				calls.push([...tokens]);
@@ -986,7 +987,7 @@ async function testInteractiveShellState(): Promise<void> {
 		]);
 		assert.ok(stdout.join('').includes('Operon CLI 0.1.0-test'));
 		assert.ok(stdout.join('').includes('✨ Update available! 0.1.0-beta.23 → 0.1.0'));
-		assert.ok(stdout.join('').includes('npm install --global operon-cli'));
+		assert.ok(stdout.join('').includes('npm install --global @stratejya/operon-cli'));
 		assert.ok(!stdout.join('').includes('operon-cli@beta'));
 		assert.ok(stdout.join('').includes('"command":"version.--json"'));
 		assert.ok(stderr.join('').includes('Error: Unknown command.'));
@@ -1003,19 +1004,23 @@ async function testInteractiveShellState(): Promise<void> {
 }
 
 async function testCliUpdateCheck(): Promise<void> {
+	assert.equal(
+		OPERON_CLI_DIST_TAGS_URL,
+		'https://registry.npmjs.org/-/package/%40stratejya%2Foperon-cli/dist-tags',
+	);
 	const stable = selectCliUpdateNoticeV1('0.1.0-beta.23', {
 		latest: '0.1.0',
 		beta: '0.1.0-beta.24',
 	});
 	assert.equal(stable?.channel, 'latest');
 	assert.equal(stable?.availableVersion, '0.1.0');
-	assert.equal(stable?.updateCommand, 'npm install --global operon-cli');
+	assert.equal(stable?.updateCommand, 'npm install --global @stratejya/operon-cli');
 
 	const beta = selectCliUpdateNoticeV1('0.1.0-beta.23', {
 		beta: '0.1.0-beta.24',
 	});
 	assert.equal(beta?.channel, 'beta');
-	assert.equal(beta?.updateCommand, 'npm install --global operon-cli@beta');
+	assert.equal(beta?.updateCommand, 'npm install --global @stratejya/operon-cli@beta');
 
 	assert.equal(selectCliUpdateNoticeV1('0.1.0', {
 		latest: '0.1.0',

--- a/scripts/agent-runtime/cli/hosted-portability.test.mjs
+++ b/scripts/agent-runtime/cli/hosted-portability.test.mjs
@@ -64,14 +64,14 @@ async function createFixture() {
 	const cellRoot = path.join(root, 'cells');
 	await mkdir(candidateRoot);
 	await mkdir(cellRoot);
-	const tarball = 'operon-cli-9.8.7.tgz';
+	const tarball = 'stratejya-operon-cli-9.8.7.tgz';
 	const tarballBytes = Buffer.from('immutable hosted candidate\n');
 	await writeFile(path.join(candidateRoot, tarball), tarballBytes);
 	const digest = value => createHash('sha256').update(value).digest('hex');
 	const evidence = {
 		evidenceVersion: 1,
 		kind: 'operon-cli-release-candidate',
-		package: 'operon-cli@9.8.7',
+		package: '@stratejya/operon-cli@9.8.7',
 		tarball,
 		sha256: digest(tarballBytes),
 		cliManifestSha256: '1'.repeat(64),

--- a/scripts/agent-runtime/cli/interactive-shell-pty.test.py
+++ b/scripts/agent-runtime/cli/interactive-shell-pty.test.py
@@ -99,7 +99,7 @@ def main() -> int:
             f"Update available! {expected_version} ".encode(),
             0,
         )
-        cursor = read_until(fd, transcript, b"npm install --global operon-cli", cursor)
+        cursor = read_until(fd, transcript, b"npm install --global @stratejya/operon-cli", cursor)
         cursor = read_until(fd, transcript, f"Operon CLI {expected_version}".encode(), cursor)
         cursor = read_until(fd, transcript, prompt, cursor)
 

--- a/scripts/agent-runtime/cli/live-acceptance-platform.mjs
+++ b/scripts/agent-runtime/cli/live-acceptance-platform.mjs
@@ -11,6 +11,10 @@ import {
 import os from 'node:os';
 import path from 'node:path';
 
+import {
+	OPERON_CLI_NPM_PACKAGE_PATH,
+} from '../../../packages/operon-cli/package-identity.mjs';
+
 const ACCEPTANCE_FIXTURE_MARKER_V1 = '.operon-developer-api-native-fixture.json';
 const ACCEPTANCE_FIXTURE_KIND_V1 = 'operon-developer-api-native-fixture-vault';
 const ACCEPTED_OBSIDIAN_VERSIONS_V1 = new Set(['1.12.2', '1.12.7']);
@@ -282,7 +286,7 @@ export function installedCliArtifactV1(prefixRoot, env) {
 		['root', '--global', '--prefix', prefixRoot],
 		{ env, encoding: 'utf8' },
 	).trim();
-	return path.join(globalRoot, 'operon-cli', 'dist', 'operon.mjs');
+	return path.join(globalRoot, ...OPERON_CLI_NPM_PACKAGE_PATH, 'dist', 'operon.mjs');
 }
 
 export function runCliJsonV1(executable, args, env, input) {

--- a/scripts/agent-runtime/cli/materialize-frozen-candidate.mjs
+++ b/scripts/agent-runtime/cli/materialize-frozen-candidate.mjs
@@ -8,6 +8,10 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { readAcceptedPublicV1Freeze } from './release-contract.mjs';
+import {
+	assertOperonCliPackageDocumentV1,
+	operonCliTarballFileNameV1,
+} from '../../../packages/operon-cli/package-identity.mjs';
 
 export async function materializeFrozenCandidate({ repositoryRoot, outputRoot }) {
 	const root = path.resolve(repositoryRoot);
@@ -18,17 +22,17 @@ export async function materializeFrozenCandidate({ repositoryRoot, outputRoot })
 		'Candidate output directory must be the canonical release directory.',
 	);
 	const { freeze } = await readAcceptedPublicV1Freeze(root);
-	const packageDocument = JSON.parse(await readFile(
+	const packageDocument = assertOperonCliPackageDocumentV1(JSON.parse(await readFile(
 		path.join(root, 'packages/operon-cli/package.json'),
 		'utf8',
-	));
+	)));
 	assert.equal(freeze.state, 'accepted', 'Public V1 freeze must be accepted.');
 	assert.equal(
 		freeze.cli?.packageVersion,
 		packageDocument.version,
 		'Frozen CLI version does not match package metadata.',
 	);
-	const fileName = `operon-cli-${packageDocument.version}.tgz`;
+	const fileName = operonCliTarballFileNameV1(packageDocument.version);
 	const relativeSource = `packages/operon-cli/freeze/${fileName}`;
 	assert.equal(
 		freeze.cli?.tarball?.path,

--- a/scripts/agent-runtime/cli/materialize-frozen-candidate.test.mjs
+++ b/scripts/agent-runtime/cli/materialize-frozen-candidate.test.mjs
@@ -12,7 +12,7 @@ test('materializes the accepted canonical tarball without rebuilding it', async 
 	try {
 		const output = path.join(fixture.root, 'packages/operon-cli/release');
 		const result = await materializeFrozenCandidate({ repositoryRoot: fixture.root, outputRoot: output });
-		assert.equal(result.fileName, 'operon-cli-1.0.6.tgz');
+		assert.equal(result.fileName, 'stratejya-operon-cli-1.0.7.tgz');
 		assert.deepEqual(await readFile(result.path), fixture.bytes);
 		assert.equal(result.sha256, digest(fixture.bytes));
 	} finally {
@@ -109,12 +109,12 @@ test('rejects symlinked source and output paths', {
 async function createFixture(mutate) {
 	const root = await mkdtemp(path.join(tmpdir(), 'operon-frozen-candidate-'));
 	const bytes = Buffer.from('immutable candidate tarball\n');
-	const source = path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.6.tgz');
+	const source = path.join(root, 'packages/operon-cli/freeze/stratejya-operon-cli-1.0.7.tgz');
 	await mkdir(path.dirname(source), { recursive: true });
 	await mkdir(path.join(root, 'contracts/agent-runtime'), { recursive: true });
 	await writeFile(path.join(root, 'packages/operon-cli/package.json'), `${JSON.stringify({
-		name: 'operon-cli',
-		version: '1.0.6',
+		name: '@stratejya/operon-cli',
+		version: '1.0.7',
 	}, null, 2)}\n`, 'utf8');
 	await writeFile(source, bytes);
 	const freeze = {
@@ -128,9 +128,9 @@ async function createFixture(mutate) {
 		cli: {
 			contractVersion: 1,
 			contractDigest: '2'.repeat(64),
-			packageVersion: '1.0.6',
+			packageVersion: '1.0.7',
 			tarball: {
-				path: 'packages/operon-cli/freeze/operon-cli-1.0.6.tgz',
+				path: 'packages/operon-cli/freeze/stratejya-operon-cli-1.0.7.tgz',
 				bytes: bytes.length,
 				sha256: digest(bytes),
 			},

--- a/scripts/agent-runtime/cli/meeting-agent-fixture.mjs
+++ b/scripts/agent-runtime/cli/meeting-agent-fixture.mjs
@@ -20,7 +20,7 @@ const env = {
 
 const manifest = run(['manifest', '--json']);
 assert.equal(manifest.ok, true);
-assert.equal(manifest.result.package.name, 'operon-cli');
+assert.equal(manifest.result.package.name, '@stratejya/operon-cli');
 const createContract = manifest.result.convenienceContracts['task.create'];
 const updateContract = manifest.result.convenienceContracts['task.update'];
 assert.equal(createContract.mutationKind, 'task.create');

--- a/scripts/agent-runtime/cli/native-acceptance.test.mjs
+++ b/scripts/agent-runtime/cli/native-acceptance.test.mjs
@@ -28,10 +28,10 @@ const evidenceSchema = JSON.parse(await readFile(
 	'utf8',
 ));
 const validateEvidence = new Ajv2020({ strict: false }).compile(evidenceSchema);
-const FIXTURE_CLI_VERSION = '1.0.6';
+const FIXTURE_CLI_VERSION = '1.0.7';
 const FIXTURE_CLI_TAG = `cli-v${FIXTURE_CLI_VERSION}`;
-const FIXTURE_CLI_PACKAGE = `operon-cli@${FIXTURE_CLI_VERSION}`;
-const FIXTURE_CLI_TARBALL = `operon-cli-${FIXTURE_CLI_VERSION}.tgz`;
+const FIXTURE_CLI_PACKAGE = `@stratejya/operon-cli@${FIXTURE_CLI_VERSION}`;
+const FIXTURE_CLI_TARBALL = `stratejya-operon-cli-${FIXTURE_CLI_VERSION}.tgz`;
 const FIXTURE_PLUGIN_VERSION = '3.0.1';
 
 test('36 digest-bound native cells produce one promotion-eligible aggregate', async () => {

--- a/scripts/agent-runtime/cli/package-version.mjs
+++ b/scripts/agent-runtime/cli/package-version.mjs
@@ -1,13 +1,14 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import {
+	assertOperonCliPackageDocumentV1,
+} from '../../../packages/operon-cli/package-identity.mjs';
+
 export async function readOperonCliPackageVersion(pluginRoot) {
-	const packageDocument = JSON.parse(await readFile(
+	const packageDocument = assertOperonCliPackageDocumentV1(JSON.parse(await readFile(
 		path.join(pluginRoot, 'packages', 'operon-cli', 'package.json'),
 		'utf8',
-	));
-	if (packageDocument.name !== 'operon-cli' || typeof packageDocument.version !== 'string') {
-		throw new Error('OPERON_CLI_TEST_PACKAGE_METADATA_INVALID');
-	}
+	)), 'OPERON_CLI_TEST_PACKAGE_METADATA_INVALID');
 	return packageDocument.version;
 }

--- a/scripts/agent-runtime/cli/public-docs.test.mjs
+++ b/scripts/agent-runtime/cli/public-docs.test.mjs
@@ -315,7 +315,7 @@ test('Developer API docs preserve projected discovery and typed result distincti
 		sourceDoc('130'),
 		sourceDoc('131'),
 	]);
-	assert.match(overview, /operon-cli\/contracts\/v1\/developer-api/u);
+	assert.match(overview, /@stratejya\/operon-cli\/contracts\/v1\/developer-api/u);
 	assert.match(overview, /"system\.health"/u);
 	assert.match(overview, /"system\.capabilities"/u);
 	assert.match(overview, /projected/iu);
@@ -358,7 +358,7 @@ test('README and discoverable contracts expose the documented public boundary', 
 	const manifest = JSON.parse(manifestSource);
 	const packageDocument = JSON.parse(packageSource);
 
-	assert.match(readme, /npm install --global operon-cli/u);
+	assert.match(readme, /npm install --global @stratejya\/operon-cli/u);
 	assert.match(readme, /Node(?:\.js)? 22, 24, (?:and|or) 26/iu);
 	assert.match(readme, /macOS/u);
 	assert.match(readme, /Linux/u);
@@ -366,7 +366,7 @@ test('README and discoverable contracts expose the documented public boundary', 
 	assert.match(readme, /WSL/u);
 	assert.match(readme, /public beta/iu);
 	assert.match(readme, /recoveryRef/u);
-	assert.match(readme, /operon-cli\/contracts\/v1\/developer-api/u);
+	assert.match(readme, /@stratejya\/operon-cli\/contracts\/v1\/developer-api/u);
 	assert.doesNotMatch(readme, /^## \d+\.\d+/mu, 'README must not copy the package version.');
 	assert.equal(packageDocument.engines.node, '^22.0.0 || ^24.0.0 || ^26.0.0');
 	assert.deepEqual(manifest.platforms, {

--- a/scripts/agent-runtime/cli/run-package-tests.mjs
+++ b/scripts/agent-runtime/cli/run-package-tests.mjs
@@ -21,6 +21,11 @@ import {
 	classifyOperonCliExecutableSize,
 	requiresOperonCliBundleContributorReview,
 } from '../../../packages/operon-cli/size-policy.mjs';
+import {
+	assertOperonCliPackageDocumentV1,
+	OPERON_CLI_NPM_PACKAGE_PATH,
+	operonCliTarballFileNameV1,
+} from '../../../packages/operon-cli/package-identity.mjs';
 import { loadCandidateBindingV1 } from './native-acceptance-lib.mjs';
 
 const pluginRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
@@ -59,13 +64,14 @@ try {
 		[],
 		'Type declaration build must clean the staging directories created by this invocation.',
 	);
-	const packageDocument = JSON.parse(await readFile(path.join(packageRoot, 'package.json'), 'utf8'));
+	const packageDocument = assertOperonCliPackageDocumentV1(JSON.parse(
+		await readFile(path.join(packageRoot, 'package.json'), 'utf8'),
+	));
 	const typedCreateGolden = JSON.parse(await readFile(
 		path.join(pluginRoot, 'scripts', 'agent-runtime', 'fixtures', 'typed-create-golden.json'),
 		'utf8',
 	));
-	assert.equal(packageDocument.name, 'operon-cli');
-		assert.match(packageDocument.version, /^\d+\.\d+\.\d+$/u);
+	assert.match(packageDocument.version, /^\d+\.\d+\.\d+$/u);
 	assert.equal(packageDocument.license, 'GPL-3.0-or-later');
 	assert.equal(packageDocument.private, undefined);
 	assert.equal(packageDocument.engines.node, '^22.0.0 || ^24.0.0 || ^26.0.0');
@@ -634,6 +640,8 @@ try {
 		{ cwd: packageRoot, env, encoding: 'utf8' },
 	);
 	const packResult = JSON.parse(packJson)[0];
+	assert.equal(packResult.name, packageDocument.name);
+	assert.equal(packResult.filename, operonCliTarballFileNameV1(packageDocument.version));
 	assert.ok(packResult.size < 1_000_000);
 	const paths = packResult.files.map(item => item.path);
 	assert.ok(paths.includes('dist/operon.mjs'));
@@ -711,7 +719,7 @@ try {
 	const fixtureRoot = path.join(tempRoot, 'prior-version');
 	await mkdir(path.join(fixtureRoot, 'dist'), { recursive: true });
 	await writeFile(path.join(fixtureRoot, 'package.json'), JSON.stringify({
-		name: 'operon-cli',
+		name: packageDocument.name,
 		version: '0.1.0-beta.0',
 		type: 'module',
 		bin: { operon: './dist/operon.mjs' },
@@ -740,7 +748,7 @@ try {
 		['root', '--global', '--prefix', prefixRoot],
 		{ env, encoding: 'utf8' },
 	).trim();
-	const installedArtifactRoot = path.join(installedGlobalRoot, 'operon-cli');
+	const installedArtifactRoot = path.join(installedGlobalRoot, ...OPERON_CLI_NPM_PACKAGE_PATH);
 	const installedManifestFile = JSON.parse(await readFile(
 		path.join(installedArtifactRoot, 'cli-manifest-v1.json'),
 		'utf8',
@@ -1024,7 +1032,7 @@ try {
 	assert.equal(unknownJsonError.code, 'invalid-request');
 	assert.equal(unknownJsonError.details.reasonCode, 'unknown-command');
 	const installedManifest = runJson(executable, ['manifest', '--json'], env);
-	assert.equal(installedManifest.result.package.name, 'operon-cli');
+	assert.equal(installedManifest.result.package.name, packageDocument.name);
 	assert.equal(installedManifest.result.package.version, packageDocument.version);
 	assert.equal(
 		installedManifest.result.convenienceContracts['task.update'].directRelationshipVersion,
@@ -1134,7 +1142,7 @@ try {
 		durableStateBeforeLifecycle,
 		'Re-upgrading to the beta candidate must preserve durable CLI state.',
 	);
-	runNpmSync(['uninstall', '--global', '--prefix', prefixRoot, 'operon-cli'], {
+	runNpmSync(['uninstall', '--global', '--prefix', prefixRoot, packageDocument.name], {
 		env,
 		stdio: 'inherit',
 	});

--- a/scripts/agent-runtime/cli/verify-hosted-candidate-install.mjs
+++ b/scripts/agent-runtime/cli/verify-hosted-candidate-install.mjs
@@ -9,6 +9,10 @@ import path from 'node:path';
 
 import { execNpmV1 } from './live-acceptance-platform.mjs';
 import { loadCandidateBindingV1 } from './native-acceptance-lib.mjs';
+import {
+	OPERON_CLI_NPM_PACKAGE_NAME,
+	OPERON_CLI_NPM_PACKAGE_PATH,
+} from '../../../packages/operon-cli/package-identity.mjs';
 
 const [candidateRootArgument] = process.argv.slice(2);
 assert.ok(candidateRootArgument, 'Candidate directory is required.');
@@ -34,7 +38,7 @@ try {
 		['root', '--global', '--prefix', prefix],
 		{ env, encoding: 'utf8' },
 	).trim();
-	const installedRoot = path.join(globalRoot, 'operon-cli');
+	const installedRoot = path.join(globalRoot, ...OPERON_CLI_NPM_PACKAGE_PATH);
 	const manifestBytes = await readFile(path.join(installedRoot, 'cli-manifest-v1.json'));
 	assert.equal(
 		createHash('sha256').update(manifestBytes).digest('hex'),
@@ -60,7 +64,7 @@ try {
 		);
 	}
 	execNpmV1(
-		['uninstall', '--global', '--prefix', prefix, 'operon-cli'],
+		['uninstall', '--global', '--prefix', prefix, OPERON_CLI_NPM_PACKAGE_NAME],
 		{ env, stdio: 'inherit' },
 	);
 	process.stdout.write(`${JSON.stringify({

--- a/scripts/agent-runtime/cli/verify-published-beta.mjs
+++ b/scripts/agent-runtime/cli/verify-published-beta.mjs
@@ -5,6 +5,8 @@ import { createHash } from 'node:crypto';
 import { readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
 
+import { OPERON_CLI_NPM_PACKAGE_NAME } from '../../../packages/operon-cli/package-identity.mjs';
+
 const [candidateRootArgument, registryRootArgument] = process.argv.slice(2);
 assert.ok(candidateRootArgument, 'Candidate directory is required.');
 assert.ok(registryRootArgument, 'Registry download directory is required.');
@@ -34,7 +36,7 @@ const registry = await readSingleTarball(registryRoot, 'Registry download');
 assert.equal(evidence.kind, 'operon-cli-release-candidate');
 assert.equal(evidence.tarball, candidate.name);
 assert.equal(evidence.sha256, candidate.sha256);
-assert.match(evidence.package, /^operon-cli@[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/u);
+assert.match(evidence.package, /^@stratejya\/operon-cli@[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/u);
 assert.equal(registry.name, candidate.name);
 assert.equal(
 	registry.sha256,
@@ -48,7 +50,7 @@ assert.deepEqual(
 );
 
 if (process.env.EXPECTED_VERSION) {
-	assert.equal(evidence.package, `operon-cli@${process.env.EXPECTED_VERSION}`);
+	assert.equal(evidence.package, `${OPERON_CLI_NPM_PACKAGE_NAME}@${process.env.EXPECTED_VERSION}`);
 }
 if (process.env.EXPECTED_SHA256) {
 	assert.equal(registry.sha256, process.env.EXPECTED_SHA256);

--- a/scripts/agent-runtime/cli/verify-published-release.mjs
+++ b/scripts/agent-runtime/cli/verify-published-release.mjs
@@ -5,6 +5,8 @@ import { createHash } from 'node:crypto';
 import { readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
 
+import { OPERON_CLI_NPM_PACKAGE_NAME } from '../../../packages/operon-cli/package-identity.mjs';
+
 const [candidateRootArgument, registryRootArgument] = process.argv.slice(2);
 assert.ok(candidateRootArgument, 'Candidate directory is required.');
 assert.ok(registryRootArgument, 'Registry download directory is required.');
@@ -34,7 +36,7 @@ const registry = await readSingleTarball(registryRoot, 'Registry download');
 assert.equal(evidence.kind, 'operon-cli-release-candidate');
 assert.equal(evidence.tarball, candidate.name);
 assert.equal(evidence.sha256, candidate.sha256);
-assert.match(evidence.package, /^operon-cli@[0-9]+\.[0-9]+\.[0-9]+$/u);
+assert.match(evidence.package, /^@stratejya\/operon-cli@[0-9]+\.[0-9]+\.[0-9]+$/u);
 assert.equal(registry.name, candidate.name);
 assert.equal(
 	registry.sha256,
@@ -48,7 +50,7 @@ assert.deepEqual(
 );
 
 if (process.env.EXPECTED_VERSION) {
-	assert.equal(evidence.package, `operon-cli@${process.env.EXPECTED_VERSION}`);
+	assert.equal(evidence.package, `${OPERON_CLI_NPM_PACKAGE_NAME}@${process.env.EXPECTED_VERSION}`);
 }
 if (process.env.EXPECTED_SHA256) {
 	assert.equal(registry.sha256, process.env.EXPECTED_SHA256);

--- a/scripts/agent-runtime/cli/write-native-candidate-evidence.mjs
+++ b/scripts/agent-runtime/cli/write-native-candidate-evidence.mjs
@@ -11,6 +11,10 @@ import {
 	assertOperonPublicRuntimeV1,
 	readAcceptedPublicV1Freeze,
 } from './release-contract.mjs';
+import {
+	assertOperonCliPackageDocumentV1,
+	operonCliTarballFileNameV1,
+} from '../../../packages/operon-cli/package-identity.mjs';
 
 const [candidateRootArgument, pluginArtifactRootArgument, outputArgument] = process.argv.slice(2);
 assert.ok(candidateRootArgument, 'Candidate directory is required.');
@@ -24,16 +28,15 @@ const tarballs = (await readdir(candidateRoot)).filter(name => name.endsWith('.t
 assert.equal(tarballs.length, 1, 'Native candidate directory must contain exactly one tarball.');
 const tarballPath = path.join(candidateRoot, tarballs[0]);
 const tarballBytes = await readFile(tarballPath);
-const packageDocument = JSON.parse(await readFile(
+const packageDocument = assertOperonCliPackageDocumentV1(JSON.parse(await readFile(
 	path.join(repositoryRoot, 'packages/operon-cli/package.json'),
 	'utf8',
-));
-assert.match(packageDocument.version, /^[0-9]+\.[0-9]+\.[0-9]+$/u);
+)));
 const cliManifestBytes = await readFile(
 	path.join(repositoryRoot, 'packages/operon-cli/cli-manifest-v1.json'),
 );
 const cliManifest = JSON.parse(cliManifestBytes.toString('utf8'));
-assert.equal(tarballs[0], `${packageDocument.name}-${packageDocument.version}.tgz`);
+assert.equal(tarballs[0], operonCliTarballFileNameV1(packageDocument.version));
 assert.equal(cliManifest.package.name, packageDocument.name);
 assert.equal(cliManifest.package.version, packageDocument.version);
 assert.match(cliManifest.contractDigest, /^[a-f0-9]{64}$/u);

--- a/scripts/agent-runtime/cli/write-release-candidate-evidence.mjs
+++ b/scripts/agent-runtime/cli/write-release-candidate-evidence.mjs
@@ -7,6 +7,10 @@ import { readFile, readdir, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { readAcceptedPublicV1Freeze } from './release-contract.mjs';
+import {
+	assertOperonCliPackageDocumentV1,
+	operonCliTarballFileNameV1,
+} from '../../../packages/operon-cli/package-identity.mjs';
 
 const [releaseRootArgument, outputArgument, pluginEvidenceArgument] = process.argv.slice(2);
 assert.ok(releaseRootArgument, 'Release directory is required.');
@@ -21,10 +25,9 @@ assert.equal(tarballs.length, 1, 'Candidate directory must contain exactly one t
 
 const tarballPath = path.join(releaseRoot, tarballs[0]);
 const bytes = await readFile(tarballPath);
-const packageDocument = JSON.parse(
+const packageDocument = assertOperonCliPackageDocumentV1(JSON.parse(
 	await readFile(path.resolve(releaseRoot, '../package.json'), 'utf8'),
-);
-assert.match(packageDocument.version, /^[0-9]+\.[0-9]+\.[0-9]+$/u);
+));
 const manifestBytes = await readFile(path.resolve(releaseRoot, '../cli-manifest-v1.json'));
 const manifest = JSON.parse(manifestBytes.toString('utf8'));
 const pluginReleaseEvidence = pluginEvidenceArgument
@@ -64,7 +67,7 @@ if (pluginReleaseEvidence) {
 }
 assert.equal(manifest.package.name, packageDocument.name);
 assert.equal(manifest.package.version, packageDocument.version);
-assert.equal(tarballs[0], `${packageDocument.name}-${packageDocument.version}.tgz`);
+assert.equal(tarballs[0], operonCliTarballFileNameV1(packageDocument.version));
 const sourceCommit = execFileSync('git', ['rev-parse', 'HEAD'], {
 	cwd: pluginRoot,
 	encoding: 'utf8',

--- a/scripts/agent-runtime/contracts/public-v1-freeze.mjs
+++ b/scripts/agent-runtime/contracts/public-v1-freeze.mjs
@@ -17,6 +17,10 @@ import { fileURLToPath } from 'node:url';
 import Ajv2020 from 'ajv/dist/2020.js';
 
 import { evaluateReleaseAuditPolicy } from '../../release/audit-policy.mjs';
+import {
+	assertOperonCliPackageDocumentV1,
+	operonCliTarballFileNameV1,
+} from '../../../packages/operon-cli/package-identity.mjs';
 
 const scriptPath = fileURLToPath(import.meta.url);
 const defaultPluginRoot = path.resolve(path.dirname(scriptPath), '../../..');
@@ -56,7 +60,7 @@ export async function buildPublicV1FreezeIndex(options = {}) {
 	assertCliPackageIdentity(packageDocument);
 	const tarball = await fileRecord(
 		root,
-		`packages/operon-cli/freeze/operon-cli-${packageDocument.version}.tgz`,
+		`packages/operon-cli/freeze/${operonCliTarballFileNameV1(packageDocument.version)}`,
 	);
 	const executable = await fileRecord(root, 'packages/operon-cli/dist/operon.mjs');
 	const license = await fileRecord(root, 'packages/operon-cli/LICENSE');
@@ -274,7 +278,7 @@ export async function writeCanonicalCliTarball(root = defaultPluginRoot) {
 		if (!Array.isArray(packed) || packed.length !== 1) {
 			throw new Error('OPERON_PUBLIC_V1_FREEZE_PACK_RESULT_INVALID');
 		}
-		const expectedFilename = `operon-cli-${packageDocument.version}.tgz`;
+		const expectedFilename = operonCliTarballFileNameV1(packageDocument.version);
 		if (packed[0]?.filename !== expectedFilename) {
 			throw new Error('OPERON_PUBLIC_V1_FREEZE_PACK_FILENAME_INVALID');
 		}
@@ -481,7 +485,7 @@ async function buildAuditArtifactMetafiles(root) {
 
 function assertAcceptedFreeze(index) {
 	if (
-		index.cli.packageVersion !== '1.0.6'
+		index.cli.packageVersion !== '1.0.7'
 		|| index.plugin.version !== '3.0.1'
 		|| index.audit.validation.status !== 'passed'
 		|| index.audit.validation.result?.status !== 'accepted-clean'
@@ -689,13 +693,10 @@ async function verifyDocumentationManifest(root, manifest) {
 }
 
 function assertCliPackageIdentity(packageDocument) {
-	if (
-		packageDocument?.name !== 'operon-cli'
-		|| typeof packageDocument.version !== 'string'
-		|| !/^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$/u.test(packageDocument.version)
-	) {
-		throw new Error('OPERON_PUBLIC_V1_FREEZE_PACKAGE_IDENTITY_INVALID');
-	}
+	assertOperonCliPackageDocumentV1(
+		packageDocument,
+		'OPERON_PUBLIC_V1_FREEZE_PACKAGE_IDENTITY_INVALID',
+	);
 }
 
 function safeRelativePath(value) {

--- a/scripts/agent-runtime/contracts/public-v1-freeze.test.mjs
+++ b/scripts/agent-runtime/contracts/public-v1-freeze.test.mjs
@@ -161,7 +161,7 @@ test('freeze writer binds exact local inputs and check rejects byte drift', asyn
 		assert.equal(written.plugin.artifactStatus, 'local-rebuilt-artifact');
 		assert.equal(
 			written.cli.tarball.path,
-			'packages/operon-cli/freeze/operon-cli-0.1.0-beta.1.tgz',
+			'packages/operon-cli/freeze/stratejya-operon-cli-0.1.0-beta.1.tgz',
 		);
 		assert.equal(written.cli.executable.path, 'packages/operon-cli/dist/operon.mjs');
 		assert.equal(written.cli.license.path, 'packages/operon-cli/LICENSE');
@@ -199,11 +199,11 @@ test('accepted freeze requires final versions, passed audit and explicit maintai
 			/OPERON_PUBLIC_V1_FREEZE_ACCEPTANCE_PREREQUISITES_UNMET/u,
 		);
 		await writeJson(path.join(root, 'packages/operon-cli/package.json'), {
-			name: 'operon-cli',
-			version: '1.0.6',
+			name: '@stratejya/operon-cli',
+			version: '1.0.7',
 		});
 		await writeFile(
-			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.6.tgz'),
+			path.join(root, 'packages/operon-cli/freeze/stratejya-operon-cli-1.0.7.tgz'),
 			'stable tarball\n',
 		);
 		await writeJson(path.join(root, 'manifest.json'), {
@@ -232,11 +232,11 @@ test('ordinary write clears prior acceptance and audit attestation', async () =>
 	const root = await fixtureRoot();
 	try {
 		await writeJson(path.join(root, 'packages/operon-cli/package.json'), {
-			name: 'operon-cli',
-			version: '1.0.6',
+			name: '@stratejya/operon-cli',
+			version: '1.0.7',
 		});
 		await writeFile(
-			path.join(root, 'packages/operon-cli/freeze/operon-cli-1.0.6.tgz'),
+			path.join(root, 'packages/operon-cli/freeze/stratejya-operon-cli-1.0.7.tgz'),
 			'stable tarball\n',
 		);
 		await writeJson(path.join(root, 'manifest.json'), {
@@ -276,7 +276,7 @@ test('canonical npm tarball generation is reproducible', async () => {
 	const root = await fixtureRoot();
 	try {
 		await writeJson(path.join(root, 'packages/operon-cli/package.json'), {
-			name: 'operon-cli',
+			name: '@stratejya/operon-cli',
 			version: '0.1.0-beta.1',
 			files: ['dist/', 'README.md', 'LICENSE'],
 		});
@@ -284,7 +284,7 @@ test('canonical npm tarball generation is reproducible', async () => {
 		const first = await readFile(firstPath);
 		const secondPath = await writeCanonicalCliTarball(root);
 		const second = await readFile(secondPath);
-		assert.equal(path.basename(firstPath), 'operon-cli-0.1.0-beta.1.tgz');
+		assert.equal(path.basename(firstPath), 'stratejya-operon-cli-0.1.0-beta.1.tgz');
 		assert.equal(
 			createHash('sha256').update(first).digest('hex'),
 			createHash('sha256').update(second).digest('hex'),
@@ -323,7 +323,7 @@ test('canonical npm tarball rejects non-public file modes', {
 	const root = await fixtureRoot();
 	try {
 		await writeJson(path.join(root, 'packages/operon-cli/package.json'), {
-			name: 'operon-cli',
+			name: '@stratejya/operon-cli',
 			version: '0.1.0-beta.1',
 			files: ['README.md', 'LICENSE'],
 		});
@@ -361,7 +361,7 @@ test('source-first preparation rebuilds plugin and CLI before packing', async ()
 		]);
 		assert.equal(
 			await readFile(
-				path.join(root, 'packages/operon-cli/freeze/operon-cli-0.1.0-beta.1.tgz'),
+				path.join(root, 'packages/operon-cli/freeze/stratejya-operon-cli-0.1.0-beta.1.tgz'),
 			).then(bytes => bytes.byteLength > 0),
 			true,
 		);
@@ -505,7 +505,7 @@ async function fixtureRoot() {
 		['packages/operon-cli/README.md', 'readme\n'],
 		['packages/operon-cli/LICENSE', 'license\n'],
 		['packages/operon-cli/dist/operon.mjs', 'executable\n'],
-		['packages/operon-cli/freeze/operon-cli-0.1.0-beta.1.tgz', 'tarball\n'],
+		['packages/operon-cli/freeze/stratejya-operon-cli-0.1.0-beta.1.tgz', 'tarball\n'],
 		['packages/operon-cli/schemas/v1/schema.json', '{}\n'],
 		['packages/operon-cli/types/index.d.ts', 'export type Value = string;\n'],
 		['packages/operon-cli/examples/developer-api-consumer/main.ts', 'export {};\n'],
@@ -558,7 +558,7 @@ async function fixtureRoot() {
 		contractDigest: 'b'.repeat(64),
 	});
 	await writeJson(path.join(root, 'packages/operon-cli/package.json'), {
-		name: 'operon-cli',
+		name: '@stratejya/operon-cli',
 		version: '0.1.0-beta.1',
 	});
 	await writeJson(path.join(root, 'manifest.json'), {

--- a/scripts/agent-runtime/developer-api/native-acceptance-consumer/acceptance.ts
+++ b/scripts/agent-runtime/developer-api/native-acceptance-consumer/acceptance.ts
@@ -3,7 +3,7 @@ import type {
 	OperonDeveloperApiAccessorV1,
 	OperonDeveloperApiConsumerPluginV1,
 	OperonDeveloperApiV1,
-} from 'operon-cli/contracts/v1/developer-api';
+} from '@stratejya/operon-cli/contracts/v1/developer-api';
 
 import {
 	ACCEPTANCE_OUTPUT_KIND_V1,

--- a/scripts/agent-runtime/developer-api/native-acceptance-consumer/build.mjs
+++ b/scripts/agent-runtime/developer-api/native-acceptance-consumer/build.mjs
@@ -15,6 +15,10 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { build } from 'esbuild';
+import {
+	OPERON_CLI_NPM_PACKAGE_NAME,
+	OPERON_CLI_NPM_PACKAGE_PATH,
+} from '../../../../packages/operon-cli/package-identity.mjs';
 
 const fixtureRoot = path.dirname(fileURLToPath(import.meta.url));
 const pluginRoot = path.resolve(fixtureRoot, '../../../..');
@@ -69,7 +73,11 @@ try {
 		],
 		stagingRoot,
 	);
-	const installedPackageRoot = path.join(stagingRoot, 'node_modules', 'operon-cli');
+	const installedPackageRoot = path.join(
+		stagingRoot,
+		'node_modules',
+		...OPERON_CLI_NPM_PACKAGE_PATH,
+	);
 	const installedPackage = JSON.parse(await readFile(
 		path.join(installedPackageRoot, 'package.json'),
 		'utf8',
@@ -128,7 +136,7 @@ try {
 		package: `${installedPackage.name}@${installedPackage.version}`,
 		tarball: path.basename(tarballPath),
 		tarballSha256: sha256(tarballBytes),
-		publicTypesEntrypoint: 'operon-cli/contracts/v1/developer-api',
+		publicTypesEntrypoint: '@stratejya/operon-cli/contracts/v1/developer-api',
 		runtimeInputs,
 		mainJsSha256: sha256(mainBytes),
 		mainJsBytes: mainBytes.length,
@@ -149,7 +157,7 @@ try {
 			cliPackageRoot,
 		);
 		const packResult = JSON.parse(result.stdout)[0];
-		assert.equal(packResult.name, 'operon-cli');
+		assert.equal(packResult.name, OPERON_CLI_NPM_PACKAGE_NAME);
 		return path.join(packRoot, packResult.filename);
 	}
 } finally {
@@ -159,10 +167,10 @@ try {
 async function assertPublicTypeImportsOnly(stagingRoot) {
 	for (const fileName of ['acceptance.ts', 'main.ts', 'runner-contract.ts']) {
 		const source = await readFile(path.join(stagingRoot, fileName), 'utf8');
-		for (const match of source.matchAll(/\boperon-cli(?:\/[^'"]*)?/gu)) {
+		for (const match of source.matchAll(/@stratejya\/operon-cli(?:\/[^'"]*)?/gu)) {
 			assert.equal(
 				match[0],
-				'operon-cli/contracts/v1/developer-api',
+				'@stratejya/operon-cli/contracts/v1/developer-api',
 				`Fixture imported a non-public or non-Developer-API package path: ${match[0]}`,
 			);
 		}

--- a/scripts/agent-runtime/developer-api/native-acceptance-consumer/main.ts
+++ b/scripts/agent-runtime/developer-api/native-acceptance-consumer/main.ts
@@ -12,7 +12,7 @@ import path from 'node:path';
 
 import type {
 	OperonDeveloperApiAccessorV1,
-} from 'operon-cli/contracts/v1/developer-api';
+} from '@stratejya/operon-cli/contracts/v1/developer-api';
 
 import { runAcceptanceV1 } from './acceptance.js';
 import {

--- a/scripts/agent-runtime/developer-api/native-acceptance-consumer/native-consumer.test.mjs
+++ b/scripts/agent-runtime/developer-api/native-acceptance-consumer/native-consumer.test.mjs
@@ -63,7 +63,10 @@ test('build consumes an exact operon-cli tarball and emits an isolated Obsidian 
 		));
 		assert.equal(evidence.kind, 'operon-developer-api-native-consumer-build');
 		assert.equal(evidence.package, `${packResult.name}@${packResult.version}`);
-		assert.equal(evidence.publicTypesEntrypoint, 'operon-cli/contracts/v1/developer-api');
+		assert.equal(
+			evidence.publicTypesEntrypoint,
+			'@stratejya/operon-cli/contracts/v1/developer-api',
+		);
 		assert.deepEqual(evidence.runtimeInputs, [
 			'acceptance.ts',
 			'main.ts',

--- a/scripts/agent-runtime/developer-api/native-acceptance-consumer/runner-contract.ts
+++ b/scripts/agent-runtime/developer-api/native-acceptance-consumer/runner-contract.ts
@@ -1,7 +1,7 @@
 import type {
 	OperonDeveloperApiAccessRequestV1,
 	OperonDeveloperApiV1,
-} from 'operon-cli/contracts/v1/developer-api';
+} from '@stratejya/operon-cli/contracts/v1/developer-api';
 
 export const ACCEPTANCE_INPUT_KIND_V1 = 'operon-developer-api-native-consumer-input';
 export const ACCEPTANCE_OUTPUT_KIND_V1 = 'operon-developer-api-native-consumer-output';


### PR DESCRIPTION
## What changed

- Renamed the unpublished npm package to `@stratejya/operon-cli` and advanced the candidate to `1.0.7`.
- Preserved the `operon` executable and all existing command syntax.
- Centralized package identity, encoded scoped registry lookups, and aligned install paths, update checks, release workflows, evidence, contracts, examples, and generated manifests.
- Updated the two affected public integration guides source-first.
- Regenerated and explicitly accepted the Public V1 freeze for the scoped package.

## Why

The unscoped npm package name could not be published. A public scoped package avoids the namespace conflict without changing how users invoke the CLI.

## Impact

Users install with `npm install --global @stratejya/operon-cli` and continue to run commands such as `operon task create` unchanged. Plugin Runtime behavior and the production `main.js` bundle are unchanged.

## Validation

- Accepted Public V1 freeze: `41c83bcbcbc8b8117c1e9989d7d430e03f2257c0004ba2af94363f203f4bf71b`
- Canonical tarball: 213,485 bytes, SHA-256 `f03c360ec83663d730d76a5e53e27e4544c82f6c6f1ecfbbc0fba1538cd980a8`
- `npm run check:local`, including Phase 5 regression 1517/1517
- Clean production and development audit results
- Package install, rollback, re-upgrade, and uninstall lifecycle
- NodeNext, Bundler, and `typesVersions` consumers
- Public docs parity, release guard, privacy scan, and accepted-freeze parity
- Independent package and release-risk review

This PR does not create a CLI tag, publish to npm, or create a GitHub Release.
