### PR TITLE
test: fully escape storage path regex

### DIFF
--- a/scripts/agent-runtime/developer-api/operon-storage-grant-persistence.test.ts
+++ b/scripts/agent-runtime/developer-api/operon-storage-grant-persistence.test.ts
@@ -333,7 +333,7 @@ function assertAllowedFixtureFiles(
 		);
 	}
 	for (const operation of durable.operations) {
-		const canonical = CANONICAL_DATA_PATH.replace(/\./gu, '\\.');
+		const canonical = CANONICAL_DATA_PATH.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&');
 		const backup = `${canonical}\\.invalid-\\d+\\.bak`;
 		const backupTemporary = `${backup}\\.tmp-\\d+-[a-z0-9]+`;
 		const allowed = [


### PR DESCRIPTION
## What changed

- escape every regular-expression metacharacter when constructing the canonical storage-path matcher in the Developer API persistence test
- keep the change limited to the CodeQL finding in `operon-storage-grant-persistence.test.ts`

## Why

CodeQL alert #10 reports incomplete sanitization because the previous expression escaped only periods and left backslashes and other regex metacharacters unescaped. The current path is a trusted test constant, so this is defensive test hardening rather than a production vulnerability.

## Impact

No production behavior, Runtime contract, persisted data, or build artifact changes. The test matcher is now robust if the canonical path changes in the future.

## Validation

- `npm run agent-runtime:developer-api` — 103 tests passed
- `npm run lint:strict` — passed
- `git diff --check` — passed