### PR TITLE
Preserve Developer API grants across restart

### DIFF
--- a/scripts/agent-runtime/developer-api/developer-api-integration.test.mjs
+++ b/scripts/agent-runtime/developer-api/developer-api-integration.test.mjs
@@ -7,6 +7,10 @@ const developerRuntimeSource = await readFile(
 	new URL('../../../src/agent-runtime/developer-api/runtime.ts', import.meta.url),
 	'utf8',
 );
+const operonStorageSource = await readFile(
+	new URL('../../../src/storage/operon-storage.ts', import.meta.url),
+	'utf8',
+);
 
 function methodBody(source, signature, nextSignature) {
 	const start = source.indexOf(signature);
@@ -56,4 +60,17 @@ test('Developer API runtime has no CLI, transport, or official Obsidian CLI depe
 		developerRuntimeSource,
 		/agentRuntimeCliTransportAvailable|nativeCliTransportAvailable|Obsidian CLI/u,
 	);
+});
+
+test('general settings persistence preserves the host-owned Developer API grant slice', () => {
+	const persistSettings = methodBody(
+		operonStorageSource,
+		'\tprivate async persistSettings(',
+		'\n\tgetSettings(): OperonSettings',
+	);
+	assert.match(
+		persistSettings,
+		/const currentDeveloperApi = currentPackage\.integrations\.developerApi;/u,
+	);
+	assert.match(persistSettings, /developerApi: currentDeveloperApi,/u);
 });

--- a/scripts/agent-runtime/receipts/indexeddb-receipt-store.test.ts
+++ b/scripts/agent-runtime/receipts/indexeddb-receipt-store.test.ts
@@ -1348,6 +1348,51 @@ test('startup reconciliation finds grant intent without matching activation only
 	);
 });
 
+test('startup reconciliation preserves a repeated unresolved grant intent at the same revision', () => {
+	const consumerIdentityHash = sha256(41_100);
+	const firstIntent = auditEvent(212, BASE_TIME, {
+		event: 'grant-requested',
+		consumerIdentityHash,
+		grantRevision: 5,
+		capability: 'tasks.read',
+		mutationKind: null,
+		risk: null,
+		planDigest: null,
+		targetDigest: null,
+		consent: 'not-required',
+		admission: 'requested',
+		outcome: 'pending',
+	});
+	const activation = auditEvent(213, BASE_TIME, {
+		...firstIntent,
+		eventId: sha256(40_213),
+		admission: 'completed',
+		outcome: 'succeeded',
+	});
+	const interruptedRetry = auditEvent(214, BASE_TIME, {
+		...firstIntent,
+		eventId: sha256(40_214),
+	});
+	const expected = [{ consumerIdentityHash, revision: 5 }];
+	assert.deepEqual(
+		findIncompleteDeveloperGrantAuditTransitionsV1([
+			firstIntent,
+			activation,
+			interruptedRetry,
+		]),
+		expected,
+	);
+	assert.deepEqual(
+		findIncompleteDeveloperGrantAuditTransitionsV1([
+			interruptedRetry,
+			activation,
+			firstIntent,
+		]),
+		expected,
+		'Random eventId order at one millisecond must not hide an unmatched retry.',
+	);
+});
+
 test('security audit retention enforces 30 days and the newest 2048 records', async () => {
 	const factory = new FakeIndexedDbFactory();
 	const now = BASE_TIME + SECURITY_AUDIT_RETENTION_MS_V1;

--- a/scripts/agent-runtime/receipts/indexeddb-receipt-store.test.ts
+++ b/scripts/agent-runtime/receipts/indexeddb-receipt-store.test.ts
@@ -1341,6 +1341,11 @@ test('startup reconciliation finds grant intent without matching activation only
 		findIncompleteDeveloperGrantAuditTransitionsV1([intent, activation]),
 		[],
 	);
+	assert.deepEqual(
+		findIncompleteDeveloperGrantAuditTransitionsV1([activation, intent]),
+		[],
+		'IndexedDB returns newest audit events first, so reconciliation must be order-independent.',
+	);
 });
 
 test('security audit retention enforces 30 days and the newest 2048 records', async () => {

--- a/src/agent-runtime/runtime/receipts/indexeddb-security-audit-store.ts
+++ b/src/agent-runtime/runtime/receipts/indexeddb-security-audit-store.ts
@@ -506,8 +506,11 @@ export function planSecurityAuditPruneV1(
 export function findIncompleteDeveloperGrantAuditTransitionsV1(
 	events: readonly SecurityAuditEventV1[],
 ): readonly IncompleteDeveloperGrantAuditTransitionV1[] {
-	const pending = new Map<string, IncompleteDeveloperGrantAuditTransitionV1>();
-	const completed = new Set<string>();
+	const transitions = new Map<string, {
+		transition: IncompleteDeveloperGrantAuditTransitionV1;
+		intentsByTime: Map<number, number>;
+		completionsByTime: Map<number, number>;
+	}>();
 	for (const event of events) {
 		if (
 			event.channel !== 'developer-api'
@@ -520,22 +523,45 @@ export function findIncompleteDeveloperGrantAuditTransitionsV1(
 			event.grantRevision,
 			event.capability ?? '',
 		].join('\0');
+		const transition = transitions.get(key) ?? {
+			transition: {
+				consumerIdentityHash: event.consumerIdentityHash,
+				revision: event.grantRevision,
+			},
+			intentsByTime: new Map<number, number>(),
+			completionsByTime: new Map<number, number>(),
+		};
+		transitions.set(key, transition);
+		const occurredAtMs = Date.parse(event.occurredAt);
 		if (event.admission === 'requested' && event.outcome === 'pending') {
-			if (!completed.has(key)) {
-				pending.set(key, {
-					consumerIdentityHash: event.consumerIdentityHash,
-					revision: event.grantRevision,
-				});
-			}
+			transition.intentsByTime.set(
+				occurredAtMs,
+				(transition.intentsByTime.get(occurredAtMs) ?? 0) + 1,
+			);
 		} else if (event.admission === 'completed') {
-			completed.add(key);
-			pending.delete(key);
+			transition.completionsByTime.set(
+				occurredAtMs,
+				(transition.completionsByTime.get(occurredAtMs) ?? 0) + 1,
+			);
 		}
 	}
 	const unique = new Map<string, IncompleteDeveloperGrantAuditTransitionV1>();
-	for (const transition of pending.values()) {
-		const key = `${transition.consumerIdentityHash}\0${transition.revision}`;
-		unique.set(key, transition);
+	for (const entry of transitions.values()) {
+		let pendingCount = 0;
+		const times = [...new Set([
+			...entry.intentsByTime.keys(),
+			...entry.completionsByTime.keys(),
+		])].sort((left, right) => left - right);
+		for (const occurredAtMs of times) {
+			pendingCount += entry.intentsByTime.get(occurredAtMs) ?? 0;
+			pendingCount = Math.max(
+				0,
+				pendingCount - (entry.completionsByTime.get(occurredAtMs) ?? 0),
+			);
+		}
+		if (pendingCount === 0) continue;
+		const key = `${entry.transition.consumerIdentityHash}\0${entry.transition.revision}`;
+		unique.set(key, entry.transition);
 	}
 	return [...unique.values()].sort((left, right) => (
 		left.consumerIdentityHash.localeCompare(right.consumerIdentityHash)

--- a/src/agent-runtime/runtime/receipts/indexeddb-security-audit-store.ts
+++ b/src/agent-runtime/runtime/receipts/indexeddb-security-audit-store.ts
@@ -507,6 +507,7 @@ export function findIncompleteDeveloperGrantAuditTransitionsV1(
 	events: readonly SecurityAuditEventV1[],
 ): readonly IncompleteDeveloperGrantAuditTransitionV1[] {
 	const pending = new Map<string, IncompleteDeveloperGrantAuditTransitionV1>();
+	const completed = new Set<string>();
 	for (const event of events) {
 		if (
 			event.channel !== 'developer-api'
@@ -520,11 +521,14 @@ export function findIncompleteDeveloperGrantAuditTransitionsV1(
 			event.capability ?? '',
 		].join('\0');
 		if (event.admission === 'requested' && event.outcome === 'pending') {
-			pending.set(key, {
-				consumerIdentityHash: event.consumerIdentityHash,
-				revision: event.grantRevision,
-			});
+			if (!completed.has(key)) {
+				pending.set(key, {
+					consumerIdentityHash: event.consumerIdentityHash,
+					revision: event.grantRevision,
+				});
+			}
 		} else if (event.admission === 'completed') {
+			completed.add(key);
 			pending.delete(key);
 		}
 	}

--- a/src/storage/operon-storage.ts
+++ b/src/storage/operon-storage.ts
@@ -633,6 +633,7 @@ export class OperonStorage {
 		});
 		await this.dataPackageStore.updateDataPackage(currentPackage => {
 			const currentMobileNotifications = currentPackage.integrations.mobileNotifications;
+			const currentDeveloperApi = currentPackage.integrations.developerApi;
 			const pinnedTasks = prunePinnedTaskTombstones(
 				mergePinnedTasksPackages(
 					currentPackage.state.pinnedTasks,
@@ -646,6 +647,7 @@ export class OperonStorage {
 				integrations: {
 					...dataPackage.integrations,
 					mobileNotifications: adoptMobileNotificationsIntegration(currentMobileNotifications, {}),
+					developerApi: currentDeveloperApi,
 				},
 				state: {
 					...dataPackage.state,


### PR DESCRIPTION
## Summary

- preserve the host-owned `integrations.developerApi` slice during general settings persistence
- make startup grant-audit reconciliation independent of IndexedDB newest-first ordering
- add regression coverage for both restart paths

## Root cause

`OperonStorage.persistSettings()` rebuilt the canonical data package but preserved only the mobile-notifications integration. A later general settings save could therefore replace the current Developer API grant package with an empty one.

Separately, startup reconciliation consumed security-audit events in IndexedDB's newest-first order while assuming oldest-first order. A completed grant transition could consequently be rediscovered as incomplete and suspended after restart.

## Impact

Approved Developer API grants survive settings saves and plugin/Obsidian restarts, and completed audit transitions are not falsely treated as interrupted.

## Validation

- `npm run agent-runtime:developer-api` — 46 Developer API tests, 6 security-policy tests, 4 integration tests, and 7 native-consumer tests passed
- receipt-store suite — 52 tests passed
- `npm run build`
- `npm run lint:strict`
- live Obsidian 1.13.5 pilot: the Bridge grant remained active after repeated Operon and Bridge reloads with 19 granted and 0 pending capabilities

Closes #113.

