### PR TITLE
fix(ci): update js-yaml lock for audit policy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3811,9 +3811,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"dev": true,
 			"funding": [
 				{


### PR DESCRIPTION
## Summary

- update the transitive development dependency lock for `js-yaml` from 4.3.0 to 4.3.1
- clear the new high-severity dependency audit finding without changing runtime code or `package.json`
- preserve the integration lineage from #118 and its replacement/integration PR #124

## Context

After #124 integrated the work originating in #118, the Ubuntu validation rerun was blocked by the newly published `js-yaml` advisory (GHSA-5p4m-2wfm-xmqj / CVE-2026-59870). The dependency is reached only through the development lint chain:

`eslint-plugin-obsidianmd -> eslint -> @eslint/eslintrc -> js-yaml`

## Validation

- `npm ci`
- `npm audit --json` — 0 vulnerabilities
- `npm run release:audit-policy` — `accepted-clean`
- `npm run check:candidate`
- `git diff --check`

Only `package-lock.json` changes.

Follow-up to #118 and #124.
