### PR TITLE
Refresh mutation evidence after Runtime settlement

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -5715,6 +5715,29 @@ export default class OperonPlugin extends Plugin {
 			commitMutation: async (request, prepared, effectiveAt) => (
 				await this.commitAgentRuntimeTaskMutation(request.plan.spec, prepared, effectiveAt)
 			),
+			refreshMutationCommitEvidence: async commit => ({
+				...commit,
+				groupResults: await Promise.all(commit.groupResults.map(async group => ({
+					...group,
+					resourceRevisions: await Promise.all((group.resourceRevisions ?? []).map(
+						async resource => {
+							if (resource.resourceKind !== 'task-source') return resource;
+							try {
+								return {
+									...resource,
+									revision: sourceRevisionForTaskCreationV1(
+										resource.resourceKey,
+										(await this.readAgentRuntimeMutationSource(resource.resourceKey)).content,
+									),
+								};
+							} catch (error) {
+								if (!(await this.app.vault.adapter.exists(resource.resourceKey))) return resource;
+								throw error;
+							}
+						},
+					)),
+				}))),
+			}),
 				verifyMutation: async (request, prepared, _postflightRevision, commit) => (
 					await this.verifyAgentRuntimeTaskMutation(request.plan.createdAt, prepared, commit)
 				),

--- a/scripts/agent-runtime/mutation/mutation-gateway.test.ts
+++ b/scripts/agent-runtime/mutation/mutation-gateway.test.ts
@@ -3165,6 +3165,111 @@ test('prepared mutation postflight failure persists an uncertain receipt and fen
 	assert.equal(commitCount, 1);
 });
 
+test('prepared mutation refreshes commit evidence only after settlement and before postflight', async () => {
+	const updateRequest: MutationPreviewRequestV1 = {
+		contractVersion: 1,
+		requestId: 'phase8-update-refresh-evidence-preview',
+		kind: 'mutation-preview',
+		clientInstanceId: 'test-client',
+		idempotencyKey: 'phase8-update-refresh-evidence',
+		capability: 'tasks.update.preview',
+		mutationKind: 'task.update',
+		target: {
+			operonId: 'abc1234',
+			locator: { representation: 'inline', filePath: 'Tasks.md', lineNumber: 1 },
+		},
+		spec: {
+			operation: 'update',
+			changes: [{ field: 'note', valueType: 'text', value: 'Updated note' }],
+		},
+		authorization: { basis: 'user-explicit-request' },
+	};
+	const prepared = {
+		target: {
+			operonId: 'abc1234',
+			locator: { representation: 'inline' as const, filePath: 'Tasks.md', lineNumber: 1 },
+			targetDigest: 'd'.repeat(64),
+		},
+		affectedResources: [{
+			resourceKind: 'task-source' as const,
+			resourceKey: 'Tasks.md',
+			revision: 'e'.repeat(64),
+		}],
+		predictedEffects: [{
+			resourceKind: 'task-source' as const,
+			resourceKey: 'Tasks.md',
+			action: 'update' as const,
+			summary: 'Update one task field.',
+		}],
+		warnings: [],
+		token: { kind: 'test-update' },
+	};
+	const events: string[] = [];
+	const refreshedRevision = 'f'.repeat(64);
+	const receiptStore = {
+		health: async () => ({ healthy: true }),
+		lookup: async () => null,
+		persist: async () => ({ expiredDeleted: 0, overflowDeleted: 0, retained: 1 }),
+	} as unknown as IndexedDbMutationReceiptStoreV1;
+	const gateway = new RuntimeMutationGatewayV1({
+		isReady: () => true,
+		sampleContextRevision: () => revision,
+		prepareCreation: async () => preparation(),
+		commitCreation: async () => ({ status: 'failed', groups: [], remainingGroupIds: [] }),
+		prepareMutation: async () => ({ ok: true, value: prepared }),
+		commitMutation: async () => ({
+			status: 'committed',
+			groupResults: [{
+				groupId: 'task-source:Tasks.md',
+				status: 'committed',
+				resourceRevisions: prepared.affectedResources,
+			}],
+			affectedFilePaths: ['Tasks.md'],
+		}),
+		refreshMutationCommitEvidence: async commit => {
+			events.push('refresh');
+			assert.deepEqual(events, ['reindex', 'settle', 'refresh']);
+			return {
+				...commit,
+				groupResults: commit.groupResults.map(group => ({
+					...group,
+					resourceRevisions: group.resourceRevisions?.map(resource => ({
+						...resource,
+						revision: refreshedRevision,
+					})),
+				})),
+			};
+		},
+		verifyMutation: async (_request, _prepared, _revision, commit) => {
+			events.push('verify');
+			assert.equal(commit.groupResults[0]?.resourceRevisions?.[0]?.revision, refreshedRevision);
+			return true;
+		},
+		reindexAffectedSources: async () => { events.push('reindex'); },
+		settleAfterMutation: async () => { events.push('settle'); },
+		reconcileCreatedHierarchy: async () => ({ ok: true, resourceRevisions: [] }),
+		verifyCreatedTasks: async () => false,
+		receiptStore: () => receiptStore,
+		vaultIdentityHash: async () => 'c'.repeat(64),
+		nowEpochMs: () => Date.parse('2026-07-24T08:00:00.000Z'),
+		randomId: () => 'phase8-update-refresh-evidence-plan',
+	});
+	const preview = await gateway.preview(updateRequest);
+	assert.equal(preview.ok, true);
+	if (!preview.ok) return;
+	const result = await gateway.apply({
+		contractVersion: 1,
+		requestId: 'phase8-update-refresh-evidence-apply',
+		kind: 'mutation-apply',
+		plan: preview.plan,
+		authorization: { basis: 'user-explicit-request' },
+		idempotencyKey: updateRequest.idempotencyKey,
+		acknowledgements: [],
+	});
+	assert.equal(result.status, 'applied', JSON.stringify(result));
+	assert.deepEqual(events, ['reindex', 'settle', 'refresh', 'verify']);
+});
+
 test('file-to-inline postflight failure preserves its durable same-plan recovery journal', async () => {
 	const conversionRequest: MutationPreviewRequestV1 = {
 		contractVersion: 1,

--- a/src/agent-runtime/runtime/mutation-gateway.ts
+++ b/src/agent-runtime/runtime/mutation-gateway.ts
@@ -244,6 +244,13 @@ export interface RuntimeMutationGatewayPortsV1 {
 		prepared: RuntimePreparedMutationV1,
 		effectiveAt: string,
 	): Promise<RuntimePreparedMutationCommitV1>;
+	/**
+	 * Resample commit evidence after Runtime-owned settlement has completed.
+	 * This is read-only and must never execute or replay a mutation write.
+	 */
+	refreshMutationCommitEvidence?(
+		commit: RuntimePreparedMutationCommitV1,
+	): Promise<RuntimePreparedMutationCommitV1>;
 	verifyMutation?(
 		request: MutationApplyRequestV1,
 		prepared: RuntimePreparedMutationV1,
@@ -1984,7 +1991,10 @@ export class RuntimeMutationGatewayV1 {
 				undefined,
 				() => this.ports.settleAfterMutation(request.requestId),
 			);
-				postflightRevision = await this.ports.sampleContextRevision();
+			if (this.ports.refreshMutationCommitEvidence) {
+				commit = await this.ports.refreshMutationCommitEvidence(commit);
+			}
+			postflightRevision = await this.ports.sampleContextRevision();
 				if (!(await this.measureMutation(
 					request.requestId,
 					'mutation-apply',


### PR DESCRIPTION
## Summary

- add an optional read-only commit-evidence refresh after Runtime settlement and before semantic postflight
- resample task-source revisions after Obsidian-managed follow-up writes
- preserve the already sealed revision when a mutation intentionally removed the source

## Root cause

Obsidian listeners can update host-managed metadata after the canonical mutation writer returns. Operon sealed the task-source revision before those follow-up writes settled, so a successful update could later fail postflight and return `outcome-unknown` even though the requested change was present.

The refresh now runs only after reindexing and Runtime settlement. It does not execute or replay writes. Missing sources are treated as intentional deletion evidence; read failures for sources that still exist continue to fail closed.

## Impact

Successful task updates can produce a verified terminal receipt against the durable vault state instead of being reported as uncertain solely because Obsidian updated metadata after the writer returned.

## Validation

- `npm run agent-runtime:mutation` — 134 mutation tests passed
- `npm run build`
- `npm run lint:strict`
- live Obsidian 1.13.5 pilot: general update returned `applied`, verified the changed description, and a second update restored the original description

Closes #120.