### PR TITLE
Integrate queued Developer API grant requests safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed **Developer API capability grants** losing or ambiguously recovering durable state across plugin restarts, persistence failures, audit retention, and vault-specific startup reconciliation.
+- Fixed **queued Developer API grant requests** being reported as persistence failures before durable storage completed, while avoiding redundant writes and audit transitions for semantically unchanged pending requests.
 
 ### Validation
 
-- Validated with the complete local candidate check suite, including Developer API grant persistence and recovery, IndexedDB security-audit retention, and release-freeze regression coverage.
+- Validated with the complete local and native Windows candidate check suites, including Developer API grant persistence and recovery, queued-request deduplication, IndexedDB security-audit retention, and release-freeze regression coverage.
 
 ## [3.1.0] - 2026-08-05
 

--- a/scripts/agent-runtime/developer-api/developer-api-grants.test.ts
+++ b/scripts/agent-runtime/developer-api/developer-api-grants.test.ts
@@ -21,6 +21,23 @@ import { DEFAULT_SETTINGS } from '../../../src/types/settings';
 
 const NOW = '2026-07-29T12:00:00.000Z';
 const LATER = '2026-07-29T12:01:00.000Z';
+
+async function waitForGrantWriteStart(started: Promise<void>, label: string): Promise<void> {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		await Promise.race([
+			started,
+			new Promise<never>((_resolve, reject) => {
+				timeout = setTimeout(() => {
+					reject(new Error(`Timed out waiting for ${label}`));
+				}, 2_000);
+			}),
+		]);
+	} finally {
+		if (timeout) clearTimeout(timeout);
+	}
+}
+
 const consumer = (
 	version = '1.2.3',
 ): DeveloperApiConsumerDescriptorV1 => ({
@@ -48,6 +65,48 @@ test('records pending exact capabilities without granting partial access', () =>
 	);
 	assert.equal(evaluation.state, 'pending');
 	assert.deepEqual(evaluation.effectiveCapabilities, []);
+});
+
+test('dedupes semantically unchanged pending requests while persisting canonical supersets', () => {
+	const initial = recordDeveloperApiGrantRequest(
+		createEmptyDeveloperApiGrantPackage(),
+		consumer(),
+		['tasks.read', 'tasks.query'],
+		NOW,
+	);
+	const repeated = recordDeveloperApiGrantRequest(
+		initial,
+		consumer(),
+		['tasks.query', 'tasks.read'],
+		LATER,
+	);
+	const subset = recordDeveloperApiGrantRequest(
+		repeated,
+		consumer(),
+		['tasks.read'],
+		LATER,
+	);
+	assert.deepEqual(repeated, initial);
+	assert.deepEqual(subset, initial);
+	assert.equal(
+		subset.consumersById['consumer.test']?.updatedAt,
+		NOW,
+	);
+
+	const expanded = recordDeveloperApiGrantRequest(
+		subset,
+		consumer(),
+		['tasks.finder', 'tasks.read'],
+		LATER,
+	);
+	assert.deepEqual(
+		expanded.consumersById['consumer.test']?.pendingCapabilities,
+		['tasks.finder', 'tasks.query', 'tasks.read'],
+	);
+	assert.equal(
+		expanded.consumersById['consumer.test']?.updatedAt,
+		LATER,
+	);
 });
 
 test('approves exact scope, preserves it for patch/minor updates, and queues new capabilities', () => {
@@ -381,6 +440,63 @@ test('grant controller keeps a queued first request pending until its durable re
 	assert.deepEqual(settled.effectiveCapabilities, []);
 });
 
+test('grant controller dedupes repeated pending requests across queued and durable state', async () => {
+	let dataPackage = buildOperonDataPackageFromSettings(DEFAULT_SETTINGS);
+	let now = NOW;
+	let updateCalls = 0;
+	let releasePersist: (() => void) | undefined;
+	let markPersistStarted: (() => void) | undefined;
+	const persistStarted = new Promise<void>(resolve => {
+		markPersistStarted = resolve;
+	});
+	const persistGate = new Promise<void>(resolve => {
+		releasePersist = resolve;
+	});
+	const auditEvents: string[] = [];
+	const controller = new DeveloperApiGrantControllerV1({
+		store: {
+			getDataPackage: () => structuredClone(dataPackage),
+			updateDataPackage: async mutator => {
+				updateCalls += 1;
+				markPersistStarted?.();
+				await persistGate;
+				dataPackage = mutator(dataPackage);
+			},
+		},
+		verifier: {
+			verify: () => consumer(),
+			isCurrent: () => true,
+		},
+		audit: {
+			createCorrelationId: () => 'deduped-pending-transition',
+			record: async event => {
+				auditEvents.push(event.phase);
+			},
+		},
+		now: () => new Date(now),
+	});
+
+	controller.recordPending(consumer(), ['tasks.read']);
+	now = LATER;
+	controller.recordPending(consumer(), ['tasks.read']);
+	try {
+		await waitForGrantWriteStart(persistStarted, 'deduped pending grant persistence');
+		assert.equal(updateCalls, 1);
+	} finally {
+		releasePersist?.();
+	}
+	await controller.drain();
+
+	controller.recordPending(consumer(), ['tasks.read']);
+	await controller.drain();
+	assert.equal(updateCalls, 1);
+	assert.deepEqual(auditEvents, ['intent', 'activated']);
+	assert.equal(
+		dataPackage.integrations.developerApi.consumersById['consumer.test']?.updatedAt,
+		NOW,
+	);
+});
+
 test('grant controller keeps a first request suspended when the store cannot persist', async () => {
 	const dataPackage = buildOperonDataPackageFromSettings(DEFAULT_SETTINGS);
 	let updateCalls = 0;
@@ -501,6 +617,207 @@ test('grant controller closes a failed first pending intent and requeues it in t
 		{ phase: 'intent', correlationId: 'pending-transition-2' },
 		{ phase: 'activated', correlationId: 'pending-transition-2' },
 	]);
+});
+
+test('grant controller retries after an audit intent fails before persistence', async () => {
+	let dataPackage = buildOperonDataPackageFromSettings(DEFAULT_SETTINGS);
+	let updateCalls = 0;
+	let failIntent = true;
+	let correlationSequence = 0;
+	const auditEvents: Array<{ phase: string; correlationId: string }> = [];
+	const controller = new DeveloperApiGrantControllerV1({
+		store: {
+			getDataPackage: () => structuredClone(dataPackage),
+			updateDataPackage: async mutator => {
+				updateCalls += 1;
+				dataPackage = mutator(dataPackage);
+			},
+		},
+		verifier: {
+			verify: () => consumer(),
+			isCurrent: () => true,
+		},
+		audit: {
+			createCorrelationId: () => `intent-failure-${++correlationSequence}`,
+			record: async event => {
+				if (event.phase === 'intent' && failIntent) {
+					failIntent = false;
+					throw new Error('injected grant audit intent failure');
+				}
+				auditEvents.push({ phase: event.phase, correlationId: event.correlationId });
+			},
+		},
+		now: () => new Date(NOW),
+	});
+
+	controller.recordPending(consumer(), ['tasks.read']);
+	await assert.rejects(controller.drain(), /injected grant audit intent failure/u);
+	assert.equal(updateCalls, 0);
+	assert.deepEqual(dataPackage.integrations.developerApi.consumersById, {});
+	assert.equal(controller.hasPersistenceError(), true);
+	const recovered = controller.evaluate(consumer(), ['tasks.read']);
+	assert.equal(recovered.state, 'pending');
+	assert.equal(recovered.reason, 'capability-approval-required');
+	assert.deepEqual(recovered.effectiveCapabilities, []);
+	assert.equal(controller.hasPersistenceError(), false);
+
+	controller.recordPending(consumer(), ['tasks.read']);
+	await controller.drain();
+	assert.equal(updateCalls, 1);
+	assert.deepEqual(
+		dataPackage.integrations.developerApi.consumersById['consumer.test']?.pendingCapabilities,
+		['tasks.read'],
+	);
+	assert.deepEqual(auditEvents, [
+		{ phase: 'intent', correlationId: 'intent-failure-2' },
+		{ phase: 'activated', correlationId: 'intent-failure-2' },
+	]);
+});
+
+test('grant controller keeps an activated-audit failure sticky and fenced across restart', async () => {
+	let dataPackage = buildOperonDataPackageFromSettings(DEFAULT_SETTINGS);
+	const auditEvents: Array<{ phase: string; correlationId: string; revision: number }> = [];
+	const controller = new DeveloperApiGrantControllerV1({
+		store: {
+			getDataPackage: () => structuredClone(dataPackage),
+			updateDataPackage: async mutator => {
+				dataPackage = mutator(dataPackage);
+			},
+		},
+		verifier: {
+			verify: () => consumer(),
+			isCurrent: () => true,
+		},
+		audit: {
+			createCorrelationId: () => 'activated-audit-failure',
+			record: async event => {
+				auditEvents.push({
+					phase: event.phase,
+					correlationId: event.correlationId,
+					revision: event.revision,
+				});
+				if (event.phase === 'activated') {
+					throw new Error('injected grant activated audit failure');
+				}
+			},
+		},
+		now: () => new Date(NOW),
+	});
+
+	controller.recordPending(consumer(), ['tasks.read']);
+	await assert.rejects(controller.drain(), /injected grant activated audit failure/u);
+	const durable = dataPackage.integrations.developerApi.consumersById['consumer.test'];
+	assert.equal(durable?.revision, 0);
+	assert.deepEqual(durable?.grantedCapabilities, []);
+	assert.deepEqual(durable?.pendingCapabilities, ['tasks.read']);
+	assert.deepEqual(auditEvents.map(event => event.phase), ['intent', 'activated']);
+	const unmatchedIntent = auditEvents.find(event => event.phase === 'intent');
+	assert.ok(unmatchedIntent);
+	assert.equal(unmatchedIntent.revision, durable?.revision);
+	assert.equal(controller.hasPersistenceError(), true);
+	const sticky = controller.evaluate(consumer(), ['tasks.read']);
+	assert.equal(sticky.state, 'suspended');
+	assert.equal(sticky.reason, 'grant-persistence-unavailable');
+	assert.deepEqual(sticky.effectiveCapabilities, []);
+
+	const restarted = new DeveloperApiGrantControllerV1({
+		store: {
+			getDataPackage: () => structuredClone(dataPackage),
+			updateDataPackage: async mutator => {
+				dataPackage = mutator(dataPackage);
+			},
+		},
+		verifier: {
+			verify: () => consumer(),
+			isCurrent: () => true,
+		},
+		startupAuditRecoveryTransitions: [{
+			consumerId: 'consumer.test',
+			revision: unmatchedIntent.revision,
+		}],
+		now: () => new Date(LATER),
+	});
+	const fenced = restarted.evaluate(consumer(), ['tasks.read']);
+	assert.equal(fenced.state, 'suspended');
+	assert.equal(fenced.reason, 'audit-activation-incomplete');
+	assert.deepEqual(fenced.effectiveCapabilities, []);
+});
+
+test('grant controller remains fail-closed when persistence and its failed audit marker both fail', async () => {
+	const activeGrants = approveDeveloperApiCapabilities(
+		createEmptyDeveloperApiGrantPackage(),
+		consumer(),
+		['tasks.read'],
+		NOW,
+	);
+	let dataPackage = buildOperonDataPackageFromSettings(DEFAULT_SETTINGS, {
+		developerApiGrants: activeGrants,
+	});
+	const auditEvents: Array<{ phase: string; correlationId: string; revision: number }> = [];
+	const controller = new DeveloperApiGrantControllerV1({
+		store: {
+			getDataPackage: () => structuredClone(dataPackage),
+			updateDataPackage: async () => {
+				throw new Error('injected pending grant store failure');
+			},
+		},
+		verifier: {
+			verify: () => consumer(),
+			isCurrent: () => true,
+		},
+		audit: {
+			createCorrelationId: () => 'failed-marker-failure',
+			record: async event => {
+				auditEvents.push({
+					phase: event.phase,
+					correlationId: event.correlationId,
+					revision: event.revision,
+				});
+				if (event.phase === 'failed') {
+					throw new Error('injected failed marker audit failure');
+				}
+			},
+		},
+		now: () => new Date(LATER),
+	});
+
+	controller.recordPending(consumer(), ['tasks.query']);
+	await assert.rejects(controller.drain(), /injected pending grant store failure/u);
+	const durable = dataPackage.integrations.developerApi.consumersById['consumer.test'];
+	assert.equal(durable?.revision, 1);
+	assert.deepEqual(durable?.grantedCapabilities, ['tasks.read']);
+	assert.deepEqual(durable?.pendingCapabilities, []);
+	assert.deepEqual(auditEvents.map(event => event.phase), ['intent', 'failed']);
+	const unmatchedIntent = auditEvents.find(event => event.phase === 'intent');
+	assert.ok(unmatchedIntent);
+	assert.equal(unmatchedIntent.revision, durable?.revision);
+	assert.equal(controller.hasPersistenceError(), true);
+	const sticky = controller.evaluate(consumer(), ['tasks.read', 'tasks.query']);
+	assert.equal(sticky.state, 'suspended');
+	assert.equal(sticky.reason, 'grant-persistence-unavailable');
+	assert.deepEqual(sticky.effectiveCapabilities, []);
+
+	const restarted = new DeveloperApiGrantControllerV1({
+		store: {
+			getDataPackage: () => structuredClone(dataPackage),
+			updateDataPackage: async mutator => {
+				dataPackage = mutator(dataPackage);
+			},
+		},
+		verifier: {
+			verify: () => consumer(),
+			isCurrent: () => true,
+		},
+		startupAuditRecoveryTransitions: [{
+			consumerId: 'consumer.test',
+			revision: unmatchedIntent.revision,
+		}],
+		now: () => new Date(LATER),
+	});
+	const fenced = restarted.evaluate(consumer(), ['tasks.read']);
+	assert.equal(fenced.state, 'suspended');
+	assert.equal(fenced.reason, 'audit-activation-incomplete');
+	assert.deepEqual(fenced.effectiveCapabilities, []);
 });
 
 test('grant controller preserves an unpersisted startup audit suspension after storage recovers', () => {

--- a/scripts/agent-runtime/developer-api/developer-api-grants.test.ts
+++ b/scripts/agent-runtime/developer-api/developer-api-grants.test.ts
@@ -307,6 +307,41 @@ test('grant controller verifies object identity and activates grants only after 
 	);
 });
 
+test('grant controller keeps a queued first request pending without weakening active admission', async () => {
+	let dataPackage = buildOperonDataPackageFromSettings(DEFAULT_SETTINGS);
+	let releasePersist: (() => void) | undefined;
+	const persistGate = new Promise<void>(resolve => {
+		releasePersist = resolve;
+	});
+	const controller = new DeveloperApiGrantControllerV1({
+		store: {
+			getDataPackage: () => structuredClone(dataPackage),
+			updateDataPackage: async mutator => {
+				await persistGate;
+				dataPackage = mutator(dataPackage);
+			},
+		},
+		verifier: {
+			verify: () => consumer(),
+			isCurrent: () => true,
+		},
+		now: () => new Date(NOW),
+	});
+
+	const initial = controller.evaluate(consumer(), ['tasks.read']);
+	assert.equal(initial.state, 'pending');
+	controller.recordPending(consumer(), ['tasks.read']);
+	assert.equal(controller.hasPersistenceError(), true);
+	const queued = controller.evaluate(consumer(), ['tasks.read']);
+	assert.equal(queued.state, 'pending');
+	assert.equal(queued.reason, 'capability-approval-required');
+	assert.deepEqual(queued.pendingCapabilities, ['tasks.read']);
+
+	releasePersist?.();
+	await controller.drain();
+	assert.equal(controller.hasPersistenceError(), false);
+});
+
 test('grant controller audits and persists version acceptance and suspension before readmission', async () => {
 	const initialGrants = approveDeveloperApiCapabilities(
 		createEmptyDeveloperApiGrantPackage(),

--- a/scripts/agent-runtime/developer-api/developer-api.test.ts
+++ b/scripts/agent-runtime/developer-api/developer-api.test.ts
@@ -13,11 +13,20 @@ import {
 	type DeveloperMutationRecoveryRecordV1,
 	type DeveloperMutationRecoveryStoreV1,
 } from '../../../src/agent-runtime/developer-api';
+import {
+	DeveloperApiGrantControllerV1,
+	type DeveloperApiGrantDataStoreV1,
+} from '../../../src/agent-runtime/developer-api/grant-controller';
 import { DeveloperMutationSecurityPolicyV1 } from '../../../src/agent-runtime/developer-api/security';
 import type {
 	DeveloperMutationPreviewInputV1,
 } from '../../../src/agent-runtime/public/v1/developer-api';
 import type { OperonAgentRuntimeCoreV1 } from '../../../src/agent-runtime/runtime/types';
+import {
+	buildOperonDataPackageFromSettings,
+	type OperonDataPackageV1,
+} from '../../../src/storage/operon-data-package';
+import { DEFAULT_SETTINGS } from '../../../src/types/settings';
 
 const allCapabilities: CapabilityAdvertisementV1[] = CAPABILITY_REGISTRY_V1.map(definition => ({
 	id: definition.id,
@@ -350,6 +359,157 @@ function request(capabilities: CapabilityIdV1[] = []) {
 	};
 }
 
+interface GrantWriteGate {
+	readonly started: Promise<void>;
+	release(): void;
+}
+
+async function waitForGrantWriteStart(started: Promise<void>, label: string): Promise<void> {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	try {
+		await Promise.race([
+			started,
+			new Promise<never>((_resolve, reject) => {
+				timeout = setTimeout(() => {
+					reject(new Error(`Timed out waiting for ${label}`));
+				}, 2_000);
+			}),
+		]);
+	} finally {
+		if (timeout) clearTimeout(timeout);
+	}
+}
+
+class GatedGrantDataStore implements DeveloperApiGrantDataStoreV1 {
+	private dataPackage: OperonDataPackageV1;
+	private persistAvailable: boolean;
+	private nextGate: Readonly<{
+		started: () => void;
+		release: Promise<void>;
+	}> | undefined;
+	private nextFailure: Error | undefined;
+	writeCount = 0;
+
+	constructor(dataPackage: OperonDataPackageV1, persistAvailable = true) {
+		this.dataPackage = structuredClone(dataPackage);
+		this.persistAvailable = persistAvailable;
+	}
+
+	canPersist(): boolean {
+		return this.persistAvailable;
+	}
+
+	getDataPackage(): OperonDataPackageV1 {
+		return structuredClone(this.dataPackage);
+	}
+
+	deferNextWrite(): GrantWriteGate {
+		if (this.nextGate) throw new Error('A grant persistence gate is already pending');
+		let markStarted: (() => void) | undefined;
+		let releaseWrite: (() => void) | undefined;
+		const started = new Promise<void>(resolve => {
+			markStarted = resolve;
+		});
+		const release = new Promise<void>(resolve => {
+			releaseWrite = resolve;
+		});
+		this.nextGate = {
+			started: () => markStarted?.(),
+			release,
+		};
+		return {
+			started,
+			release: () => releaseWrite?.(),
+		};
+	}
+
+	failNextWrite(error: Error): void {
+		this.nextFailure = error;
+	}
+
+	snapshot(): OperonDataPackageV1 {
+		return structuredClone(this.dataPackage);
+	}
+
+	async updateDataPackage(
+		mutator: (dataPackage: OperonDataPackageV1) => OperonDataPackageV1,
+	): Promise<void> {
+		this.writeCount += 1;
+		const failure = this.nextFailure;
+		this.nextFailure = undefined;
+		if (failure) throw failure;
+		const gate = this.nextGate;
+		this.nextGate = undefined;
+		if (gate) {
+			gate.started();
+			await gate.release;
+		}
+		this.dataPackage = structuredClone(mutator(structuredClone(this.dataPackage)));
+	}
+}
+
+function realGrantRuntimeHarness(store: GatedGrantDataStore) {
+	const consumerPlugin = {
+		manifest: { id: 'consumer.test', name: 'Consumer Test', version: '1.2.3' },
+	};
+	const controller = new DeveloperApiGrantControllerV1({
+		store,
+		verifier: {
+			verify: candidate => candidate === consumerPlugin
+				? {
+					id: 'consumer.test',
+					name: 'Consumer Test',
+					version: '1.2.3',
+					instanceEpoch: 'real-controller-instance',
+				}
+				: null,
+			isCurrent: candidate => candidate.instanceEpoch === 'real-controller-instance',
+		},
+		now: () => new Date('2026-07-29T00:00:00.000Z'),
+	});
+	const core = runtime();
+	const access = (capabilities: CapabilityIdV1[]) => getOperonDeveloperApiV1(
+		core,
+		consumerPlugin,
+		request(capabilities),
+		{
+			isDesktopAvailable: () => true,
+			isHostVersionSupported: () => true,
+			lifecyclePhase: () => 'ready',
+			retryAfterMs: () => undefined,
+			lifecycleError: () => undefined,
+			isCoreActive: candidate => candidate === core,
+			grantController: controller,
+			recoveryStore: new MemoryDeveloperRecoveryStore(),
+			createSessionId: () => 'real-controller-session',
+			now: () => new Date('2026-07-29T00:00:00.000Z'),
+		},
+	);
+	return { access, controller };
+}
+
+function assertPendingNonAuthorizing(
+	result: ReturnType<ReturnType<typeof realGrantRuntimeHarness>['access']>,
+): void {
+	assert.equal(result.ok, false);
+	assert.equal(result.ok ? undefined : result.error.code, 'authority-insufficient');
+	assert.equal(result.ok ? undefined : result.error.details?.grantState, 'pending');
+	assert.equal(
+		result.ok ? undefined : result.error.details?.reasonCode,
+		'capability-approval-required',
+	);
+	assert.deepEqual(
+		result.ok ? undefined : result.error.details?.pendingCapabilities,
+		['tasks.read'],
+	);
+	assert.equal(result.status.grant?.state, 'pending');
+	assert.deepEqual(result.status.grant?.effectiveCapabilities, []);
+	assert.equal(result.status.authority, 'revoked');
+	assert.equal(result.status.admission.reads, false);
+	assert.equal(result.status.admission.writes, false);
+	assert.equal('api' in result, false);
+}
+
 test('strictly rejects unknown, duplicate, malformed, and disjoint access requests', () => {
 	const { access } = harness();
 	const extra = access({ ...request(), consumerId: 'forbidden' });
@@ -471,6 +631,110 @@ test('keeps queued grant states coherent without granting Runtime authority', ()
 	assert.equal(revoked.ok ? undefined : revoked.error.details?.grantState, 'revoked');
 	assert.equal(revoked.ok ? undefined : revoked.error.details?.reasonCode, 'revoked');
 	assert.equal(revoked.status.grant?.state, 'revoked');
+});
+
+test('keeps real Runtime authority closed until pending and approved grants are durable', async () => {
+	const store = new GatedGrantDataStore(buildOperonDataPackageFromSettings(DEFAULT_SETTINGS));
+	const pendingGate = store.deferNextWrite();
+	const { access, controller } = realGrantRuntimeHarness(store);
+	const mixedCapabilities: CapabilityIdV1[] = ['tasks.read', 'system.health'];
+
+	const initial = access(mixedCapabilities);
+	assertPendingNonAuthorizing(initial);
+	assert.deepEqual(initial.status.grant?.requestedCapabilities, mixedCapabilities);
+	try {
+		await waitForGrantWriteStart(pendingGate.started, 'initial Runtime grant persistence');
+		assert.equal(controller.hasPersistenceError(), true);
+		const queued = access(mixedCapabilities);
+		assertPendingNonAuthorizing(queued);
+		assert.deepEqual(queued.status.grant?.requestedCapabilities, mixedCapabilities);
+		assert.equal(store.writeCount, 1);
+	} finally {
+		pendingGate.release();
+	}
+	await controller.drain();
+	const durablePending = store.snapshot().integrations.developerApi.consumersById['consumer.test'];
+	assert.deepEqual(durablePending?.grantedCapabilities, []);
+	assert.deepEqual(durablePending?.pendingCapabilities, ['tasks.read']);
+	assertPendingNonAuthorizing(access(['tasks.read']));
+
+	const approvalGate = store.deferNextWrite();
+	const approval = controller.approvePending('consumer.test', ['tasks.read']);
+	try {
+		await waitForGrantWriteStart(approvalGate.started, 'Runtime grant approval persistence');
+		const gatedActive = access(['tasks.read']);
+		assert.equal(gatedActive.ok, false);
+		assert.equal(gatedActive.ok ? undefined : gatedActive.error.code, 'authority-insufficient');
+		assert.equal(gatedActive.ok ? undefined : gatedActive.error.details?.grantState, 'suspended');
+		assert.equal(
+			gatedActive.ok ? undefined : gatedActive.error.details?.reasonCode,
+			'grant-persistence-unavailable',
+		);
+		assert.equal(gatedActive.status.grant?.state, 'suspended');
+		assert.deepEqual(gatedActive.status.grant?.effectiveCapabilities, []);
+		assert.equal(gatedActive.status.admission.reads, false);
+		assert.equal(gatedActive.status.admission.writes, false);
+		assert.equal('api' in gatedActive, false);
+	} finally {
+		approvalGate.release();
+	}
+	await approval;
+
+	const durableActive = store.snapshot().integrations.developerApi.consumersById['consumer.test'];
+	assert.equal(durableActive?.state, 'active');
+	assert.deepEqual(durableActive?.grantedCapabilities, ['tasks.read']);
+	assert.deepEqual(durableActive?.pendingCapabilities, []);
+	const active = access(['tasks.read']);
+	assert.equal(active.ok, true);
+	if (!active.ok) return;
+	assert.equal(active.status.authority, 'granted');
+	assert.equal(active.status.grant?.state, 'active');
+	assert.deepEqual(active.status.grant?.effectiveCapabilities, ['tasks.read']);
+	assert.equal(active.api.hasCapability('tasks.read'), true);
+	assert.equal(store.writeCount, 2);
+});
+
+test('keeps the real controller and Runtime fail-closed when persistence is unavailable', async () => {
+	const store = new GatedGrantDataStore(
+		buildOperonDataPackageFromSettings(DEFAULT_SETTINGS),
+		false,
+	);
+	const { access, controller } = realGrantRuntimeHarness(store);
+	const unavailable = access(['tasks.read']);
+	assert.equal(unavailable.ok, false);
+	assert.equal(unavailable.ok ? undefined : unavailable.error.code, 'authority-insufficient');
+	assert.equal(unavailable.ok ? undefined : unavailable.error.details?.grantState, 'suspended');
+	assert.equal(
+		unavailable.ok ? undefined : unavailable.error.details?.reasonCode,
+		'grant-persistence-unavailable',
+	);
+	assert.equal(unavailable.status.grant?.state, 'suspended');
+	assert.deepEqual(unavailable.status.grant?.effectiveCapabilities, []);
+	assert.equal(unavailable.status.admission.reads, false);
+	assert.equal(unavailable.status.admission.writes, false);
+	assert.equal('api' in unavailable, false);
+	await controller.drain();
+	assert.equal(store.writeCount, 0);
+	assert.deepEqual(store.snapshot().integrations.developerApi.consumersById, {});
+});
+
+test('retries a failed real pending write without exposing Runtime authority', async () => {
+	const store = new GatedGrantDataStore(buildOperonDataPackageFromSettings(DEFAULT_SETTINGS));
+	store.failNextWrite(new Error('injected real pending grant write failure'));
+	const { access, controller } = realGrantRuntimeHarness(store);
+
+	assertPendingNonAuthorizing(access(['tasks.read']));
+	await assert.rejects(controller.drain(), /injected real pending grant write failure/u);
+	assert.equal(store.writeCount, 1);
+	assert.deepEqual(store.snapshot().integrations.developerApi.consumersById, {});
+
+	assertPendingNonAuthorizing(access(['tasks.read']));
+	await controller.drain();
+	assert.equal(store.writeCount, 2);
+	const durable = store.snapshot().integrations.developerApi.consumersById['consumer.test'];
+	assert.deepEqual(durable?.grantedCapabilities, []);
+	assert.deepEqual(durable?.pendingCapabilities, ['tasks.read']);
+	assertPendingNonAuthorizing(access(['tasks.read']));
 });
 
 test('fails access closed off desktop, without a core, while booting, and on terminal startup failure', () => {

--- a/scripts/agent-runtime/developer-api/developer-api.test.ts
+++ b/scripts/agent-runtime/developer-api/developer-api.test.ts
@@ -225,6 +225,7 @@ function harness(options: {
 	error?: StructuredErrorV1;
 	active?: { value: boolean };
 	grantState?: { value: 'pending' | 'active' | 'suspended' | 'revoked'; revision: number };
+	grantPersistenceUnavailable?: boolean;
 	consumerCurrent?: { value: boolean };
 	mutationSecurityPolicy?: DeveloperMutationSecurityPolicyV1;
 	recoveryStore?: DeveloperMutationRecoveryStoreV1;
@@ -266,7 +267,7 @@ function harness(options: {
 						: 'consumer-major-version-changed' as const,
 		}),
 		recordPending: () => undefined,
-		hasPersistenceError: () => false,
+		hasPersistenceError: () => options.grantPersistenceUnavailable ?? false,
 	};
 	const accessAs = (consumer: typeof consumerPlugin, request: unknown) => getOperonDeveloperApiV1(core, consumer, request, {
 		isDesktopAvailable: () => options.desktop ?? true,
@@ -422,6 +423,16 @@ test('fails exact-scope access closed while pending and revokes a live session s
 	});
 	assert.equal(refused.ok, false);
 	assert.equal(refused.ok ? undefined : refused.error.code, 'authority-insufficient');
+});
+
+test('keeps a first-request grant pending while its persistence write is queued', () => {
+	const pending = harness({
+		grantState: { value: 'pending', revision: 1 },
+		grantPersistenceUnavailable: true,
+	}).access(request(['tasks.read']));
+	assert.equal(pending.ok, false);
+	assert.equal(pending.ok ? undefined : pending.error.code, 'authority-insufficient');
+	assert.equal(pending.status.grant?.state, 'pending');
 });
 
 test('fails access closed off desktop, without a core, while booting, and on terminal startup failure', () => {

--- a/src/agent-runtime/developer-api/grant-controller.ts
+++ b/src/agent-runtime/developer-api/grant-controller.ts
@@ -108,7 +108,10 @@ export class DeveloperApiGrantControllerV1 {
 	): DeveloperApiGrantEvaluationV1 {
 		this.observeConsumerVersion(consumer, requestedCapabilities);
 		const evaluation = evaluateDeveloperApiGrant(this.grants, consumer, requestedCapabilities);
-		if (!this.hasPersistenceError()) return evaluation;
+		if (
+			this.persistenceError === null
+			&& (evaluation.state !== 'active' || this.pendingWrites === 0)
+		) return evaluation;
 		return {
 			...evaluation,
 			state: 'suspended',

--- a/src/agent-runtime/developer-api/grants.ts
+++ b/src/agent-runtime/developer-api/grants.ts
@@ -211,7 +211,33 @@ export function recordDeveloperApiGrantRequest(
 		createdAt: reconciledExisting?.createdAt ?? nowIso,
 		updatedAt: nowIso,
 	};
+	if (reconciledExisting && grantRecordsEqualExceptUpdatedAt(next, reconciledExisting)) {
+		return reconciled;
+	}
 	return replaceRecord(reconciled, next);
+}
+
+function grantRecordsEqualExceptUpdatedAt(
+	left: DeveloperApiGrantRecordV1,
+	right: DeveloperApiGrantRecordV1,
+): boolean {
+	return left.consumerId === right.consumerId
+		&& left.consumerName === right.consumerName
+		&& left.consumerVersion === right.consumerVersion
+		&& left.observedConsumerVersion === right.observedConsumerVersion
+		&& left.approvedMajorVersion === right.approvedMajorVersion
+		&& left.state === right.state
+		&& left.suspensionReason === right.suspensionReason
+		&& left.revision === right.revision
+		&& left.createdAt === right.createdAt
+		&& left.grantedCapabilities.length === right.grantedCapabilities.length
+		&& left.grantedCapabilities.every((capability, index) => (
+			capability === right.grantedCapabilities[index]
+		))
+		&& left.pendingCapabilities.length === right.pendingCapabilities.length
+		&& left.pendingCapabilities.every((capability, index) => (
+			capability === right.pendingCapabilities[index]
+		));
 }
 
 export function suspendDeveloperApiGrantForAuditRecovery(

--- a/src/agent-runtime/developer-api/runtime.ts
+++ b/src/agent-runtime/developer-api/runtime.ts
@@ -1116,7 +1116,7 @@ function evaluateSessionGrant(
 		};
 	}
 	const grant = options.grantController.evaluate(consumer, required);
-	if (options.grantController.hasPersistenceError()) {
+	if (grant.state !== 'pending' && options.grantController.hasPersistenceError()) {
 		return {
 			...grant,
 			state: 'suspended',


### PR DESCRIPTION
## Summary

Integrates and supersedes the implementation proposed in #119 by @optimikelabs. The source PR conflicts with current `main` after the intervening integration and CI updates, so this branch preserves the original commits and authorship in merge ancestry while applying the fix narrowly on the current base.

The change keeps a queued first Developer API grant request `pending` and non-authorizing, preserves the durability barrier for active grants, fails closed on real persistence and audit failures, and removes redundant persistence/audit churn for semantically unchanged pending requests.

## Provenance

- Source PR: #119
- Source head: `99c7cb71f4956830974303408e8fb7ff8d9f1765`
- Integration base: `a703551b3cb5f00d5499d831fafee79e318fd501`
- Provenance merge: `ab671ea0e7d9b1aea6c7058ea4be12ba252deca7`
- Validated candidate: `4aafb5e1d22b3d92033377ab4fbf2c3c11eb4b9b`

Mickaël Ahouansou's original commits remain intact as the second-parent ancestry of the provenance merge. The follow-up commit contains the current-main hardening and expanded recovery coverage.

## Scope

The net diff is limited to five Developer API implementation/test files. There are no public API, DTO, schema, capability, CLI, package, manifest, styles, documentation, changelog, or release-input changes.

## Validation

- Canonical Node `24.18.0` / npm `11.12.1`
- Release audit policy passed
- Full candidate validation passed
- Developer API `84/84`; security `6/6`; integration `6/6`; native consumer `7/7`
- Runtime validation and integration `10/10`
- Strict lint, production builds, release guard, and candidate freeze passed
- Base/candidate bundle analysis passed with no forbidden inputs
- `main.js`: `4,341,038` bytes, SHA-256 `16ee6827dfa01813a4c561162880686708b18656e7602841d7ba5e72f5f9a535`, delta `+737` bytes (`+0.016980%`)
- Correctness, persistence/recovery, test-validity, bundle/performance, and scope/provenance reviews found no actionable issues

This draft exists to obtain exact-head Ubuntu, native Windows 2022, and CodeQL evidence. It must not be merged before the formal candidate deployment and explicit manual acceptance stages.

Closes #114
