### PR TITLE
Accept all read-only Runtime commands on persistent transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Routed `health`, `capabilities`, `diagnostics`, `catalog`, `entity.resolve`,
+  `task.get`, `tasks.query`, `tasks.finder`, `relationships.get`,
+  `context.build`, and `timers.read` through the authenticated persistent
+  Runtime transport, while keeping mutation preview and apply on the one-shot
+  safety path.
+
 ### Validation
 
 ## [3.0.2] - 2026-08-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Routed `health`, `capabilities`, `diagnostics`, `catalog`, `entity.resolve`,
+- Expanded the authenticated persistent Runtime server allowlist to accept
+  `health`, `capabilities`, `diagnostics`, `catalog`, `entity.resolve`,
   `task.get`, `tasks.query`, `tasks.finder`, `relationships.get`,
-  `context.build`, and `timers.read` through the authenticated persistent
-  Runtime transport, while keeping mutation preview and apply on the one-shot
-  safety path.
+  `context.build`, and `timers.read`, while keeping mutation preview and apply
+  on the one-shot safety path.
 
 ### Validation
 

--- a/scripts/agent-runtime/cli-transport/native-transport.test.ts
+++ b/scripts/agent-runtime/cli-transport/native-transport.test.ts
@@ -536,7 +536,7 @@ test('persistent read server dispatches allowlisted tokens and rejects mutation 
 		const batchInvocations = ['batch-one', 'batch-two'].map((requestId, index) => ({
 			...invocation,
 			requestId,
-			command: 'health' as const,
+			command: index === 0 ? 'health' as const : 'capabilities' as const,
 			requestToken: String.fromCharCode(108 + index).repeat(32),
 		}));
 		for (const batchInvocation of batchInvocations) {

--- a/scripts/agent-runtime/cli-transport/native-transport.test.ts
+++ b/scripts/agent-runtime/cli-transport/native-transport.test.ts
@@ -41,6 +41,10 @@ import {
 	type AgentRuntimePersistentReadServerHandleV1,
 } from '../../../src/agent-runtime/transport/persistent-read-server';
 import {
+	PERSISTENT_READ_COMMANDS_V1,
+	isPersistentReadCommandV1,
+} from '../../../src/agent-runtime/transport/persistent-read-commands';
+import {
 	AgentRuntimePersistentReadSupervisorV1,
 } from '../../../src/agent-runtime/transport/persistent-read-supervisor';
 import {
@@ -425,7 +429,28 @@ test('Windows broker staging is one-shot, bounded and expires fail-closed', () =
 		scope: WINDOWS_BROKER_SCOPE,
 		now: 40_001,
 	}), /broker-capacity-full/u);
-	clearWindowsBrokerStagesForTestsV1();
+clearWindowsBrokerStagesForTestsV1();
+});
+
+test('persistent read policy covers every read-only Runtime command and no mutation', () => {
+	assert.deepEqual(PERSISTENT_READ_COMMANDS_V1, [
+		'health',
+		'capabilities',
+		'diagnostics',
+		'catalog',
+		'entity.resolve',
+		'task.get',
+		'tasks.query',
+		'tasks.finder',
+		'relationships.get',
+		'context.build',
+		'timers.read',
+	]);
+	for (const command of PERSISTENT_READ_COMMANDS_V1) {
+		assert.equal(isPersistentReadCommandV1(command), true, `${command} must be allowlisted`);
+	}
+	assert.equal(isPersistentReadCommandV1('mutation.preview'), false);
+	assert.equal(isPersistentReadCommandV1('mutation.apply'), false);
 });
 
 if (process.platform !== 'win32') {

--- a/scripts/agent-runtime/cli-transport/native-transport.test.ts
+++ b/scripts/agent-runtime/cli-transport/native-transport.test.ts
@@ -429,7 +429,7 @@ test('Windows broker staging is one-shot, bounded and expires fail-closed', () =
 		scope: WINDOWS_BROKER_SCOPE,
 		now: 40_001,
 	}), /broker-capacity-full/u);
-clearWindowsBrokerStagesForTestsV1();
+	clearWindowsBrokerStagesForTestsV1();
 });
 
 test('persistent read policy covers every read-only Runtime command and no mutation', () => {

--- a/src/agent-runtime/transport/persistent-read-commands.ts
+++ b/src/agent-runtime/transport/persistent-read-commands.ts
@@ -1,5 +1,10 @@
 import type { CliCommandV1 } from '../contracts/v1/cli';
 
+type PersistentReadCommandV1 = Exclude<
+	CliCommandV1,
+	'mutation.preview' | 'mutation.apply'
+>;
+
 /**
  * Runtime commands that are read-only and may use the authenticated
  * persistent transport. Mutation preview/apply deliberately stay on the
@@ -17,7 +22,15 @@ export const PERSISTENT_READ_COMMANDS_V1 = [
 	'relationships.get',
 	'context.build',
 	'timers.read',
-] as const satisfies readonly CliCommandV1[];
+] as const satisfies readonly PersistentReadCommandV1[];
+
+type MissingPersistentReadCommandV1 = Exclude<
+	PersistentReadCommandV1,
+	typeof PERSISTENT_READ_COMMANDS_V1[number]
+>;
+const PERSISTENT_READ_POLICY_IS_EXHAUSTIVE_V1:
+	MissingPersistentReadCommandV1 extends never ? true : never = true;
+void PERSISTENT_READ_POLICY_IS_EXHAUSTIVE_V1;
 
 export function isPersistentReadCommandV1(command: CliCommandV1): boolean {
 	return (PERSISTENT_READ_COMMANDS_V1 as readonly string[]).includes(command);

--- a/src/agent-runtime/transport/persistent-read-commands.ts
+++ b/src/agent-runtime/transport/persistent-read-commands.ts
@@ -1,0 +1,24 @@
+import type { CliCommandV1 } from '../contracts/v1/cli';
+
+/**
+ * Runtime commands that are read-only and may use the authenticated
+ * persistent transport. Mutation preview/apply deliberately stay on the
+ * one-shot path so their consent and recovery semantics remain separate.
+ */
+export const PERSISTENT_READ_COMMANDS_V1 = [
+	'health',
+	'capabilities',
+	'diagnostics',
+	'catalog',
+	'entity.resolve',
+	'task.get',
+	'tasks.query',
+	'tasks.finder',
+	'relationships.get',
+	'context.build',
+	'timers.read',
+] as const satisfies readonly CliCommandV1[];
+
+export function isPersistentReadCommandV1(command: CliCommandV1): boolean {
+	return (PERSISTENT_READ_COMMANDS_V1 as readonly string[]).includes(command);
+}

--- a/src/agent-runtime/transport/persistent-read-server.ts
+++ b/src/agent-runtime/transport/persistent-read-server.ts
@@ -21,6 +21,7 @@ import {
 	unregisterWindowsBrokerScopeV1,
 	type WindowsBrokerScopeV1,
 } from './windows-broker-state';
+import { PERSISTENT_READ_COMMANDS_V1 } from './persistent-read-commands';
 
 const PROTOCOL_VERSION_V1 = 1;
 const MAX_CONNECTIONS_V1 = 4;
@@ -29,10 +30,7 @@ const AUTHENTICATED_FRAME_OVERHEAD_BYTES_V1 = 16 * 1024;
 const MAX_FRAME_BYTES_V1 = CONTRACT_LIMITS_V1.transportInputBytes
 	+ AUTHENTICATED_FRAME_OVERHEAD_BYTES_V1;
 const READ_COMMANDS_V1 = new Set<CliCommandV1>([
-	'health',
-	'task.get',
-	'tasks.query',
-	'context.build',
+	...PERSISTENT_READ_COMMANDS_V1,
 ]);
 const HEX_256_PATTERN_V1 = /^[a-f0-9]{64}$/u;
 const REQUEST_TOKEN_PATTERN_V1 = /^[A-Za-z0-9_-]{32}$/u;


### PR DESCRIPTION
## What changed

- Expands the authenticated persistent-read server allowlist to every current read-only Runtime V1 command.
- Keeps mutation preview and apply outside the persistent server path.
- Adds an exhaustiveness guard so a Runtime command cannot be silently classified as read-only when the contract evolves.
- Covers the policy and a capabilities request in the native persistent transport suite.

## Why

The standalone client now routes the full read-only surface over the persistent channel. The plugin must accept the same policy or the newly routed requests are rejected.

This is the Operon half of hasanyilmaz/operon#103 and is paired with hasanyilmaz/operon-cli#6. The two releases need to be coordinated; the Runtime V1 wire contract is unchanged.

## Validation

- npm run lint:strict
- npm run build
- native persistent transport suite: 13 passing
- npm run release:notes:test

The broader Windows Agent Runtime validation commands have pre-existing harness failures, tracked separately in #107.