### PR TITLE
fix(ci): use candidate freeze on main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,9 @@ jobs:
       - name: Verify release guard
         run: npm run release:guard
 
-      - name: Verify final accepted Public V1 freeze
+      - name: Verify candidate Public V1 freeze
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: npm run release:freeze:check
+        run: npm run candidate:freeze:check
 
   windows-native:
     runs-on: windows-2022

--- a/scripts/release-guard.mjs
+++ b/scripts/release-guard.mjs
@@ -352,7 +352,7 @@ function checkContinuousIntegrationWorkflow() {
 	const auditPolicyIndex = workflowText.indexOf('run: npm run release:audit-policy');
 	const validationIndex = workflowText.indexOf('run: npm run check');
 	const releaseGuardIndex = workflowText.indexOf('run: npm run release:guard');
-	const acceptedFreezeIndex = workflowText.indexOf('run: npm run release:freeze:check');
+	const candidateFreezeIndex = workflowText.indexOf('run: npm run candidate:freeze:check');
 
 	assertIncludes(workflow, 'node-version: "24.18.0"', 'CI must use the exact canonical Node release baseline');
 	assertIncludes(workflow, 'npm install --global npm@11.12.1', 'CI must pin the canonical npm version');
@@ -381,6 +381,19 @@ function checkContinuousIntegrationWorkflow() {
 		/run:\s+npm audit(?:\s|$)/u,
 		'CI must not bypass the canonical dependency audit policy with raw npm audit',
 	);
+	assertIncludes(
+		workflow,
+		'run: npm run candidate:freeze:check',
+		'CI main pushes must verify candidate evidence without requiring accepted-release artifact identity',
+	);
+	assertNoMatch(
+		workflow,
+		/run:\s+npm run release:freeze:check/u,
+		'CI must reserve exact accepted-release artifact identity for the release workflow',
+	);
+	if (!/- name: Verify candidate Public V1 freeze\s+if: github\.event_name == 'push' && github\.ref == 'refs\/heads\/main'\s+run: npm run candidate:freeze:check/u.test(workflowText)) {
+		fail('CI must bind the candidate evidence check to exact main-branch pushes');
+	}
 	if (!/- name: Run validation\s+env:\s+OPERON_TASK_FINDER_PERFORMANCE_MODE: diagnostic\s+run: npm run check/u.test(workflowText)) {
 		fail('CI must keep shared-runner Task Finder timings diagnostic while reference runs enforce performance gates');
 	}
@@ -394,9 +407,9 @@ function checkContinuousIntegrationWorkflow() {
 		|| auditPolicyIndex < installIndex
 		|| validationIndex < auditPolicyIndex
 		|| releaseGuardIndex < validationIndex
-		|| acceptedFreezeIndex < releaseGuardIndex
+		|| candidateFreezeIndex < releaseGuardIndex
 	) {
-		fail('CI must run npm ci, audit policy, validation, release guard, and final accepted-freeze check in order');
+		fail('CI must run npm ci, audit policy, validation, release guard, and candidate evidence check in order');
 	}
 }
 


### PR DESCRIPTION
## Summary

- use the candidate evidence freeze check for development commits pushed to `main`
- keep exact accepted-release artifact identity enforcement in the release workflow
- harden the release guard so the candidate check remains bound to exact `main` pushes

## Context

The post-merge CI run for #126 failed with `OPERON_PUBLIC_V1_FREEZE_STALE`. Pull requests correctly allow a new development artifact while preserving accepted evidence, but the `main` push path still required byte-for-byte equality with the published 3.1.0 `main.js`.

This change preserves the intended boundary:

- pull request and development-main validation: candidate evidence integrity
- release publication: exact accepted release artifact identity

Follow-up to #118, #124, and #126.

## Validation

- Node 24.18.0 / npm 11.12.1
- `npm run check:candidate`
- `npm run release:guard`
- `npm run candidate:freeze:check`
- `git diff --check`

Only `.github/workflows/ci.yml` and `scripts/release-guard.mjs` change.
