### PR TITLE
Bind Developer API confirmations to sealed targets

### DIFF
--- a/scripts/agent-runtime/developer-api/recovery-store.test.ts
+++ b/scripts/agent-runtime/developer-api/recovery-store.test.ts
@@ -64,6 +64,51 @@ test('production recovery store persists, isolates, lists, and retains terminal 
 	assert.deepEqual(await store.list(refused.consumerId), []);
 });
 
+test('production recovery store accepts host confirmation bound to the sealed target', async () => {
+	const factory = new FakeIndexedDbFactory();
+	const store = createStore(factory);
+	const base = recoveryRecord(77);
+	const sealed = structuredClone(base.sealed);
+	sealed.riskLevel = 'elevated';
+	sealed.requiresConfirmation = true;
+	sealed.requiredAcknowledgements = ['terminal-transition'];
+	sealed.planHash = computeSealedMutationPlanHashV1(sealed);
+	const record: DeveloperMutationRecoveryRecordV1 = {
+		...base,
+		planDigest: sealed.planHash,
+		sealed,
+		binding: {
+			...base.binding,
+			planHash: sealed.planHash,
+		},
+		authorization: { basis: 'user-explicit-confirmation' },
+		acknowledgements: [{
+			code: 'terminal-transition',
+			planHash: sealed.planHash,
+			targetDigest: sealed.targets[0].targetDigest,
+			acknowledgedAt: sealed.createdAt,
+		}],
+	};
+
+	await store.putPrepared(record);
+
+	const aggregateBound: DeveloperMutationRecoveryRecordV1 = {
+		...structuredClone(record),
+		recoveryRef: `dvr1_${'4e'.padStart(48, '0')}`,
+		acknowledgements: record.acknowledgements.map(acknowledgement => ({
+			...acknowledgement,
+			targetDigest: sealed.receiptTargetDigest,
+		})),
+	};
+	await assert.rejects(
+		store.putPrepared(aggregateBound),
+		(error: unknown) => (
+			error instanceof DeveloperMutationRecoveryStoreErrorV1
+			&& error.code === 'recovery-store-corrupt'
+		),
+	);
+});
+
 test('production recovery store prunes expired records and protects 256 live records', async () => {
 	let now = BASE_TIME;
 	const factory = new FakeIndexedDbFactory();

--- a/scripts/agent-runtime/developer-api/security/security-policy.test.ts
+++ b/scripts/agent-runtime/developer-api/security/security-policy.test.ts
@@ -53,7 +53,15 @@ function plan(options: {
 		mutationKind,
 		createdAt: '2026-07-29T10:00:00.000Z',
 		expiresAt: '2026-07-29T10:10:00.000Z',
-		targets: [],
+		targets: [{
+			operonId: 'abc1234',
+			locator: {
+				representation: 'inline',
+				filePath: 'Tasks.md',
+				lineNumber: 0,
+			},
+			targetDigest: 'sealed-target-digest',
+		}],
 		contextRevision: {
 			index: {
 				sessionId: 'index-session',
@@ -215,13 +223,13 @@ test('mints host-owned destructive confirmation and target-bound acknowledgement
 		{
 			code: 'destructive-delete',
 			planHash: sealed.planHash,
-			targetDigest: sealed.receiptTargetDigest,
+			targetDigest: sealed.targets[0].targetDigest,
 			acknowledgedAt: '2026-07-29T10:01:00.000Z',
 		},
 		{
 			code: 'attached-checkboxes',
 			planHash: sealed.planHash,
-			targetDigest: sealed.receiptTargetDigest,
+			targetDigest: sealed.targets[0].targetDigest,
 			acknowledgedAt: '2026-07-29T10:01:00.000Z',
 		},
 	]);

--- a/src/agent-runtime/developer-api/security/policy.ts
+++ b/src/agent-runtime/developer-api/security/policy.ts
@@ -141,13 +141,21 @@ export class DeveloperMutationSecurityPolicyV1 {
 		if (postConsentDenial) return postConsentDenial;
 
 		const acknowledgedAt = this.ports.now().toISOString();
+		const acknowledgementTargetDigest = input.plan.targets[0]?.targetDigest;
+		if (!acknowledgementTargetDigest) {
+			return denialResult(
+				'invalid-request',
+				'plan-binding-mismatch',
+				'The sealed plan does not expose a target for confirmation.',
+			);
+		}
 		return {
 			ok: true,
 			authorization: hostAuthorization('user-explicit-confirmation'),
 			acknowledgements: input.plan.requiredAcknowledgements.map(code => ({
 				code,
 				planHash: input.plan.planHash,
-				targetDigest: input.plan.receiptTargetDigest,
+				targetDigest: acknowledgementTargetDigest,
 				acknowledgedAt,
 			})),
 			consent: 'fresh-user-confirmation',


### PR DESCRIPTION
## Summary

- bind host-minted Developer API acknowledgements to the primary sealed target
- fail closed when a confirmation-gated plan exposes no target
- cover canonical recovery-store admission for an elevated confirmed plan

## Root cause

The Developer API security policy minted acknowledgement `targetDigest` values from `receiptTargetDigest`, which is the aggregate digest of the complete target list. The V1 apply decoder requires acknowledgements to bind an actual sealed target digest. Confirmation-gated transitions therefore passed the user-consent UI but their private recovery record was rejected before Runtime dispatch.

## Impact

Elevated and destructive Developer API applies can persist their prepared recovery proof and reach Runtime after user confirmation, while malformed or targetless confirmation plans still fail closed.

## Validation

- `npm run agent-runtime:developer-api` — 47 Developer API tests, 6 security-policy tests, 3 integration tests, and 7 native-consumer tests passed
- `npm run build`
- `npm run lint:strict`
- live Obsidian 1.13.5 pilot: terminal transition returned `applied`; same idempotency key replayed without a second write; restart preserved the terminal state and grant

Related to #99, but independent from the unscoped project-serial planner fix in #101.

Closes #121.