### PR TITLE
Keep queued Developer API grant requests pending

### DIFF
--- a/scripts/agent-runtime/developer-api/developer-api-grants.test.ts
+++ b/scripts/agent-runtime/developer-api/developer-api-grants.test.ts
@@ -307,6 +307,41 @@ test('grant controller verifies object identity and activates grants only after 
 	);
 });
 
+test('grant controller keeps a queued first request pending without weakening active admission', async () => {
+	let dataPackage = buildOperonDataPackageFromSettings(DEFAULT_SETTINGS);
+	let releasePersist: (() => void) | undefined;
+	const persistGate = new Promise<void>(resolve => {
+		releasePersist = resolve;
+	});
+	const controller = new DeveloperApiGrantControllerV1({
+		store: {
+			getDataPackage: () => structuredClone(dataPackage),
+			updateDataPackage: async mutator => {
+				await persistGate;
+				dataPackage = mutator(dataPackage);
+			},
+		},
+		verifier: {
+			verify: () => consumer(),
+			isCurrent: () => true,
+		},
+		now: () => new Date(NOW),
+	});
+
+	const initial = controller.evaluate(consumer(), ['tasks.read']);
+	assert.equal(initial.state, 'pending');
+	controller.recordPending(consumer(), ['tasks.read']);
+	assert.equal(controller.hasPersistenceError(), true);
+	const queued = controller.evaluate(consumer(), ['tasks.read']);
+	assert.equal(queued.state, 'pending');
+	assert.equal(queued.reason, 'capability-approval-required');
+	assert.deepEqual(queued.pendingCapabilities, ['tasks.read']);
+
+	releasePersist?.();
+	await controller.drain();
+	assert.equal(controller.hasPersistenceError(), false);
+});
+
 test('grant controller audits and persists version acceptance and suspension before readmission', async () => {
 	const initialGrants = approveDeveloperApiCapabilities(
 		createEmptyDeveloperApiGrantPackage(),

--- a/scripts/agent-runtime/developer-api/developer-api.test.ts
+++ b/scripts/agent-runtime/developer-api/developer-api.test.ts
@@ -225,6 +225,7 @@ function harness(options: {
 	error?: StructuredErrorV1;
 	active?: { value: boolean };
 	grantState?: { value: 'pending' | 'active' | 'suspended' | 'revoked'; revision: number };
+	grantPersistenceUnavailable?: boolean;
 	consumerCurrent?: { value: boolean };
 	mutationSecurityPolicy?: DeveloperMutationSecurityPolicyV1;
 	recoveryStore?: DeveloperMutationRecoveryStoreV1;
@@ -266,7 +267,7 @@ function harness(options: {
 						: 'consumer-major-version-changed' as const,
 		}),
 		recordPending: () => undefined,
-		hasPersistenceError: () => false,
+		hasPersistenceError: () => options.grantPersistenceUnavailable ?? false,
 	};
 	const accessAs = (consumer: typeof consumerPlugin, request: unknown) => getOperonDeveloperApiV1(core, consumer, request, {
 		isDesktopAvailable: () => options.desktop ?? true,
@@ -422,6 +423,16 @@ test('fails exact-scope access closed while pending and revokes a live session s
 	});
 	assert.equal(refused.ok, false);
 	assert.equal(refused.ok ? undefined : refused.error.code, 'authority-insufficient');
+});
+
+test('keeps a first-request grant pending while its persistence write is queued', () => {
+	const pending = harness({
+		grantState: { value: 'pending', revision: 1 },
+		grantPersistenceUnavailable: true,
+	}).access(request(['tasks.read']));
+	assert.equal(pending.ok, false);
+	assert.equal(pending.ok ? undefined : pending.error.code, 'authority-insufficient');
+	assert.equal(pending.status.grant?.state, 'pending');
 });
 
 test('fails access closed off desktop, without a core, while booting, and on terminal startup failure', () => {

--- a/src/agent-runtime/developer-api/grant-controller.ts
+++ b/src/agent-runtime/developer-api/grant-controller.ts
@@ -108,7 +108,10 @@ export class DeveloperApiGrantControllerV1 {
 	): DeveloperApiGrantEvaluationV1 {
 		this.observeConsumerVersion(consumer, requestedCapabilities);
 		const evaluation = evaluateDeveloperApiGrant(this.grants, consumer, requestedCapabilities);
-		if (!this.hasPersistenceError()) return evaluation;
+		if (
+			this.persistenceError === null
+			&& (evaluation.state !== 'active' || this.pendingWrites === 0)
+		) return evaluation;
 		return {
 			...evaluation,
 			state: 'suspended',

--- a/src/agent-runtime/developer-api/runtime.ts
+++ b/src/agent-runtime/developer-api/runtime.ts
@@ -1116,7 +1116,7 @@ function evaluateSessionGrant(
 		};
 	}
 	const grant = options.grantController.evaluate(consumer, required);
-	if (options.grantController.hasPersistenceError()) {
+	if (grant.state !== 'pending' && options.grantController.hasPersistenceError()) {
 		return {
 			...grant,
 			state: 'suspended',


### PR DESCRIPTION
## Summary

- keep a queued first-time capability request in the canonical `pending` state
- retain the existing durable-persistence barrier for active grants
- add a regression test covering a request while its persistence write is still queued

## Root cause

`DeveloperApiGrantController.evaluate()` treated every `pendingWrites > 0` state as a persistence failure. A first-time request records its own pending grant and queues persistence, so the immediate status evaluation changed the result from `pending` to `suspended` even though no write had failed.

The controller now distinguishes the safety requirements by state: an `active` grant still waits for all persistence writes, a genuine persistence error still suspends access, and a non-authorizing `pending` request remains pending while its write completes.

## Impact

Consumers receive a coherent approval-required status instead of a false persistence-unavailable suspension, without weakening durable activation or revocation guarantees.

## Validation

- `npm run agent-runtime:developer-api` — 47 Developer API tests, 6 security-policy tests, 3 integration tests, and 7 native-consumer tests passed
- `npm run build`
- `npm run lint:strict`

Closes #114.

