### PR TITLE
Small fixes: Calendar, Filter popovers, and Table datetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### New
+
+- Added a responsive **Filter pop-over to Kanban**, allowing the selected preset filter to be edited or a new filter to be created and attached without leaving the board.
+
+### Improved
+
+- Improved **Filter pop-over consistency** across workspace Tables, embedded Tables, and Kanban with a shared lifecycle and visuals aligned with the full Filter editor.
+- Improved completed-task date correction in the Calendar by allowing tasks in the **Finished row** to be dragged to another completion date.
+- Improved Calendar **In Day time chips** so their background and border colors follow the task’s configured color instead of the interface accent.
+- Standardized built-in and custom **datetime columns in Tables**: detailed cells show readable date and seconds, compact cells show hours and minutes, hover tooltips use the detailed format, and both modes respect the selected 12-hour or 24-hour preference with appropriate default column widths.
+- Extended the **Table task contextual menu** to Task Type icons while preserving their existing click-to-open behavior.
+
+### Fixed
+
+- Fixed multi-day **Calendar All Day tasks** being unavailable for drag-and-drop while preserving their duration and the grabbed-day offset.
+- Removed the redundant **“Go to Task” tooltip** from inline tasks in Reading Mode.
+
 ### Validation
 
 ## [3.1.0] - 2026-08-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed **Developer API capability grants** losing or ambiguously recovering durable state across plugin restarts, persistence failures, audit retention, and vault-specific startup reconciliation.
+- Fixed **queued Developer API grant requests** being reported as persistence failures before durable storage completed, while avoiding redundant writes and audit transitions for semantically unchanged pending requests.
 - Fixed multi-day **Calendar All Day tasks** being unavailable for drag-and-drop while preserving their duration and the grabbed-day offset.
 - Removed the redundant **“Go to Task” tooltip** from inline tasks in Reading Mode.
 
 ### Validation
+
+- Validated with the complete local and native Windows candidate check suites, including Developer API grant persistence and recovery, queued-request deduplication, IndexedDB security-audit retention, and release-freeze regression coverage.
 
 ## [3.1.0] - 2026-08-05
 

--- a/main.ts
+++ b/main.ts
@@ -578,6 +578,7 @@ import {
 	KanbanCellActionId,
 	KanbanLeafState,
 	KanbanPreset,
+	type KanbanPresetFilterCommitRequest,
 	buildKanbanLaneCollapseScopeKey,
 	buildKanbanStatusCollapseScopeKey,
 	cloneDefaultKanbanPresets,
@@ -1557,6 +1558,37 @@ export default class OperonPlugin extends Plugin {
 	private async saveFilterSetAndRefresh(filterSet: FilterSet): Promise<void> {
 		await this.storage.filters.upsert(filterSet);
 		this.syncFilterSetsFromStore();
+		this.refreshViews();
+	}
+
+	private async commitKanbanPresetFilter(request: KanbanPresetFilterCommitRequest): Promise<void> {
+		const preset = this.settings.kanbanPresets.find(entry => entry.id === request.presetId) ?? null;
+		if (!preset) throw new Error('Operon: Kanban preset is no longer available.');
+		if (preset.filterSetId !== request.expectedPresetFilterSetId) {
+			throw new Error('Operon: Kanban preset filter changed while the editor was open.');
+		}
+		if (request.sourceFilterSetId && (
+			request.sourceFilterSetId !== request.expectedPresetFilterSetId
+			|| request.filterSet.id !== request.sourceFilterSetId
+		)) {
+			throw new Error('Operon: Kanban filter edit no longer matches the selected preset.');
+		}
+
+		await this.storage.filters.upsert(request.filterSet);
+		this.syncFilterSetsFromStore();
+		if (request.sourceFilterSetId) {
+			this.refreshViews();
+			return;
+		}
+
+		const previousFilterSetId = preset.filterSetId;
+		preset.filterSetId = request.filterSet.id;
+		try {
+			await this.storage.saveSettings();
+		} catch (error) {
+			preset.filterSetId = previousFilterSetId;
+			throw error;
+		}
 		this.refreshViews();
 	}
 
@@ -11995,6 +12027,7 @@ export default class OperonPlugin extends Plugin {
 						await this.toggleTimerForTask(operonId, 'command');
 					},
 					getTrackingSignature: () => this.timeTracker.getActiveOperonId() ?? '',
+					onCommitPresetFilter: request => this.commitKanbanPresetFilter(request),
 					onOpenPresetSettings: (presetId) => {
 						const preset = this.settings.kanbanPresets.find(entry => entry.id === presetId) ?? null;
 						new KanbanPresetQuickSettingsModal(this.app, {

--- a/main.ts
+++ b/main.ts
@@ -642,6 +642,7 @@ import {
 	PriorityRenamePreview,
 } from './src/core/priority-rename-migration';
 import { CalendarView, CALENDAR_VIEW_TYPE, type CalendarTrackedSessionRef } from './src/ui/calendar/calendar-view';
+import { buildFinishedDateMovePayload } from './src/ui/calendar/all-day-drag';
 import {
 	filterTasksForCalendar,
 } from './src/systems/calendar-filter-materialization';
@@ -11875,6 +11876,7 @@ export default class OperonPlugin extends Plugin {
 					onAllDaySlotSelection: (selection) => this.handleCalendarSlotSelection(leaf, selection),
 					onAllDayScheduledMove: (taskId, selection) => this.handleCalendarScheduledMove(taskId, selection),
 					onAllDayScheduledResizeRight: (taskId, selection) => this.handleCalendarScheduledResizeRight(taskId, selection),
+					onFinishedItemMove: (taskId, dateCompleted) => this.handleCalendarFinishedMove(taskId, dateCompleted),
 					onAllDayItemDropToTimed: (taskId, selection, sourcePayload) => this.handleCalendarAllDayDropToTimed(taskId, selection, sourcePayload),
 					onItemAction: (taskId, actionId, context, invocation) => this.handleContextualMenuAction(taskId, actionId, context, invocation),
 					onOpenTaskSource: openTaskSourceInNewTab,
@@ -13092,6 +13094,22 @@ export default class OperonPlugin extends Plugin {
 			changedKeys,
 		});
 		this.refreshViews();
+	}
+
+	private async handleCalendarFinishedMove(taskId: string, dateCompleted: string): Promise<boolean> {
+		const task = this.indexer.getTask(taskId);
+		if (!task || task.checkbox !== 'done') return false;
+		const payload = buildFinishedDateMovePayload(
+			(task.fieldValues['dateCompleted'] ?? '').trim(),
+			dateCompleted,
+		);
+		if (!payload) return false;
+
+		const updated = await this.updateTaskFieldsAndRefresh(task.operonId, payload, {
+			changedKeys: ['dateCompleted'],
+		});
+		this.refreshViews();
+		return updated;
 	}
 
 	private async handleCalendarTimedMove(

--- a/main.ts
+++ b/main.ts
@@ -1577,17 +1577,21 @@ export default class OperonPlugin extends Plugin {
 		await this.storage.filters.upsert(request.filterSet);
 		this.syncFilterSetsFromStore();
 		if (request.sourceFilterSetId) {
+			const currentPreset = this.settings.kanbanPresets.find(entry => entry.id === request.presetId) ?? null;
+			if (!currentPreset || currentPreset.filterSetId !== request.expectedPresetFilterSetId) {
+				throw new Error('Operon: Kanban preset filter changed while the filter was saving.');
+			}
 			this.refreshViews();
 			return;
 		}
 
-		const previousFilterSetId = preset.filterSetId;
-		preset.filterSetId = request.filterSet.id;
-		try {
-			await this.storage.saveSettings();
-		} catch (error) {
-			preset.filterSetId = previousFilterSetId;
-			throw error;
+		const attached = await this.storage.attachKanbanPresetFilterIfUnchanged(
+			request.presetId,
+			request.expectedPresetFilterSetId,
+			request.filterSet.id,
+		);
+		if (!attached) {
+			throw new Error('Operon: Kanban preset filter changed while the filter was saving.');
 		}
 		this.refreshViews();
 	}

--- a/src/storage/operon-storage.ts
+++ b/src/storage/operon-storage.ts
@@ -615,6 +615,29 @@ export class OperonStorage {
 		});
 	}
 
+	async attachKanbanPresetFilterIfUnchanged(
+		presetId: string,
+		expectedFilterSetId: string | null,
+		nextFilterSetId: string,
+	): Promise<boolean> {
+		return this.enqueueSettingsTransaction(async () => {
+			const preset = this.settings.kanbanPresets.find(entry => entry.id === presetId) ?? null;
+			if (!preset || preset.filterSetId !== expectedFilterSetId) return false;
+			preset.filterSetId = nextFilterSetId;
+			try {
+				await this.persistSettings({ forceRecoveredWrite: true });
+			} catch (error) {
+				const currentPreset = this.settings.kanbanPresets.find(entry => entry.id === presetId) ?? null;
+				if (currentPreset?.filterSetId === nextFilterSetId) {
+					currentPreset.filterSetId = expectedFilterSetId;
+					this.syncKanbanPresetStoreFromSettings();
+				}
+				throw error;
+			}
+			return this.settings.kanbanPresets.find(entry => entry.id === presetId)?.filterSetId === nextFilterSetId;
+		});
+	}
+
 	private async persistSettings(_options: RecoveredStoreWriteOptions): Promise<void> {
 		if (!this.dataPackageStore.canPersist()) {
 			if (_options.forceRecoveredWrite === false) return;

--- a/src/types/kanban.ts
+++ b/src/types/kanban.ts
@@ -4,6 +4,7 @@ import type { ProjectSerialDisplay } from '../core/project-serials';
 import type { InlineRepeatCompletionMode } from '../storage/repeat-series-store';
 import type { IndexedTask } from './fields';
 import type { RelatedViewCreateTarget, RelatedViewOpenTarget } from './related-views';
+import type { FilterSet } from './settings';
 
 export type BuiltInKanbanSwimlaneBy =
 	| 'priority'
@@ -107,6 +108,13 @@ export interface KanbanCellActionContext {
 	pipelineId: string | null;
 }
 
+export interface KanbanPresetFilterCommitRequest {
+	presetId: string;
+	filterSet: FilterSet;
+	sourceFilterSetId: string | null;
+	expectedPresetFilterSetId: string | null;
+}
+
 export interface KanbanViewCallbacks {
 	getManualOrder?: (presetId: string) => Record<string, string[]>;
 	onCardDrop?: (context: KanbanDropContext) => void | Promise<void>;
@@ -114,6 +122,7 @@ export interface KanbanViewCallbacks {
 	onOpenTaskSource?: (taskId: string) => void | Promise<void>;
 	onStatusIconClick?: (taskId: string) => void | Promise<void>;
 	onOpenPresetSettings?: (presetId: string) => void | Promise<void>;
+	onCommitPresetFilter?: (request: KanbanPresetFilterCommitRequest) => Promise<void>;
 	onOpenRelatedView?: (target: RelatedViewOpenTarget) => void | Promise<void>;
 	onCreateRelatedView?: (target: RelatedViewCreateTarget) => void | Promise<void>;
 	onCellAction?: (context: KanbanCellActionContext) => void | Promise<void>;

--- a/src/ui/calendar/all-day-drag.ts
+++ b/src/ui/calendar/all-day-drag.ts
@@ -13,6 +13,28 @@ export function canEditAllDayCalendarItemPlacement(
 		&& item.repeatRef?.projectionKind !== 'doneRolling';
 }
 
+export function canEditFinishedCalendarItemPlacement(
+	item: Pick<CalendarItem, 'kind' | 'origin' | 'repeatRef'> & {
+		renderSnapshot: Pick<CalendarItem['renderSnapshot'], 'checkbox' | 'fieldValues'>;
+	},
+): boolean {
+	return item.kind === 'finishedMarker'
+		&& item.origin === 'materialized'
+		&& item.repeatRef?.projectionKind !== 'doneRolling'
+		&& item.renderSnapshot.checkbox === 'done'
+		&& parseDateKey(item.renderSnapshot.fieldValues['dateCompleted'] ?? '') !== null;
+}
+
+export function buildFinishedDateMovePayload(
+	currentDate: string,
+	targetDate: string,
+): { dateCompleted: string } | null {
+	if (!parseDateKey(currentDate) || !parseDateKey(targetDate) || currentDate === targetDate) {
+		return null;
+	}
+	return { dateCompleted: targetDate };
+}
+
 export function resolveAnchoredAllDayMoveRange(
 	startDate: string,
 	endDate: string,

--- a/src/ui/calendar/all-day-drag.ts
+++ b/src/ui/calendar/all-day-drag.ts
@@ -1,0 +1,51 @@
+import { shiftCalendarDateKey } from '../../systems/calendar-query';
+import type { CalendarItem } from '../../types/calendar';
+
+export interface AnchoredAllDayMoveRange {
+	startDate: string;
+	endDate: string;
+}
+
+export function canEditAllDayCalendarItemPlacement(
+	item: Pick<CalendarItem, 'origin' | 'repeatRef'>,
+): boolean {
+	return item.origin !== 'external'
+		&& item.repeatRef?.projectionKind !== 'doneRolling';
+}
+
+export function resolveAnchoredAllDayMoveRange(
+	startDate: string,
+	endDate: string,
+	anchorDate: string,
+	targetDate: string,
+): AnchoredAllDayMoveRange {
+	const deltaDays = diffCalendarDateKeys(anchorDate, targetDate);
+	return {
+		startDate: shiftCalendarDateKey(startDate, deltaDays),
+		endDate: shiftCalendarDateKey(endDate, deltaDays),
+	};
+}
+
+function diffCalendarDateKeys(fromDate: string, toDate: string): number {
+	const from = parseDateKey(fromDate);
+	const to = parseDateKey(toDate);
+	if (!from || !to) return 0;
+	return Math.round((to.getTime() - from.getTime()) / 86400000);
+}
+
+function parseDateKey(dateKey: string): Date | null {
+	const match = /^(\d{4})-(\d{2})-(\d{2})$/u.exec(dateKey);
+	if (!match) return null;
+	const year = Number.parseInt(match[1], 10);
+	const month = Number.parseInt(match[2], 10);
+	const day = Number.parseInt(match[3], 10);
+	const parsed = new Date(year, month - 1, day, 12, 0, 0, 0);
+	if (
+		parsed.getFullYear() !== year
+		|| parsed.getMonth() !== month - 1
+		|| parsed.getDate() !== day
+	) {
+		return null;
+	}
+	return parsed;
+}

--- a/src/ui/calendar/calendar-view.ts
+++ b/src/ui/calendar/calendar-view.ts
@@ -24,6 +24,10 @@ import {
 	CALENDAR_TIMED_SNAP_MINUTES,
 } from '../../systems/calendar-writeback';
 import { parseLocalDatetime } from '../../systems/tracker-utils';
+import {
+	canEditAllDayCalendarItemPlacement,
+	resolveAnchoredAllDayMoveRange,
+} from './all-day-drag';
 import { getConfiguredKeyMappingIcon } from '../../core/key-mapping-icons';
 import { t } from '../../core/i18n';
 import { getAppLocale } from '../../core/obsidian-app';
@@ -8393,7 +8397,7 @@ export class CalendarView extends ItemView {
 					this.bindHoverMenuTarget(hoverTrigger, placement.item);
 				}
 				if (!isDueTrack) {
-					if (!this.canEditCalendarItemPlacement(placement.item)) {
+					if (!canEditAllDayCalendarItemPlacement(placement.item)) {
 						itemEl.addClass('is-read-only');
 						this.bindPrimaryItemClick(itemEl, placement.item);
 					} else {
@@ -9653,14 +9657,18 @@ export class CalendarView extends ItemView {
 					}
 				} else {
 					const column = this.resolveAllDayColumnIndex(body, clientX, visibleDates.length);
-					const span = placement.endColumn - placement.startColumn;
-					const delta = column - dragState.anchorColumn;
-					const maxStart = Math.max(0, visibleDates.length - span - 1);
-					const nextStart = Math.max(0, Math.min(maxStart, placement.startColumn + delta));
-					dragState.currentStartColumn = nextStart;
-					dragState.currentEndColumn = nextStart + span;
-					dragState.currentStartDate = visibleDates[nextStart] ?? placement.item.startDate;
-					dragState.currentEndDate = visibleDates[nextStart + span] ?? placement.item.endDate;
+					const targetDate = visibleDates[column] ?? dragState.anchorDate;
+					const nextRange = resolveAnchoredAllDayMoveRange(
+						placement.item.startDate,
+						placement.item.endDate,
+						dragState.anchorDate,
+						targetDate,
+					);
+					const columnDelta = column - dragState.anchorColumn;
+					dragState.currentStartColumn = placement.startColumn + columnDelta;
+					dragState.currentEndColumn = placement.endColumn + columnDelta;
+					dragState.currentStartDate = nextRange.startDate;
+					dragState.currentEndDate = nextRange.endDate;
 				}
 			} else {
 				if (dropContextMode === 'multiWeek') {

--- a/src/ui/calendar/calendar-view.ts
+++ b/src/ui/calendar/calendar-view.ts
@@ -25,7 +25,9 @@ import {
 } from '../../systems/calendar-writeback';
 import { parseLocalDatetime } from '../../systems/tracker-utils';
 import {
+	buildFinishedDateMovePayload,
 	canEditAllDayCalendarItemPlacement,
+	canEditFinishedCalendarItemPlacement,
 	resolveAnchoredAllDayMoveRange,
 } from './all-day-drag';
 import { getConfiguredKeyMappingIcon } from '../../core/key-mapping-icons';
@@ -730,6 +732,7 @@ export interface CalendarViewCallbacks {
 	onAllDaySlotSelection?: (selection: CalendarSlotSelection) => void | Promise<void>;
 	onAllDayScheduledMove?: (taskId: string, selection: CalendarSlotSelection) => void | Promise<void>;
 	onAllDayScheduledResizeRight?: (taskId: string, selection: CalendarSlotSelection) => void | Promise<void>;
+	onFinishedItemMove?: (taskId: string, dateCompleted: string) => CalendarDropCallbackResult | Promise<CalendarDropCallbackResult>;
 	onTimedItemDropToAllDay?: (taskId: string, selection: CalendarSlotSelection) => void | Promise<void>;
 	onAllDayItemDropToTimed?: (taskId: string, selection: CalendarSlotSelection, sourcePayload?: CalendarDropSourcePayload) => CalendarDropCallbackResult | Promise<CalendarDropCallbackResult>;
 	onItemAction?: ContextualMenuActionHandler;
@@ -865,8 +868,10 @@ export class CalendarView extends ItemView {
 	private renderFrame: number | null = null;
 	private preserveScrollOnNextRender = false;
 	private allDayDropContext: CalendarAllDayDropContext | null = null;
+	private finishedDropContext: CalendarAllDayDropContext | null = null;
 	private timedDropContext: CalendarTimedDropContext | null = null;
 	private multiWeekAllDayDropContexts: CalendarAllDayDropContext[] = [];
+	private multiWeekFinishedDropContexts: CalendarAllDayDropContext[] = [];
 	private multiWeekInDayDropContexts: CalendarMultiWeekInDayDropContext[] = [];
 	private expandedHiddenTimeKey: string | null = null;
 	private lastRenderPresetKey: string | null = null;
@@ -1798,8 +1803,10 @@ export class CalendarView extends ItemView {
 		this.sidebarTaskPoolListEl = null;
 		this.mobileTimeGridScrollEl = null;
 		this.allDayDropContext = null;
+		this.finishedDropContext = null;
 		this.timedDropContext = null;
 		this.multiWeekAllDayDropContexts = [];
+		this.multiWeekFinishedDropContexts = [];
 		this.multiWeekInDayDropContexts = [];
 		const {
 			settings,
@@ -8299,13 +8306,13 @@ export class CalendarView extends ItemView {
 	): void {
 		const section = container.createDiv('operon-calendar-all-day-section');
 		if (showAllDayLane) {
-			this.renderAllDayTrack(section, t('calendar', 'allDay'), 'allDay', visibleDates, scheduledItems, false, preset, settings, dropContextMode);
+			this.renderAllDayTrack(section, t('calendar', 'allDay'), 'allDay', visibleDates, scheduledItems, preset, settings, dropContextMode);
 		}
 		if (showDueMarkers) {
-			this.renderAllDayTrack(section, t('calendar', 'due'), 'due', visibleDates, dueItems, true, preset, settings, dropContextMode);
+			this.renderAllDayTrack(section, t('calendar', 'due'), 'due', visibleDates, dueItems, preset, settings, dropContextMode);
 		}
 		if (showFinishedLane) {
-			this.renderAllDayTrack(section, t('calendar', 'finished'), 'finished', visibleDates, finishedItems, true, preset, settings, dropContextMode);
+			this.renderAllDayTrack(section, t('calendar', 'finished'), 'finished', visibleDates, finishedItems, preset, settings, dropContextMode);
 		}
 	}
 
@@ -8315,7 +8322,6 @@ export class CalendarView extends ItemView {
 		trackKind: 'allDay' | 'due' | 'finished',
 		visibleDates: string[],
 		items: CalendarItem[],
-		isDueTrack: boolean,
 		preset: CalendarRenderPreset,
 		settings: OperonSettings,
 		dropContextMode: 'timeGrid' | 'multiWeek' = 'timeGrid',
@@ -8353,14 +8359,16 @@ export class CalendarView extends ItemView {
 
 		const grid = body.createDiv('operon-calendar-all-day-grid');
 		grid.style.gridTemplateColumns = `repeat(${Math.max(1, visibleDates.length)}, minmax(0, 1fr))`;
+		const cells: HTMLElement[] = [];
 		for (const dateKey of visibleDates) {
 			const cell = grid.createDiv('operon-calendar-all-day-cell');
+			cells.push(cell);
 			const dayDate = this.parseDateKey(dateKey);
 			cell.classList.toggle('is-weekend', dayDate?.getDay() === 0 || dayDate?.getDay() === 6);
 			if (dateKey === localToday()) {
 				cell.addClass('is-today');
 			}
-			if (!isDueTrack) {
+			if (trackKind === 'allDay') {
 				this.bindCalendarCellQuickAdd(cell, dateKey, () => {
 					void this.callbacks.onAllDaySlotSelection?.(buildAllDaySlotSelection(dateKey, dateKey));
 				});
@@ -8368,7 +8376,7 @@ export class CalendarView extends ItemView {
 		}
 
 		const overlay = body.createDiv('operon-calendar-all-day-overlay');
-		if (!isDueTrack) {
+		if (trackKind === 'allDay' || trackKind === 'finished') {
 			const dropContext = {
 				body,
 				overlay,
@@ -8376,8 +8384,15 @@ export class CalendarView extends ItemView {
 				laneHeight,
 				laneInset,
 				previewLane: totalLaneCount - 1,
+				cells,
 			};
-			if (dropContextMode === 'multiWeek') {
+			if (trackKind === 'finished') {
+				if (dropContextMode === 'multiWeek') {
+					this.multiWeekFinishedDropContexts.push(dropContext);
+				} else {
+					this.finishedDropContext = dropContext;
+				}
+			} else if (dropContextMode === 'multiWeek') {
 				this.multiWeekAllDayDropContexts.push(dropContext);
 			} else {
 				this.allDayDropContext = dropContext;
@@ -8396,7 +8411,7 @@ export class CalendarView extends ItemView {
 				if (hoverTrigger) {
 					this.bindHoverMenuTarget(hoverTrigger, placement.item);
 				}
-				if (!isDueTrack) {
+				if (trackKind === 'allDay') {
 					if (!canEditAllDayCalendarItemPlacement(placement.item)) {
 						itemEl.addClass('is-read-only');
 						this.bindPrimaryItemClick(itemEl, placement.item);
@@ -8413,6 +8428,13 @@ export class CalendarView extends ItemView {
 							dropContextMode,
 						);
 					}
+				} else if (trackKind === 'finished' && canEditFinishedCalendarItemPlacement(placement.item)) {
+					itemEl.addClass('is-finished-date-draggable');
+					this.bindFinishedAllDayItemInteraction(
+						itemEl,
+						placement,
+						dropContextMode,
+					);
 				} else {
 					itemEl.addClass('is-read-only');
 					this.bindPrimaryItemClick(itemEl, placement.item);
@@ -9796,6 +9818,103 @@ export class CalendarView extends ItemView {
 		itemEl.addEventListener('pointercancel', (event: PointerEvent) => this.finishActiveCalendarDragSession('cancel', event));
 	}
 
+	private bindFinishedAllDayItemInteraction(
+		itemEl: HTMLElement,
+		placement: AllDayPlacement,
+		dropContextMode: 'timeGrid' | 'multiWeek',
+	): void {
+		const dragThresholdPx = 6;
+		let dragState: {
+			pointerId: number;
+			activated: boolean;
+			initialClientX: number;
+			initialClientY: number;
+			targetDate: string;
+			dragGhostEl: HTMLElement | null;
+		} | null = null;
+
+		const updateFromClient = (clientX: number, clientY: number): void => {
+			if (!dragState) return;
+			if (!dragState.activated) {
+				const deltaX = clientX - dragState.initialClientX;
+				const deltaY = clientY - dragState.initialClientY;
+				if (Math.hypot(deltaX, deltaY) < dragThresholdPx) return;
+				dragState.activated = true;
+				itemEl.addClass('is-dragging');
+				dragState.dragGhostEl = this.createCalendarDragGhost(
+					itemEl,
+					'operon-calendar-finished-drag-ghost',
+				);
+				itemEl.addClass('operon-calendar-drag-source-hidden');
+			}
+
+			this.updateCalendarDragGhostPosition(dragState.dragGhostEl, clientX, clientY);
+			const target = dropContextMode === 'multiWeek'
+				? this.resolveMultiWeekFinishedDropTarget(clientX, clientY)
+				: this.resolveFinishedDropTarget(this.finishedDropContext, clientX, clientY);
+			if (target?.dateKey) {
+				dragState.targetDate = target.dateKey;
+			} else {
+				dragState.targetDate = placement.item.startDate;
+			}
+		};
+
+		const finishDrag = (reason: CalendarDragEndReason, event: PointerEvent | null): void => {
+			if (!dragState) return;
+			if (event && dragState.pointerId !== event.pointerId) return;
+			if (event) updateFromClient(event.clientX, event.clientY);
+			const pointerId = dragState.pointerId;
+			const activated = dragState.activated;
+			const targetDate = dragState.targetDate;
+			this.releaseCalendarPointerCapture(itemEl, pointerId);
+			itemEl.removeClass('is-dragging', 'operon-calendar-drag-source-hidden');
+			this.removeCalendarDragGhost(dragState.dragGhostEl);
+			dragState = null;
+
+			if (reason !== 'commit') return;
+			if (!activated) {
+				if (event && this.maybeOpenMaterializedTaskSourceFromEvent(event, placement.item.taskId, true)) return;
+				void this.callbacks.onItemAction?.(placement.item.taskId, 'openEditor');
+				return;
+			}
+
+			const payload = buildFinishedDateMovePayload(placement.item.startDate, targetDate);
+			if (!payload) return;
+			itemEl.dataset.suppressCalendarClick = 'true';
+			this.invokeCalendarDropCallback(
+				placement.item.taskId,
+				payload,
+				() => this.callbacks.onFinishedItemMove?.(placement.item.taskId, payload.dateCompleted),
+				{ verifyOptimisticPatchAfterWrite: true },
+			);
+		};
+
+		itemEl.addEventListener('pointerdown', (event: PointerEvent) => {
+			if (event.button !== 0) return;
+			const target = asHTMLElement(event.target, itemEl);
+			if (target?.closest('.operon-calendar-status-button, a.internal-link')) return;
+			event.stopPropagation();
+			this.hideCalendarHoverMenu(true);
+			dragState = {
+				pointerId: event.pointerId,
+				activated: false,
+				initialClientX: event.clientX,
+				initialClientY: event.clientY,
+				targetDate: placement.item.startDate,
+				dragGhostEl: null,
+			};
+			this.beginCalendarDragSession(itemEl, event.pointerId, finishDrag);
+			itemEl.setPointerCapture?.(event.pointerId);
+		});
+
+		itemEl.addEventListener('pointermove', (event: PointerEvent) => {
+			if (!dragState || dragState.pointerId !== event.pointerId) return;
+			updateFromClient(event.clientX, event.clientY);
+		});
+		itemEl.addEventListener('pointerup', (event: PointerEvent) => this.finishActiveCalendarDragSession('commit', event));
+		itemEl.addEventListener('pointercancel', (event: PointerEvent) => this.finishActiveCalendarDragSession('cancel', event));
+	}
+
 	private buildAllDayPlacements(items: CalendarItem[], visibleDates: string[]): AllDayPlacement[] {
 		const ranges = items
 			.map(item => {
@@ -10727,6 +10846,34 @@ export class CalendarView extends ItemView {
 			return { context, column, dateKey };
 		}
 		return null;
+	}
+
+	private resolveMultiWeekFinishedDropTarget(
+		clientX: number,
+		clientY: number,
+	): { context: CalendarAllDayDropContext; column: number; dateKey: string } | null {
+		for (const context of this.multiWeekFinishedDropContexts) {
+			const target = this.resolveFinishedDropTarget(context, clientX, clientY);
+			if (target) return target;
+		}
+		return null;
+	}
+
+	private resolveFinishedDropTarget(
+		context: CalendarAllDayDropContext | null,
+		clientX: number,
+		clientY: number,
+	): { context: CalendarAllDayDropContext; column: number; dateKey: string } | null {
+		if (!context) return null;
+		const rect = context.body.getBoundingClientRect();
+		const inside = clientX >= rect.left
+			&& clientX <= rect.right
+			&& clientY >= rect.top
+			&& clientY <= rect.bottom;
+		if (!inside) return null;
+		const column = this.resolveAllDayColumnIndex(context.body, clientX, context.visibleDates.length);
+		const dateKey = context.visibleDates[column];
+		return dateKey ? { context, column, dateKey } : null;
 	}
 
 	private setMobileAllDayDropHighlight(context: CalendarAllDayDropContext | null, column: number): void {

--- a/src/ui/embed-table-processor.ts
+++ b/src/ui/embed-table-processor.ts
@@ -3021,7 +3021,7 @@ function renderEmbedTableIconOnlyCell(
 	if (locationVisual) {
 		bindEmbedTableLocationMapPreviewTrigger(icon, deps, task, locationVisual, renderState);
 	}
-	if (isTaskIconColumn && canWriteEmbedTable(deps) && deps.onContextualAction) {
+	if ((isTaskIconColumn || isTaskTypeColumn) && canWriteEmbedTable(deps) && deps.onContextualAction) {
 		bindTableTaskContextualHoverMenu(icon, {
 			task,
 			settings: renderState.settings,
@@ -3116,11 +3116,16 @@ function renderEmbedTableAdminCell(
 		return;
 	}
 	if (column.key === TABLE_TASK_TYPE_COLUMN_KEY) {
+		const canWrite = canWriteEmbedTable(deps);
 		cell.addClass('operon-table-task-type-cell');
 		renderTableTaskTypeButton(cell, {
 			task,
 			onOpenTaskEditor: deps.openTaskEditor,
 			onOpenTaskSource: deps.openTaskSource,
+			settings: renderState.settings,
+			onContextualAction: canWrite ? deps.onContextualAction : undefined,
+			isPinned: deps.isTaskPinned,
+			hasSubtasks: deps.hasSubtasks,
 		});
 	}
 }

--- a/src/ui/embed-table-processor.ts
+++ b/src/ui/embed-table-processor.ts
@@ -3,7 +3,7 @@ import type { OperonIndexer } from '../indexer/indexer';
 import type { PinnedCache } from '../storage/pinned-cache';
 import type { ProjectSerialDisplay } from '../core/project-serials';
 import type { IndexedTask } from '../types/fields';
-import { cloneFilterSet, type FilterSet, type OperonSettings, type TaskFinderDefaultScopeKey } from '../types/settings';
+import type { FilterSet, OperonSettings, TaskFinderDefaultScopeKey } from '../types/settings';
 import type { TrackerSession } from '../types/tracker';
 import type { RelatedViewCreateTarget, RelatedViewOpenTarget } from '../types/related-views';
 import {
@@ -151,7 +151,7 @@ import {
 	snapshotFloatingRectAnchor,
 } from './field-pickers/common';
 import { closeIconOnlyChipPreviewsForRoot } from './icon-only-chip-preview';
-import { getOwnerDocument, getOwnerWindow } from '../core/dom-compat';
+import { getOwnerWindow } from '../core/dom-compat';
 import { setAccessibleLabelWithoutTooltip } from './accessibility-label';
 import {
 	applyTaskSearchBoxShortcutCommand,
@@ -174,7 +174,7 @@ import { resolveTableToolbarSurfacePolicy } from './table/table-toolbar-surface-
 import { showTableExportMenu } from './table/table-export-menu';
 import { bindOperonHoverTooltip, cleanupOperonHoverTooltips } from './operon-hover-tooltip';
 import { renderRelatedViewsLauncher } from './related-views';
-import { FilterSetModal } from './filter-set-modal';
+import { showPresetFilterPopover } from './preset-filter-popover';
 import {
 	bindEmbedPercentWidth,
 	parseEmbedWidthPercent,
@@ -361,34 +361,6 @@ class TableEmbedPresetSourceUpdateSkippedError extends Error {
 		super('Embedded table source no longer matches the active preset reference.');
 		this.name = 'TableEmbedPresetSourceUpdateSkippedError';
 	}
-}
-
-function generateEmbedTableFilterSetId(): string {
-	return 'fs_' + Math.random().toString(36).slice(2, 9);
-}
-
-function generateEmbedTableFilterGroupId(): string {
-	return 'fg_' + Math.random().toString(36).slice(2, 10);
-}
-
-function generateEmbedTableFilterPopoverId(): string {
-	return 'operon-table-filter-popover-' + Math.random().toString(36).slice(2, 10);
-}
-
-function createEmptyEmbedTableFilterSet(name: string): FilterSet {
-	return {
-		id: generateEmbedTableFilterSetId(),
-		name,
-		icon: 'filter',
-		rootGroup: {
-			id: generateEmbedTableFilterGroupId(),
-			logic: 'all',
-			children: [],
-		},
-		sorts: [],
-		matchLogic: 'all',
-		conditions: [],
-	};
 }
 
 export function parseTableEmbedReference(source: string): TableEmbedReference | null {
@@ -1439,71 +1411,17 @@ function openEmbedTableFilterPopover(
 	closeEmbedTableActivePicker(instance);
 	const settings = deps.getSettings();
 	const currentFilter = resolveTablePresetFilterSet(preset, settings.filterSets);
-	const draft = currentFilter
-		? cloneFilterSet(currentFilter)
-		: createEmptyEmbedTableFilterSet(createUniqueEmbedTableFilterName(settings));
 	const sourceFilterSetId = currentFilter?.id ?? null;
-	const ownerDocument = getOwnerDocument(host);
-	const ownerWindow = ownerDocument.defaultView ?? window;
-	const floatingOptions = resolveSurfaceFloatingHostOptions(button);
-	const popoverHost = floatingOptions.floatingHost ?? ownerDocument.body;
-	const floatingScrollHost = floatingOptions.floatingScrollHost ?? ownerWindow;
-	const popover = popoverHost.createDiv('operon-table-filter-popover');
-	const popoverId = generateEmbedTableFilterPopoverId();
-	let editor: FilterSetModal | null = null;
-	let isClosed = false;
-	let repositionFrame: number | null = null;
-	popover.id = popoverId;
-	popover.setAttribute('role', 'dialog');
-	setAccessibleLabelWithoutTooltip(popover, t('table', 'filter'));
-	button.setAttribute('aria-expanded', 'true');
-	button.setAttribute('aria-controls', popoverId);
-
-	const close = (): void => {
-		if (isClosed) return;
-		isClosed = true;
-		if (instance.activePickerClose === close) {
-			instance.activePickerClose = null;
-			instance.keepActivePickerOnRender = false;
-		}
-		ownerDocument.removeEventListener('pointerdown', handleDocumentPointerDown, true);
-		ownerDocument.removeEventListener('keydown', handleDocumentKeyDown, true);
-		ownerWindow.removeEventListener('resize', close);
-		floatingScrollHost.removeEventListener('scroll', scheduleReposition, true);
-		if (repositionFrame !== null) ownerWindow.cancelAnimationFrame(repositionFrame);
-		editor?.destroyInlineConditionEditor();
-		button.setAttribute('aria-expanded', 'false');
-		button.removeAttribute('aria-controls');
-		popover.remove();
-	};
-	const handleDocumentPointerDown = (event: PointerEvent): void => {
-		const target = event.target;
-		if (target && typeof (target as Node).nodeType === 'number' && host.contains(target as Node)) return;
-		if (editor?.isInlineEditorTarget(target)) return;
-		close();
-	};
-	const reposition = (): void => positionEmbedTableFilterPopover(popover, button);
-	const scheduleReposition = (): void => {
-		if (repositionFrame !== null) return;
-		repositionFrame = ownerWindow.requestAnimationFrame(() => {
-			repositionFrame = null;
-			if (!isClosed && popover.isConnected) reposition();
-		});
-	};
-	const handleDocumentKeyDown = (event: KeyboardEvent): void => {
-		if (event.key !== 'Escape') return;
-		if (editor?.isInlineEditorFloatingTarget(event.target)) return;
-		event.preventDefault();
-		close();
-	};
-
-	editor = new FilterSetModal(
-		deps.app,
-		draft,
-		settings.keyMappings,
-		() => undefined,
-		undefined,
-		{
+	let closePopover: (() => void) | null = null;
+	closePopover = showPresetFilterPopover({
+		app: deps.app,
+		anchor: button,
+		triggerHost: host,
+		label: t('table', 'filter'),
+		currentFilter,
+		newFilterName: createUniqueEmbedTableFilterName(settings),
+		keyMappings: settings.keyMappings,
+		filterModalOptions: {
 			getSettings: deps.getSettings,
 			getProjectSerialScopeTasks: () => deps.indexer.getAllTasks(),
 			getFilePropertyDiscoveryTasks: () => deps.indexer.getAllTasks(),
@@ -1512,12 +1430,6 @@ function openEmbedTableFilterPopover(
 				deps.indexer.getGeneration(),
 				{ keyMappings: deps.getSettings().keyMappings },
 			),
-		},
-	);
-	editor.renderInlineConditionEditor(popover, {
-		onCancel: close,
-		onSave: updated => {
-			void saveEmbedTableFilterPopoverDraft(instance, deps, updated, sourceFilterSetId, close);
 		},
 		countTasks: filterSet => filterTasksForCalendar(
 			filterSet,
@@ -1539,44 +1451,24 @@ function openEmbedTableFilterPopover(
 		saveTooltip: sourceFilterSetId
 			? buildEmbedTableFilterUsageTooltip(sourceFilterSetId, deps)
 			: undefined,
+		classNames: ['operon-table-filter-popover'],
+		onCommit: updated => saveEmbedTableFilterPopoverDraft(instance, deps, updated, sourceFilterSetId),
+		onCommitError: error => {
+			console.error('Operon: failed to save embedded table filter popover draft', error);
+			new Notice(t('table', 'presetActionFailed'));
+		},
+		onClose: close => {
+			if (instance.activePickerClose === close) {
+				instance.activePickerClose = null;
+				instance.keepActivePickerOnRender = false;
+			}
+		},
+		resolveFallbackFocusTarget: () => instance.el.querySelector<HTMLButtonElement>(
+			'button.operon-table-filter-popover-button',
+		),
 	});
-	reposition();
-
 	instance.keepActivePickerOnRender = true;
-	instance.activePickerClose = close;
-	ownerDocument.addEventListener('pointerdown', handleDocumentPointerDown, true);
-	ownerDocument.addEventListener('keydown', handleDocumentKeyDown, true);
-	ownerWindow.addEventListener('resize', close);
-	floatingScrollHost.addEventListener('scroll', scheduleReposition, true);
-}
-
-function positionEmbedTableFilterPopover(popover: HTMLElement, button: HTMLElement): void {
-	const rect = button.getBoundingClientRect();
-	const ownerDocument = getOwnerDocument(button);
-	const ownerWindow = ownerDocument.defaultView ?? window;
-	const floatingOptions = resolveSurfaceFloatingHostOptions(button);
-	const floatingHost = floatingOptions.floatingHost;
-	const hostRect = floatingHost?.getBoundingClientRect();
-	const hostScrollLeft = floatingHost?.scrollLeft ?? 0;
-	const hostScrollTop = floatingHost?.scrollTop ?? 0;
-	const margin = 12;
-	const gap = 6;
-	const availableWidth = Math.max(240, (floatingHost?.clientWidth ?? ownerWindow.innerWidth) - margin * 2);
-	const availableHeight = floatingHost?.clientHeight ?? ownerWindow.innerHeight;
-	const width = Math.min(760, availableWidth);
-	const anchorRight = hostRect ? rect.right - hostRect.left + hostScrollLeft : rect.right;
-	const anchorBottom = hostRect ? rect.bottom - hostRect.top + hostScrollTop : rect.bottom;
-	const left = Math.max(hostScrollLeft + margin, Math.min(
-		anchorRight - width,
-		hostScrollLeft + availableWidth - width - margin,
-	));
-	const top = Math.max(hostScrollTop + margin, anchorBottom + gap);
-	const maxHeight = Math.max(240, hostScrollTop + availableHeight - top - margin);
-	popover.style.width = `${Math.round(width)}px`;
-	popover.style.position = floatingHost ? 'absolute' : 'fixed';
-	popover.style.left = `${Math.round(left)}px`;
-	popover.style.top = `${Math.round(top)}px`;
-	popover.style.maxHeight = `${Math.round(maxHeight)}px`;
+	instance.activePickerClose = closePopover;
 }
 
 function createUniqueEmbedTableFilterName(settings: OperonSettings): string {
@@ -1625,24 +1517,19 @@ async function saveEmbedTableFilterPopoverDraft(
 	deps: EmbedTableDeps,
 	filterSet: FilterSet,
 	sourceFilterSetId: string | null,
-	close: () => void,
 ): Promise<void> {
 	if (!deps.onSaveFilterSet) {
-		new Notice(t('table', 'presetActionFailed'));
-		return;
+		throw new Error('Operon: embedded Table filter save callback is unavailable.');
 	}
-	try {
-		await deps.onSaveFilterSet(filterSet);
-		if (!sourceFilterSetId) {
-			await deps.onSavePresetPatch?.({
-				id: getCurrentEmbedTablePreset(instance, deps).id,
-				filterSetId: filterSet.id,
-			});
+	await deps.onSaveFilterSet(filterSet);
+	if (!sourceFilterSetId) {
+		if (!deps.onSavePresetPatch) {
+			throw new Error('Operon: embedded Table preset save callback is unavailable.');
 		}
-		close();
-	} catch (error) {
-		console.error('Operon: failed to save embedded table filter popover draft', error);
-		new Notice(t('table', 'presetActionFailed'));
+		await deps.onSavePresetPatch({
+			id: getCurrentEmbedTablePreset(instance, deps).id,
+			filterSetId: filterSet.id,
+		});
 	}
 }
 

--- a/src/ui/embed-table-processor.ts
+++ b/src/ui/embed-table-processor.ts
@@ -47,7 +47,7 @@ import {
 import {
 	formatTableTaskSource,
 } from './table/table-value-adapter';
-import { formatTableDependencyTooltipContent, renderTableCellChips } from './table/table-cell-chip';
+import { formatTableDependencyTooltipContent, formatTableDetailedDatetimeValue, renderTableCellChips } from './table/table-cell-chip';
 import { resolveTableColumnCellAccent, resolveTableIconOnlyCellAccent } from './table/table-column-color';
 import { renderTableDescriptionCellContent, type TableInlineEditSession } from './table/table-description-cell';
 import { bindMobileTableViewport, isMobileTableTextInputFocused } from './table/mobile-table-viewport';
@@ -821,7 +821,7 @@ function renderEmbedTable(instance: EmbedTableInstance, deps: EmbedTableDeps): v
 		};
 	}
 	const rowHeight = resolveTableRowHeight(result.preset);
-	const columnGeometry = buildTableColumnGeometry(columns);
+	const columnGeometry = buildTableColumnGeometry(columns, settings);
 	const tableWidthPx = columnGeometry.tableWidthPx;
 	const scrollbarGutterPx = measureTableScrollbarGutterPx(instance.el.ownerDocument);
 	const collapsedGroupKeys = result.preset.collapsedGroupKeys;
@@ -2972,15 +2972,19 @@ function renderEmbedTableIconOnlyCell(
 		task,
 		locationResolver: renderState.locationResolver,
 	});
-	const content = locationVisual?.label
+	const field = getTableTaskField(column.key, renderState.settings);
+	const content = field?.type === 'datetime'
+		? formatTableDetailedDatetimeValue(column.key, value, renderState.settings)
+		: locationVisual?.label
 		?? formatTableDependencyTooltipContent(column.key, value, renderState.valueResolver.taskLookup)
 		?? formatTableIconOnlyTooltipContent(value);
-	const fallbackIcon = getTableTaskField(column.key, renderState.settings)?.icon ?? 'text';
+	const fallbackIcon = field?.icon ?? 'text';
 	const isTaskIconColumn = column.key === 'taskIcon';
 	const isTaskTypeColumn = column.key === 'taskType';
-	if (column.key === 'datetimeStart' || column.key === 'datetimeEnd') {
+	if (field?.type === 'datetime') {
 		renderTableCompactDatetimeCell(cell, {
 			value,
+			timeFormat: renderState.settings.timeFormat,
 			title: fieldLabel,
 			content,
 			ariaLabel: `${fieldLabel}: ${content}`,

--- a/src/ui/embed-table-processor.ts
+++ b/src/ui/embed-table-processor.ts
@@ -174,7 +174,11 @@ import { resolveTableToolbarSurfacePolicy } from './table/table-toolbar-surface-
 import { showTableExportMenu } from './table/table-export-menu';
 import { bindOperonHoverTooltip, cleanupOperonHoverTooltips } from './operon-hover-tooltip';
 import { renderRelatedViewsLauncher } from './related-views';
-import { showPresetFilterPopover } from './preset-filter-popover';
+import {
+	buildPresetFilterUsageTooltip,
+	createUniquePresetFilterName,
+	showPresetFilterPopover,
+} from './preset-filter-popover';
 import {
 	bindEmbedPercentWidth,
 	parseEmbedWidthPercent,
@@ -1419,7 +1423,7 @@ function openEmbedTableFilterPopover(
 		triggerHost: host,
 		label: t('table', 'filter'),
 		currentFilter,
-		newFilterName: createUniqueEmbedTableFilterName(settings),
+		newFilterName: createUniquePresetFilterName(t('table', 'newFilterName'), settings.filterSets),
 		keyMappings: settings.keyMappings,
 		filterModalOptions: {
 			getSettings: deps.getSettings,
@@ -1449,7 +1453,7 @@ function openEmbedTableFilterPopover(
 			},
 		).length,
 		saveTooltip: sourceFilterSetId
-			? buildEmbedTableFilterUsageTooltip(sourceFilterSetId, deps)
+			? buildPresetFilterUsageTooltip(settings, sourceFilterSetId, getEmbedTablePresets(deps))
 			: undefined,
 		classNames: ['operon-table-filter-popover'],
 		onCommit: updated => saveEmbedTableFilterPopoverDraft(instance, deps, updated, sourceFilterSetId),
@@ -1469,47 +1473,6 @@ function openEmbedTableFilterPopover(
 	});
 	instance.keepActivePickerOnRender = true;
 	instance.activePickerClose = closePopover;
-}
-
-function createUniqueEmbedTableFilterName(settings: OperonSettings): string {
-	const baseName = t('table', 'newFilterName');
-	const existingNames = new Set(
-		settings.filterSets.map(filterSet => filterSet.name.trim().toLocaleLowerCase()),
-	);
-	if (!existingNames.has(baseName.toLocaleLowerCase())) return baseName;
-	let suffix = 2;
-	while (existingNames.has(`${baseName} ${suffix}`.toLocaleLowerCase())) {
-		suffix += 1;
-	}
-	return `${baseName} ${suffix}`;
-}
-
-function buildEmbedTableFilterUsageTooltip(filterSetId: string, deps: EmbedTableDeps): { title: string; content: string } | undefined {
-	const settings = deps.getSettings();
-	const lines: string[] = [];
-	const calendarPresets = settings.calendarPresets
-		.filter(entry => entry.filterSetId === filterSetId)
-		.map(entry => entry.name.trim() || entry.id);
-	const kanbanPresets = settings.kanbanPresets
-		.filter(entry => entry.filterSetId === filterSetId)
-		.map(entry => entry.name.trim() || entry.id);
-	const tablePresets = getEmbedTablePresets(deps)
-		.filter(entry => entry.filterSetId === filterSetId)
-		.map(entry => entry.name.trim() || entry.id);
-	if (calendarPresets.length > 0) {
-		lines.push(`${t('filterSets', 'usedByCalendar')}: ${calendarPresets.join(', ')}`);
-	}
-	if (kanbanPresets.length > 0) {
-		lines.push(`${t('filterSets', 'usedByKanban')}: ${kanbanPresets.join(', ')}`);
-	}
-	if (tablePresets.length > 0) {
-		lines.push(`${t('filterSets', 'usedByTable')}: ${tablePresets.join(', ')}`);
-	}
-	if (lines.length === 0) return undefined;
-	return {
-		title: t('filterSets', 'usedByTitle'),
-		content: lines.join(' · '),
-	};
 }
 
 async function saveEmbedTableFilterPopoverDraft(

--- a/src/ui/filter-set-modal.ts
+++ b/src/ui/filter-set-modal.ts
@@ -42,7 +42,11 @@ import {
 } from '../core/dynamic-file-task-filter';
 import { showOperonDayPickerPopover } from './field-pickers/day-picker-popover';
 import { showDatetimePicker } from './field-pickers/datetime-picker';
-import { closeFloatingPanelsForRoot, isFloatingPanelTargetForRoot } from './field-pickers/common';
+import {
+	closeFloatingPanelsForRoot,
+	isFloatingPanelTargetForRoot,
+	requestFloatingPanelCloseForRoot,
+} from './field-pickers/common';
 import { showFilterConditionPicker } from './field-pickers/filter-condition-picker';
 import { showSearchableMultiOptionPicker, type SearchableMultiOption } from './field-pickers/list-picker';
 import { showSearchableFieldPicker, type SearchableFieldPickerOption } from './field-pickers/searchable-field-picker';
@@ -395,6 +399,16 @@ export class FilterSetModal extends Modal {
 		const targetNode = target as Node;
 		return isFloatingPanelTargetForRoot(inlineEditor.container, targetNode)
 			|| this.bodyDropdowns.some(dropdown => dropdown.contains(targetNode));
+	}
+
+	requestInlineEditorChildEscapeClose(): boolean {
+		const inlineEditor = this.inlineEditor;
+		if (!inlineEditor) return false;
+		if (requestFloatingPanelCloseForRoot(inlineEditor.container, 'escape')) return true;
+		const openDropdown = this.bodyDropdowns.find(dropdown => dropdown.hasClass('is-open'));
+		if (!openDropdown) return false;
+		openDropdown.removeClass('is-open');
+		return true;
 	}
 
 	private renderModal(): void {

--- a/src/ui/kanban/kanban-view.ts
+++ b/src/ui/kanban/kanban-view.ts
@@ -101,6 +101,11 @@ import {
 import { getKanbanPresetPickerLabel, showKanbanPresetPicker } from './kanban-preset-picker';
 import { getFavoriteKanbanPresets, resolveKanbanPresetPickerButtonState } from './kanban-preset-visibility';
 import {
+	buildPresetFilterUsageTooltip,
+	createUniquePresetFilterName,
+	showPresetFilterPopover,
+} from '../preset-filter-popover';
+import {
 	applyTaskSearchBoxShortcutCommand,
 	cloneTaskSearchBoxScopeState,
 	getTaskSearchBoxRecentModifiedCutoff,
@@ -380,6 +385,7 @@ export class KanbanView extends ItemView {
 	private boardLayoutRefreshCleanup: (() => void) | null = null;
 	private toolbarLayoutCleanup: (() => void) | null = null;
 	private activePresetPickerClose: (() => void) | null = null;
+	private activeFilterPopoverClose: (() => void) | null = null;
 	private kanbanSearchScopePopoverCleanup: (() => void) | null = null;
 	private kanbanMobileLayoutCleanup: (() => void) | null = null;
 	private kanbanLazyObservers: IntersectionObserver[] = [];
@@ -507,6 +513,7 @@ export class KanbanView extends ItemView {
 		this.resetKanbanSearchScope();
 		this.lastRenderSignature = null;
 		this.closeActivePresetPicker();
+		this.closeActiveFilterPopover();
 		if (this.persistStateTimer !== null) {
 			this.clearPersistStateTimer();
 			this.app.workspace.requestSaveLayout();
@@ -542,13 +549,8 @@ export class KanbanView extends ItemView {
 		const pipeline = preset?.pipelineId
 			? settings.pipelines.find(entry => entry.id === preset.pipelineId) ?? null
 			: null;
-		const filterSet = (() => {
-			const raw = preset?.filterSetId
-				? settings.filterSets.find(entry => entry.id === preset.filterSetId) ?? null
-				: null;
-			if (raw && isSpecialDynamicFilterSet(raw)) return null;
-			return raw ? stripFilterViewOnlyOptions(raw) : null;
-		})();
+		const currentFilter = preset ? this.resolveEditableKanbanFilter(preset, settings) : null;
+		const filterSet = currentFilter ? stripFilterViewOnlyOptions(currentFilter) : null;
 		const parentSearchUi = pipeline && preset
 			? this.buildParentSearchUiState(state.searchQuery, pipeline, filterSet, settings, this.searchScope)
 			: null;
@@ -558,6 +560,7 @@ export class KanbanView extends ItemView {
 		}
 
 		this.closeActivePresetPicker();
+		this.closeActiveFilterPopover();
 		this.hideHoverMenu(true);
 		this.clearKanbanSearchRefreshTimer();
 		this.clearBoardLayoutRefresh();
@@ -579,7 +582,7 @@ export class KanbanView extends ItemView {
 		}
 		this.applyKanbanPresetTheme(root, preset);
 
-		this.renderToolbar(root, state, preset, parentSearchUi);
+		this.renderToolbar(root, state, preset, currentFilter, parentSearchUi);
 		const content = root.createDiv('operon-kanban-content');
 		this.renderBoardContent(content, state, preset, pipeline, filterSet, settings, parentSearchUi);
 		this.restoreSearchFocus(root);
@@ -784,6 +787,7 @@ export class KanbanView extends ItemView {
 		container: HTMLElement,
 		state: KanbanLeafState,
 		preset: KanbanPreset,
+		currentFilter: FilterSet | null,
 		parentSearchUi: KanbanParentSearchUiState | null,
 	): void {
 		const toolbar = container.createDiv('operon-kanban-toolbar');
@@ -837,6 +841,7 @@ export class KanbanView extends ItemView {
 		}
 
 		this.renderKanbanPresetPickerButton(end, kanbanPresets, preset);
+		this.renderKanbanFilterPopoverButton(end, preset, currentFilter);
 
 		const searchWrap = end.createDiv('operon-kanban-toolbar-search-wrap');
 		this.syncKanbanSearchWrapClasses(searchWrap, state.searchQuery);
@@ -956,7 +961,7 @@ export class KanbanView extends ItemView {
 		this.renderParentSearchDropdown(searchWrap, parentSearchUi);
 
 		const settingsButton = end.createEl('button', {
-			cls: 'operon-kanban-toolbar-settings-button',
+			cls: 'operon-kanban-toolbar-settings-button operon-kanban-toolbar-preset-settings-button',
 			attr: { type: 'button' },
 		});
 		setIcon(settingsButton, 'settings-2');
@@ -968,9 +973,116 @@ export class KanbanView extends ItemView {
 		settingsButton.addEventListener('click', () => {
 			if (!preset.id) return;
 			this.closeActivePresetPicker();
+			this.closeActiveFilterPopover();
 			void this.callbacks.onOpenPresetSettings?.(preset.id);
 		});
 		this.applyKanbanToolbarLayoutMode(toolbar, start, center, end);
+	}
+
+	private resolveEditableKanbanFilter(preset: KanbanPreset, settings: OperonSettings): FilterSet | null {
+		if (!preset.filterSetId) return null;
+		const filterSet = settings.filterSets.find(entry => entry.id === preset.filterSetId) ?? null;
+		return filterSet && !isSpecialDynamicFilterSet(filterSet) ? filterSet : null;
+	}
+
+	private renderKanbanFilterPopoverButton(
+		container: HTMLElement,
+		preset: KanbanPreset,
+		currentFilter: FilterSet | null,
+	): void {
+		const host = container.createDiv('operon-kanban-filter-popover-host');
+		const button = host.createEl('button', {
+			cls: 'operon-kanban-toolbar-settings-button operon-kanban-filter-popover-button',
+			attr: {
+				type: 'button',
+				'aria-haspopup': 'dialog',
+				'aria-expanded': 'false',
+			},
+		});
+		button.classList.toggle('is-active', currentFilter !== null);
+		setIcon(button, 'funnel');
+		setAccessibleLabelWithoutTooltip(button, t('table', 'filter'));
+		bindOperonHoverTooltip(button, {
+			content: t('table', 'filter'),
+			taskColor: null,
+			preferredVertical: 'above',
+		});
+		button.addEventListener('click', event => {
+			event.preventDefault();
+			event.stopPropagation();
+			this.closeActivePresetPicker();
+			this.closeActiveFilterPopover();
+			this.openKanbanFilterPopover(host, button, preset, currentFilter);
+		});
+	}
+
+	private openKanbanFilterPopover(
+		host: HTMLElement,
+		button: HTMLButtonElement,
+		preset: KanbanPreset,
+		currentFilter: FilterSet | null,
+	): void {
+		const settings = this.getSettings();
+		const expectedPresetFilterSetId = preset.filterSetId;
+		let closePopover: (() => void) | null = null;
+		closePopover = showPresetFilterPopover({
+			app: this.app,
+			anchor: button,
+			triggerHost: host,
+			label: t('table', 'filter'),
+			currentFilter,
+			newFilterName: createUniquePresetFilterName(t('table', 'newFilterName'), settings.filterSets),
+			keyMappings: settings.keyMappings,
+			filterModalOptions: {
+				getSettings: () => this.getSettings(),
+				getProjectSerialScopeTasks: () => this.indexer.getAllTasks(),
+				getFilePropertyDiscoveryTasks: () => this.indexer.getAllTasks(),
+				getFilePropertySnapshot: tasks => getTableFilePropertyIndex(this.app).getSnapshot(
+					tasks,
+					this.indexer.getGeneration(),
+					{ keyMappings: this.getSettings().keyMappings },
+				),
+			},
+			countTasks: filterSet => filterTasksForCalendar(
+				filterSet,
+				this.indexer.getAllTasks(),
+				this.getSettings().priorities,
+				this.getPinnedCache(),
+				{
+					projectSerialScopes: this.getSettings().projectSerialScopes,
+					projectSerialScopeTasks: this.indexer.getAllTasks(),
+					dependencyTasks: this.indexer.getAllTasks(),
+					pipelines: this.getSettings().pipelines,
+					filePropertyContext: this.getFilePropertyContext(this.getSettings()),
+				},
+			).length,
+			saveTooltip: currentFilter
+				? buildPresetFilterUsageTooltip(settings, currentFilter.id)
+				: undefined,
+			classNames: ['operon-kanban-filter-popover'],
+			onCommit: async (filterSet, sourceFilterSetId) => {
+				if (!this.callbacks.onCommitPresetFilter) {
+					throw new Error('Operon: Kanban filter save callback is unavailable.');
+				}
+				await this.callbacks.onCommitPresetFilter({
+					presetId: preset.id,
+					filterSet,
+					sourceFilterSetId,
+					expectedPresetFilterSetId,
+				});
+			},
+			onCommitError: error => {
+				console.error('Operon: failed to save Kanban filter popover draft', error);
+				new Notice(t('table', 'presetActionFailed'));
+			},
+			onClose: close => {
+				if (this.activeFilterPopoverClose === close) this.activeFilterPopoverClose = null;
+			},
+			resolveFallbackFocusTarget: () => this.contentEl.querySelector<HTMLButtonElement>(
+				'button.operon-kanban-filter-popover-button',
+			),
+		});
+		this.activeFilterPopoverClose = closePopover;
 	}
 
 	private renderKanbanRelatedViewsButton(container: HTMLElement, preset: KanbanPreset): void {
@@ -979,7 +1091,10 @@ export class KanbanView extends ItemView {
 			settings: this.getSettings(),
 			source: { type: 'kanban', preset },
 			buttonClass: 'operon-kanban-related-views-button',
-			closeBeforeOpen: () => this.closeActivePresetPicker(),
+			closeBeforeOpen: () => {
+				this.closeActivePresetPicker();
+				this.closeActiveFilterPopover();
+			},
 			onOpenRelatedView: target => this.callbacks.onOpenRelatedView?.(target),
 			onCreateRelatedView: target => this.callbacks.onCreateRelatedView?.(target),
 		});
@@ -1018,6 +1133,7 @@ export class KanbanView extends ItemView {
 			event.preventDefault();
 			event.stopPropagation();
 			this.closeActivePresetPicker();
+			this.closeActiveFilterPopover();
 			button.setAttribute('aria-expanded', 'true');
 			let closePicker: (() => void) | null = null;
 			closePicker = showKanbanPresetPicker(button, {
@@ -1044,6 +1160,12 @@ export class KanbanView extends ItemView {
 	private closeActivePresetPicker(): void {
 		const close = this.activePresetPickerClose;
 		this.activePresetPickerClose = null;
+		close?.();
+	}
+
+	private closeActiveFilterPopover(): void {
+		const close = this.activeFilterPopoverClose;
+		this.activeFilterPopoverClose = null;
 		close?.();
 	}
 

--- a/src/ui/preset-filter-popover.ts
+++ b/src/ui/preset-filter-popover.ts
@@ -1,0 +1,197 @@
+import type { App } from 'obsidian';
+
+import { getOwnerDocument, getOwnerWindow } from '../core/dom-compat';
+import { cloneFilterSet, type FilterSet, type KeyMapping } from '../types/settings';
+import { setAccessibleLabelWithoutTooltip } from './accessibility-label';
+import { resolveSurfaceFloatingHostOptions } from './field-pickers/common';
+import {
+	FilterSetModal,
+	type FilterModalEvalDeps,
+	type FilterSetModalOptions,
+} from './filter-set-modal';
+
+export interface PresetFilterPopoverOptions {
+	app: App;
+	anchor: HTMLButtonElement;
+	triggerHost: HTMLElement;
+	label: string;
+	currentFilter: FilterSet | null;
+	newFilterName: string;
+	keyMappings: KeyMapping[];
+	evalDeps?: FilterModalEvalDeps;
+	filterModalOptions?: FilterSetModalOptions;
+	countTasks?: (filterSet: FilterSet) => number;
+	saveTooltip?: { title: string; content: string };
+	classNames?: string[];
+	onCommit: (filterSet: FilterSet, sourceFilterSetId: string | null) => Promise<void>;
+	onCommitError: (error: unknown) => void;
+	onClose?: (close: () => void) => void;
+	resolveFallbackFocusTarget?: () => HTMLElement | null;
+}
+
+let presetFilterPopoverSequence = 0;
+
+function generateFilterSetId(): string {
+	return 'fs_' + Math.random().toString(36).slice(2, 9);
+}
+
+function generateFilterGroupId(): string {
+	return 'fg_' + Math.random().toString(36).slice(2, 10);
+}
+
+function createEmptyFilterSet(name: string): FilterSet {
+	return {
+		id: generateFilterSetId(),
+		name,
+		icon: 'filter',
+		rootGroup: {
+			id: generateFilterGroupId(),
+			logic: 'all',
+			children: [],
+		},
+		sorts: [],
+		matchLogic: 'all',
+		conditions: [],
+	};
+}
+
+function positionPresetFilterPopover(popover: HTMLElement, anchor: HTMLElement): void {
+	const rect = anchor.getBoundingClientRect();
+	const ownerWindow = getOwnerWindow(anchor);
+	const floatingOptions = resolveSurfaceFloatingHostOptions(anchor);
+	const floatingHost = floatingOptions.floatingHost;
+	const hostRect = floatingHost?.getBoundingClientRect();
+	const hostScrollLeft = floatingHost?.scrollLeft ?? 0;
+	const hostScrollTop = floatingHost?.scrollTop ?? 0;
+	const margin = 12;
+	const gap = 6;
+	const availableWidth = Math.max(240, (floatingHost?.clientWidth ?? ownerWindow.innerWidth) - margin * 2);
+	const availableHeight = floatingHost?.clientHeight ?? ownerWindow.innerHeight;
+	const width = Math.min(760, availableWidth);
+	const anchorRight = hostRect ? rect.right - hostRect.left + hostScrollLeft : rect.right;
+	const anchorBottom = hostRect ? rect.bottom - hostRect.top + hostScrollTop : rect.bottom;
+	const left = Math.max(hostScrollLeft + margin, Math.min(
+		anchorRight - width,
+		hostScrollLeft + availableWidth - width - margin,
+	));
+	const top = Math.max(hostScrollTop + margin, anchorBottom + gap);
+	const maxHeight = Math.max(240, hostScrollTop + availableHeight - top - margin);
+	popover.style.width = `${Math.round(width)}px`;
+	popover.style.position = floatingHost ? 'absolute' : 'fixed';
+	popover.style.left = `${Math.round(left)}px`;
+	popover.style.top = `${Math.round(top)}px`;
+	popover.style.maxHeight = `${Math.round(maxHeight)}px`;
+}
+
+export function showPresetFilterPopover(options: PresetFilterPopoverOptions): () => void {
+	const {
+		anchor,
+		triggerHost,
+		currentFilter,
+	} = options;
+	const draft = currentFilter
+		? cloneFilterSet(currentFilter)
+		: createEmptyFilterSet(options.newFilterName);
+	const sourceFilterSetId = currentFilter?.id ?? null;
+	const ownerDocument = getOwnerDocument(triggerHost);
+	const ownerWindow = getOwnerWindow(triggerHost);
+	const floatingOptions = resolveSurfaceFloatingHostOptions(anchor);
+	const popoverHost = floatingOptions.floatingHost ?? ownerDocument.body;
+	const floatingScrollHost = floatingOptions.floatingScrollHost ?? ownerWindow;
+	const popover = popoverHost.createDiv('operon-preset-filter-popover');
+	for (const className of options.classNames ?? []) popover.addClass(className);
+	presetFilterPopoverSequence += 1;
+	popover.id = `operon-preset-filter-popover-${presetFilterPopoverSequence}`;
+	popover.setAttribute('role', 'dialog');
+	setAccessibleLabelWithoutTooltip(popover, options.label);
+	anchor.setAttribute('aria-expanded', 'true');
+	anchor.setAttribute('aria-controls', popover.id);
+
+	let editor: FilterSetModal | null = null;
+	let isClosed = false;
+	let saveInFlight = false;
+	let repositionFrame: number | null = null;
+
+	const restoreAnchorFocus = (): void => {
+		ownerWindow.requestAnimationFrame(() => {
+			const focusTarget = anchor.isConnected
+				? anchor
+				: options.resolveFallbackFocusTarget?.() ?? null;
+			if (focusTarget?.isConnected) focusTarget.focus({ preventScroll: true });
+		});
+	};
+	const close = (restoreFocus = false): void => {
+		if (isClosed) return;
+		isClosed = true;
+		ownerDocument.removeEventListener('pointerdown', handleDocumentPointerDown, true);
+		ownerDocument.removeEventListener('keydown', handleDocumentKeyDown, true);
+		ownerWindow.removeEventListener('resize', handleWindowResize);
+		floatingScrollHost.removeEventListener('scroll', scheduleReposition, true);
+		if (repositionFrame !== null) ownerWindow.cancelAnimationFrame(repositionFrame);
+		editor?.destroyInlineConditionEditor();
+		anchor.setAttribute('aria-expanded', 'false');
+		anchor.removeAttribute('aria-controls');
+		popover.remove();
+		options.onClose?.(publicClose);
+		if (restoreFocus) restoreAnchorFocus();
+	};
+	const publicClose = (): void => close(false);
+	const handleDocumentPointerDown = (event: PointerEvent): void => {
+		const target = event.target;
+		if (target && typeof (target as Node).nodeType === 'number' && triggerHost.contains(target as Node)) return;
+		if (editor?.isInlineEditorTarget(target)) return;
+		close(false);
+	};
+	const handleDocumentKeyDown = (event: KeyboardEvent): void => {
+		if (event.key !== 'Escape') return;
+		if (editor?.requestInlineEditorChildEscapeClose()) {
+			event.preventDefault();
+			event.stopImmediatePropagation();
+			return;
+		}
+		if (editor?.isInlineEditorFloatingTarget(event.target)) return;
+		event.preventDefault();
+		close(true);
+	};
+	const reposition = (): void => positionPresetFilterPopover(popover, anchor);
+	const scheduleReposition = (): void => {
+		if (repositionFrame !== null) return;
+		repositionFrame = ownerWindow.requestAnimationFrame(() => {
+			repositionFrame = null;
+			if (!isClosed && popover.isConnected) reposition();
+		});
+	};
+	const handleWindowResize = (): void => close(false);
+
+	editor = new FilterSetModal(
+		options.app,
+		draft,
+		options.keyMappings,
+		() => undefined,
+		options.evalDeps,
+		options.filterModalOptions,
+	);
+	editor.renderInlineConditionEditor(popover, {
+		onCancel: () => close(true),
+		onSave: updated => {
+			if (saveInFlight || isClosed) return;
+			saveInFlight = true;
+			void Promise.resolve()
+				.then(() => options.onCommit(updated, sourceFilterSetId))
+				.then(() => close(true))
+				.catch(error => {
+					saveInFlight = false;
+					options.onCommitError(error);
+				});
+		},
+		countTasks: options.countTasks,
+		saveTooltip: options.saveTooltip,
+	});
+	reposition();
+
+	ownerDocument.addEventListener('pointerdown', handleDocumentPointerDown, true);
+	ownerDocument.addEventListener('keydown', handleDocumentKeyDown, true);
+	ownerWindow.addEventListener('resize', handleWindowResize);
+	floatingScrollHost.addEventListener('scroll', scheduleReposition, true);
+	return publicClose;
+}

--- a/src/ui/preset-filter-popover.ts
+++ b/src/ui/preset-filter-popover.ts
@@ -1,7 +1,8 @@
 import type { App } from 'obsidian';
 
 import { getOwnerDocument, getOwnerWindow } from '../core/dom-compat';
-import { cloneFilterSet, type FilterSet, type KeyMapping } from '../types/settings';
+import { cloneFilterSet, type FilterSet, type KeyMapping, type OperonSettings } from '../types/settings';
+import { t } from '../core/i18n';
 import { setAccessibleLabelWithoutTooltip } from './accessibility-label';
 import { resolveSurfaceFloatingHostOptions } from './field-pickers/common';
 import {
@@ -30,6 +31,36 @@ export interface PresetFilterPopoverOptions {
 }
 
 let presetFilterPopoverSequence = 0;
+
+export function createUniquePresetFilterName(baseName: string, filterSets: readonly FilterSet[]): string {
+	const existingNames = new Set(filterSets.map(filterSet => filterSet.name.trim().toLocaleLowerCase()));
+	if (!existingNames.has(baseName.toLocaleLowerCase())) return baseName;
+	let suffix = 2;
+	while (existingNames.has(`${baseName} ${suffix}`.toLocaleLowerCase())) suffix += 1;
+	return `${baseName} ${suffix}`;
+}
+
+export function buildPresetFilterUsageTooltip(
+	settings: Pick<OperonSettings, 'calendarPresets' | 'kanbanPresets' | 'tablePresets'>,
+	filterSetId: string,
+	tablePresets: readonly { id: string; name: string; filterSetId: string | null }[] = settings.tablePresets,
+): { title: string; content: string } | undefined {
+	const lines: string[] = [];
+	const addUsageLine = (label: string, presets: readonly { id: string; name: string; filterSetId: string | null }[]): void => {
+		const names = presets
+			.filter(entry => entry.filterSetId === filterSetId)
+			.map(entry => entry.name.trim() || entry.id);
+		if (names.length > 0) lines.push(`${label}: ${names.join(', ')}`);
+	};
+	addUsageLine(t('filterSets', 'usedByCalendar'), settings.calendarPresets);
+	addUsageLine(t('filterSets', 'usedByKanban'), settings.kanbanPresets);
+	addUsageLine(t('filterSets', 'usedByTable'), tablePresets);
+	if (lines.length === 0) return undefined;
+	return {
+		title: t('filterSets', 'usedByTitle'),
+		content: lines.join(' · '),
+	};
+}
 
 function generateFilterSetId(): string {
 	return 'fs_' + Math.random().toString(36).slice(2, 9);

--- a/src/ui/preset-filter-popover.ts
+++ b/src/ui/preset-filter-popover.ts
@@ -192,7 +192,7 @@ export function showPresetFilterPopover(options: PresetFilterPopoverOptions): ()
 			if (!isClosed && popover.isConnected) reposition();
 		});
 	};
-	const handleWindowResize = (): void => close(false);
+	const handleWindowResize = (): void => scheduleReposition();
 
 	editor = new FilterSetModal(
 		options.app,

--- a/src/ui/reading-task-row.ts
+++ b/src/ui/reading-task-row.ts
@@ -210,12 +210,6 @@ export function buildReadingTaskRowElement(
 	} else {
 		renderTaskDescription(description, task, callbacks);
 	}
-	if (options?.rowClassName !== 'operon-filter-task-row') {
-		bindOperonHoverTooltip(description, {
-			content: t('tooltips', 'goToTask'),
-			taskColor,
-		});
-	}
 	if (terminalVisualState === 'done') {
 		description.classList.add('operon-task-done');
 	} else if (terminalVisualState === 'cancelled') {

--- a/src/ui/table/operon-table-view.ts
+++ b/src/ui/table/operon-table-view.ts
@@ -1995,10 +1995,14 @@ export class OperonTableView extends FileView {
 		}
 		if (column.key === TABLE_TASK_TYPE_COLUMN_KEY) {
 			cell.addClass('operon-table-task-type-cell');
-				renderTableTaskTypeButton(cell, {
-					task,
-					onOpenTaskEditor: this.callbacks.onOpenTaskEditor,
-					onOpenTaskSource: this.callbacks.onOpenTaskSource,
+			renderTableTaskTypeButton(cell, {
+				task,
+				onOpenTaskEditor: this.callbacks.onOpenTaskEditor,
+				onOpenTaskSource: this.callbacks.onOpenTaskSource,
+				settings: renderState.settings,
+				onContextualAction: this.callbacks.onContextualAction,
+				isPinned: this.callbacks.isTaskPinned,
+				hasSubtasks: this.callbacks.hasSubtasks,
 			});
 		}
 	}
@@ -2135,7 +2139,7 @@ export class OperonTableView extends FileView {
 		if (locationVisual) {
 			this.bindLocationMapPreviewTrigger(icon, task, locationVisual, renderState);
 		}
-		if (isTaskIconColumn && this.callbacks.onContextualAction) {
+		if ((isTaskIconColumn || isTaskTypeColumn) && this.callbacks.onContextualAction) {
 			bindTableTaskContextualHoverMenu(icon, {
 				task,
 				settings: renderState.settings,

--- a/src/ui/table/operon-table-view.ts
+++ b/src/ui/table/operon-table-view.ts
@@ -3,7 +3,7 @@ import type { OperonIndexer } from '../../indexer/indexer';
 import type { PinnedCache } from '../../storage/pinned-cache';
 import type { ProjectSerialDisplay } from '../../core/project-serials';
 import type { IndexedTask } from '../../types/fields';
-import { cloneFilterSet, type FilterSet, type OperonSettings } from '../../types/settings';
+import type { FilterSet, OperonSettings } from '../../types/settings';
 import type { TaskFinderDefaultScopeKey } from '../../types/settings';
 import type { TrackerSession } from '../../types/tracker';
 import {
@@ -146,13 +146,13 @@ import { showTextFieldPopover } from '../text-field-popover';
 import { showTaskNotePopover } from '../task-note-action';
 import { buildTrackerSessionEditContext, TrackerSessionEditModal } from '../tracker-session-edit-modal';
 import { formatDurationHuman } from '../../systems/tracker-utils';
-import { getOwnerDocument, getOwnerWindow } from '../../core/dom-compat';
+import { getOwnerWindow } from '../../core/dom-compat';
 import type { ContextualMenuActionHandler } from '../../core/contextual-menu-engine';
 import { setAccessibleLabelWithoutTooltip } from '../accessibility-label';
 import { resolveSurfaceFloatingHostOptions, snapshotFloatingRectAnchor } from '../field-pickers/common';
 import { openWebViewerNewTab } from '../external-link-actions';
 import { bindOperonHoverTooltip, cleanupOperonHoverTooltips } from '../operon-hover-tooltip';
-import { FilterSetModal } from '../filter-set-modal';
+import { showPresetFilterPopover } from '../preset-filter-popover';
 import { bindTableTaskContextualHoverMenu, renderTableTaskIconButton } from './table-task-icon-button';
 import { bindTableTaskTypeEditorOpen, renderTableTaskTypeButton } from './table-task-type-button';
 import {
@@ -300,34 +300,6 @@ interface TableNoSearchResultCache {
 	key: string;
 	result: TableQueryResult;
 	summariesEvaluated: boolean;
-}
-
-function generateTableFilterSetId(): string {
-	return 'fs_' + Math.random().toString(36).slice(2, 9);
-}
-
-function generateTableFilterGroupId(): string {
-	return 'fg_' + Math.random().toString(36).slice(2, 10);
-}
-
-function generateTableFilterPopoverId(): string {
-	return 'operon-table-filter-popover-' + Math.random().toString(36).slice(2, 10);
-}
-
-function createEmptyTableFilterSet(name: string): FilterSet {
-	return {
-		id: generateTableFilterSetId(),
-		name,
-		icon: 'filter',
-		rootGroup: {
-			id: generateTableFilterGroupId(),
-			logic: 'all',
-			children: [],
-		},
-		sorts: [],
-		matchLogic: 'all',
-		conditions: [],
-	};
 }
 
 export class OperonTableView extends FileView {
@@ -1415,144 +1387,64 @@ export class OperonTableView extends FileView {
 		this.closeActivePicker();
 		const settings = this.getSettings();
 		const currentFilter = resolveTablePresetFilterSet(preset, settings.filterSets);
-		const draft = currentFilter
-			? cloneFilterSet(currentFilter)
-			: createEmptyTableFilterSet(this.createUniqueTableFilterName());
 		const sourceFilterSetId = currentFilter?.id ?? null;
-		const ownerDocument = getOwnerDocument(host);
-		const ownerWindow = ownerDocument.defaultView ?? window;
-		const floatingOptions = resolveSurfaceFloatingHostOptions(button);
-		const popoverHost = floatingOptions.floatingHost ?? ownerDocument.body;
-		const floatingScrollHost = floatingOptions.floatingScrollHost ?? ownerWindow;
-		const popover = popoverHost.createDiv('operon-table-filter-popover');
-		const popoverId = generateTableFilterPopoverId();
-		let editor: FilterSetModal | null = null;
-		let isClosed = false;
-		let repositionFrame: number | null = null;
-		popover.id = popoverId;
-		popover.setAttribute('role', 'dialog');
-		setAccessibleLabelWithoutTooltip(popover, t('table', 'filter'));
-		button.setAttribute('aria-expanded', 'true');
-		button.setAttribute('aria-controls', popoverId);
-
-		const close = (): void => {
-			if (isClosed) return;
-			isClosed = true;
-			if (this.activePickerClose === close) {
-				this.activePickerClose = null;
-				this.keepActivePickerOnRender = false;
-			}
-			ownerDocument.removeEventListener('pointerdown', handleDocumentPointerDown, true);
-			ownerDocument.removeEventListener('keydown', handleDocumentKeyDown, true);
-			ownerWindow.removeEventListener('resize', close);
-			floatingScrollHost.removeEventListener('scroll', scheduleReposition, true);
-			if (repositionFrame !== null) ownerWindow.cancelAnimationFrame(repositionFrame);
-			editor?.destroyInlineConditionEditor();
-			button.setAttribute('aria-expanded', 'false');
-			button.removeAttribute('aria-controls');
-			popover.remove();
-		};
-		const handleDocumentPointerDown = (event: PointerEvent): void => {
-			const target = event.target;
-			if (target && typeof (target as Node).nodeType === 'number' && host.contains(target as Node)) return;
-			if (editor?.isInlineEditorTarget(target)) return;
-			close();
-		};
-		const handleDocumentKeyDown = (event: KeyboardEvent): void => {
-			if (event.key !== 'Escape') return;
-			if (editor?.isInlineEditorFloatingTarget(event.target)) return;
-			event.preventDefault();
-			close();
-		};
-		const reposition = (): void => this.positionTableFilterPopover(popover, button);
-		const scheduleReposition = (): void => {
-			if (repositionFrame !== null) return;
-			repositionFrame = ownerWindow.requestAnimationFrame(() => {
-				repositionFrame = null;
-				if (!isClosed && popover.isConnected) reposition();
-			});
-		};
-
-		editor = new FilterSetModal(
-			this.app,
-			draft,
-			settings.keyMappings,
-			() => undefined,
-			undefined,
+		let closePopover: (() => void) | null = null;
+		closePopover = showPresetFilterPopover({
+			app: this.app,
+			anchor: button,
+			triggerHost: host,
+			label: t('table', 'filter'),
+			currentFilter,
+			newFilterName: this.createUniqueTableFilterName(),
+			keyMappings: settings.keyMappings,
+			filterModalOptions: {
+				getSettings: () => this.getSettings(),
+				getProjectSerialScopeTasks: () => this.indexer.getAllTasks(),
+				getFilePropertyDiscoveryTasks: () => this.indexer.getAllTasks(),
+				getFilePropertySnapshot: tasks => getTableFilePropertyIndex(this.app).getSnapshot(
+					tasks,
+					this.indexer.getGeneration(),
+					{ keyMappings: this.getSettings().keyMappings },
+				),
+			},
+			countTasks: filterSet => filterTasksForCalendar(
+				filterSet,
+				this.indexer.getAllTasks(),
+				this.getSettings().priorities,
+				this.getPinnedCache(),
 				{
-					getSettings: () => this.getSettings(),
-					getProjectSerialScopeTasks: () => this.indexer.getAllTasks(),
-					getFilePropertyDiscoveryTasks: () => this.indexer.getAllTasks(),
-					getFilePropertySnapshot: tasks => getTableFilePropertyIndex(this.app).getSnapshot(
-						tasks,
+					projectSerialScopes: this.getSettings().projectSerialScopes,
+					projectSerialScopeTasks: this.indexer.getAllTasks(),
+					dependencyTasks: this.indexer.getAllTasks(),
+					pipelines: this.getSettings().pipelines,
+					filePropertyContext: getTableFilePropertyIndex(this.app).getSnapshot(
+						this.indexer.getAllTasks(),
 						this.indexer.getGeneration(),
 						{ keyMappings: this.getSettings().keyMappings },
 					),
 				},
-		);
-		editor.renderInlineConditionEditor(popover, {
-			onCancel: close,
-			onSave: updated => {
-				void this.saveTableFilterPopoverDraft(updated, sourceFilterSetId, preset, close);
+			).length,
+			saveTooltip: sourceFilterSetId
+				? this.buildFilterUsageTooltip(sourceFilterSetId)
+				: undefined,
+			classNames: ['operon-table-filter-popover'],
+			onCommit: updated => this.saveTableFilterPopoverDraft(updated, sourceFilterSetId, preset),
+			onCommitError: error => {
+				console.error('Operon: failed to save table filter popover draft', error);
+				new Notice(t('table', 'presetActionFailed'));
 			},
-				countTasks: filterSet => filterTasksForCalendar(
-					filterSet,
-					this.indexer.getAllTasks(),
-					this.getSettings().priorities,
-					this.getPinnedCache(),
-							{
-								projectSerialScopes: this.getSettings().projectSerialScopes,
-								projectSerialScopeTasks: this.indexer.getAllTasks(),
-								dependencyTasks: this.indexer.getAllTasks(),
-								pipelines: this.getSettings().pipelines,
-								filePropertyContext: getTableFilePropertyIndex(this.app).getSnapshot(
-								this.indexer.getAllTasks(),
-								this.indexer.getGeneration(),
-								{ keyMappings: this.getSettings().keyMappings },
-							),
-						},
-				).length,
-				saveTooltip: sourceFilterSetId
-					? this.buildFilterUsageTooltip(sourceFilterSetId)
-					: undefined,
-			});
-		reposition();
-
+			onClose: close => {
+				if (this.activePickerClose === close) {
+					this.activePickerClose = null;
+					this.keepActivePickerOnRender = false;
+				}
+			},
+			resolveFallbackFocusTarget: () => this.contentEl.querySelector<HTMLButtonElement>(
+				'button.operon-table-filter-popover-button',
+			),
+		});
 		this.keepActivePickerOnRender = true;
-		this.activePickerClose = close;
-		ownerDocument.addEventListener('pointerdown', handleDocumentPointerDown, true);
-		ownerDocument.addEventListener('keydown', handleDocumentKeyDown, true);
-		ownerWindow.addEventListener('resize', close);
-		floatingScrollHost.addEventListener('scroll', scheduleReposition, true);
-	}
-
-	private positionTableFilterPopover(popover: HTMLElement, button: HTMLElement): void {
-		const rect = button.getBoundingClientRect();
-		const ownerDocument = getOwnerDocument(button);
-		const ownerWindow = ownerDocument.defaultView ?? window;
-		const floatingOptions = resolveSurfaceFloatingHostOptions(button);
-		const floatingHost = floatingOptions.floatingHost;
-		const hostRect = floatingHost?.getBoundingClientRect();
-		const hostScrollLeft = floatingHost?.scrollLeft ?? 0;
-		const hostScrollTop = floatingHost?.scrollTop ?? 0;
-		const margin = 12;
-		const gap = 6;
-		const availableWidth = Math.max(240, (floatingHost?.clientWidth ?? ownerWindow.innerWidth) - margin * 2);
-		const availableHeight = floatingHost?.clientHeight ?? ownerWindow.innerHeight;
-		const width = Math.min(760, availableWidth);
-		const anchorRight = hostRect ? rect.right - hostRect.left + hostScrollLeft : rect.right;
-		const anchorBottom = hostRect ? rect.bottom - hostRect.top + hostScrollTop : rect.bottom;
-		const left = Math.max(hostScrollLeft + margin, Math.min(
-			anchorRight - width,
-			hostScrollLeft + availableWidth - width - margin,
-		));
-		const top = Math.max(hostScrollTop + margin, anchorBottom + gap);
-		const maxHeight = Math.max(240, hostScrollTop + availableHeight - top - margin);
-		popover.style.width = `${Math.round(width)}px`;
-		popover.style.position = floatingHost ? 'absolute' : 'fixed';
-		popover.style.left = `${Math.round(left)}px`;
-		popover.style.top = `${Math.round(top)}px`;
-		popover.style.maxHeight = `${Math.round(maxHeight)}px`;
+		this.activePickerClose = closePopover;
 	}
 
 	private createUniqueTableFilterName(): string {
@@ -1600,25 +1492,20 @@ export class OperonTableView extends FileView {
 		filterSet: FilterSet,
 		sourceFilterSetId: string | null,
 		preset: TablePreset,
-		close: () => void,
 	): Promise<void> {
 		if (!this.callbacks.onSaveFilterSet) {
-			new Notice(t('table', 'presetActionFailed'));
-			return;
+			throw new Error('Operon: Table filter save callback is unavailable.');
 		}
-		try {
-			await this.callbacks.onSaveFilterSet(filterSet);
-			if (!sourceFilterSetId) {
-				const ticket = this.callbacks.onSavePresetPatch?.({
-					id: preset.id,
-					filterSetId: filterSet.id,
-				}, { surfaceToken: this.surfaceToken });
-				await ticket?.flush();
+		await this.callbacks.onSaveFilterSet(filterSet);
+		if (!sourceFilterSetId) {
+			if (!this.callbacks.onSavePresetPatch) {
+				throw new Error('Operon: Table preset save callback is unavailable.');
 			}
-			close();
-		} catch (error) {
-			console.error('Operon: failed to save table filter popover draft', error);
-			new Notice(t('table', 'presetActionFailed'));
+			const ticket = this.callbacks.onSavePresetPatch({
+				id: preset.id,
+				filterSetId: filterSet.id,
+			}, { surfaceToken: this.surfaceToken });
+			await ticket.flush();
 		}
 	}
 

--- a/src/ui/table/operon-table-view.ts
+++ b/src/ui/table/operon-table-view.ts
@@ -152,7 +152,11 @@ import { setAccessibleLabelWithoutTooltip } from '../accessibility-label';
 import { resolveSurfaceFloatingHostOptions, snapshotFloatingRectAnchor } from '../field-pickers/common';
 import { openWebViewerNewTab } from '../external-link-actions';
 import { bindOperonHoverTooltip, cleanupOperonHoverTooltips } from '../operon-hover-tooltip';
-import { showPresetFilterPopover } from '../preset-filter-popover';
+import {
+	buildPresetFilterUsageTooltip,
+	createUniquePresetFilterName,
+	showPresetFilterPopover,
+} from '../preset-filter-popover';
 import { bindTableTaskContextualHoverMenu, renderTableTaskIconButton } from './table-task-icon-button';
 import { bindTableTaskTypeEditorOpen, renderTableTaskTypeButton } from './table-task-type-button';
 import {
@@ -1395,7 +1399,7 @@ export class OperonTableView extends FileView {
 			triggerHost: host,
 			label: t('table', 'filter'),
 			currentFilter,
-			newFilterName: this.createUniqueTableFilterName(),
+			newFilterName: createUniquePresetFilterName(t('table', 'newFilterName'), settings.filterSets),
 			keyMappings: settings.keyMappings,
 			filterModalOptions: {
 				getSettings: () => this.getSettings(),
@@ -1425,7 +1429,7 @@ export class OperonTableView extends FileView {
 				},
 			).length,
 			saveTooltip: sourceFilterSetId
-				? this.buildFilterUsageTooltip(sourceFilterSetId)
+				? buildPresetFilterUsageTooltip(settings, sourceFilterSetId)
 				: undefined,
 			classNames: ['operon-table-filter-popover'],
 			onCommit: updated => this.saveTableFilterPopoverDraft(updated, sourceFilterSetId, preset),
@@ -1445,47 +1449,6 @@ export class OperonTableView extends FileView {
 		});
 		this.keepActivePickerOnRender = true;
 		this.activePickerClose = closePopover;
-	}
-
-	private createUniqueTableFilterName(): string {
-		const baseName = t('table', 'newFilterName');
-		const existingNames = new Set(
-			this.getSettings().filterSets.map(filterSet => filterSet.name.trim().toLocaleLowerCase()),
-		);
-		if (!existingNames.has(baseName.toLocaleLowerCase())) return baseName;
-		let suffix = 2;
-		while (existingNames.has(`${baseName} ${suffix}`.toLocaleLowerCase())) {
-			suffix += 1;
-		}
-		return `${baseName} ${suffix}`;
-	}
-
-	private buildFilterUsageTooltip(filterSetId: string): { title: string; content: string } | undefined {
-		const settings = this.getSettings();
-		const lines: string[] = [];
-		const calendarPresets = settings.calendarPresets
-			.filter(entry => entry.filterSetId === filterSetId)
-			.map(entry => entry.name.trim() || entry.id);
-		const kanbanPresets = settings.kanbanPresets
-			.filter(entry => entry.filterSetId === filterSetId)
-			.map(entry => entry.name.trim() || entry.id);
-		const tablePresets = settings.tablePresets
-			.filter(entry => entry.filterSetId === filterSetId)
-			.map(entry => entry.name.trim() || entry.id);
-		if (calendarPresets.length > 0) {
-			lines.push(`${t('filterSets', 'usedByCalendar')}: ${calendarPresets.join(', ')}`);
-		}
-		if (kanbanPresets.length > 0) {
-			lines.push(`${t('filterSets', 'usedByKanban')}: ${kanbanPresets.join(', ')}`);
-		}
-		if (tablePresets.length > 0) {
-			lines.push(`${t('filterSets', 'usedByTable')}: ${tablePresets.join(', ')}`);
-		}
-		if (lines.length === 0) return undefined;
-		return {
-			title: t('filterSets', 'usedByTitle'),
-			content: lines.join(' · '),
-		};
 	}
 
 	private async saveTableFilterPopoverDraft(

--- a/src/ui/table/operon-table-view.ts
+++ b/src/ui/table/operon-table-view.ts
@@ -55,7 +55,7 @@ import {
 import {
 	formatTableTaskSource,
 } from './table-value-adapter';
-import { formatTableDependencyTooltipContent, renderTableCellChips } from './table-cell-chip';
+import { formatTableDependencyTooltipContent, formatTableDetailedDatetimeValue, renderTableCellChips } from './table-cell-chip';
 import { resolveTableColumnCellAccent, resolveTableIconOnlyCellAccent } from './table-column-color';
 import { renderTableDescriptionCellContent, type TableInlineEditSession } from './table-description-cell';
 import { bindMobileTableViewport, isMobileTableTextInputFocused } from './mobile-table-viewport';
@@ -818,7 +818,7 @@ export class OperonTableView extends FileView {
 			};
 		}
 		const rowHeight = resolveTableRowHeight(result.preset);
-		const columnGeometry = buildTableColumnGeometry(columns);
+		const columnGeometry = buildTableColumnGeometry(columns, settings);
 		const tableWidthPx = columnGeometry.tableWidthPx;
 		const scrollbarGutterPx = measureTableScrollbarGutterPx(this.contentEl.ownerDocument);
 		const searchControlSignature = this.buildSearchControlSignature(searchContext.parentSearchUi);
@@ -2090,15 +2090,19 @@ export class OperonTableView extends FileView {
 			task,
 			locationResolver: renderState.locationResolver,
 		});
-		const content = locationVisual?.label
+		const field = getTableTaskField(column.key, renderState.settings);
+		const content = field?.type === 'datetime'
+			? formatTableDetailedDatetimeValue(column.key, value, renderState.settings)
+			: locationVisual?.label
 			?? formatTableDependencyTooltipContent(column.key, value, renderState.valueResolver.taskLookup)
 			?? formatTableIconOnlyTooltipContent(value);
-		const fallbackIcon = getTableTaskField(column.key, renderState.settings)?.icon ?? 'text';
+		const fallbackIcon = field?.icon ?? 'text';
 		const isTaskIconColumn = column.key === 'taskIcon';
 		const isTaskTypeColumn = column.key === 'taskType';
-		if (column.key === 'datetimeStart' || column.key === 'datetimeEnd') {
+		if (field?.type === 'datetime') {
 			renderTableCompactDatetimeCell(cell, {
 				value,
+				timeFormat: renderState.settings.timeFormat,
 				title: fieldLabel,
 				content,
 				ariaLabel: `${fieldLabel}: ${content}`,

--- a/src/ui/table/table-cell-chip.ts
+++ b/src/ui/table/table-cell-chip.ts
@@ -20,9 +20,11 @@ import {
 	resolveBlockedByVisualStateForId,
 } from '../../core/blocked-by-visual-state';
 import type { TableTaskLookup } from './table-value-adapter';
+import { parseLocalDatetime } from '../../systems/tracker-utils';
 
-type TableCellChipSettings = Pick<OperonSettings, 'colorPalette' | 'keyMappings' | 'pipelines' | 'priorities'>;
+type TableCellChipSettings = Pick<OperonSettings, 'colorPalette' | 'keyMappings' | 'pipelines' | 'priorities' | 'timeFormat'>;
 const TABLE_DEPENDENCY_DESCRIPTION_MAX_LENGTH = 37;
+const TABLE_DETAILED_DATETIME_RE = /^(\d{4}-\d{2}-\d{2})[T ](\d{2}):(\d{2}):(\d{2})$/u;
 
 export interface TableCellChipRenderOptions {
 	column?: Pick<TableColumn, 'key' | 'colorMode'>;
@@ -84,7 +86,7 @@ export function renderTableCellChipContent(
 		renderTableExternalLinkChip(chip, externalLink, options.onExternalLinkModifierActivate!);
 		return;
 	}
-	const displayValue = formatTableDetailedDatetimeValue(key, value);
+	const displayValue = formatTableDetailedDatetimeValue(key, value, options.settings);
 	const locationVisual = resolveTableLocationCellVisual(key, value, options);
 	if (locationVisual) {
 		renderTableLocationChipContent(
@@ -163,9 +165,26 @@ function renderTableExternalLinkChip(
 	});
 }
 
-export function formatTableDetailedDatetimeValue(key: string, value: string): string {
-	if (key !== 'datetimeStart' && key !== 'datetimeEnd') return value;
-	return value.replace(/^(\d{4}-\d{2}-\d{2})T/u, '$1 ');
+export function formatTableDetailedDatetimeValue(
+	key: string,
+	value: string,
+	settings?: TableCellChipSettings,
+): string {
+	const isDatetime = settings
+		? getTableTaskField(key, settings)?.type === 'datetime'
+		: key === 'datetimeStart' || key === 'datetimeEnd';
+	if (!isDatetime) return value;
+
+	const trimmed = value.trim();
+	const match = TABLE_DETAILED_DATETIME_RE.exec(trimmed);
+	if (!match) return value;
+	const [, date, hourText, minute, second] = match;
+	if (!parseLocalDatetime(`${date}T${hourText}:${minute}:${second}`)) return value;
+	if (settings?.timeFormat !== '12h') return `${date} ${hourText}:${minute}:${second}`;
+
+	const hour = Number(hourText);
+	const displayHour = hour % 12 || 12;
+	return `${date} ${displayHour}:${minute}:${second} ${hour < 12 ? 'AM' : 'PM'}`;
 }
 
 function getTableCellChipItems(

--- a/src/ui/table/table-cell-chip.ts
+++ b/src/ui/table/table-cell-chip.ts
@@ -20,11 +20,12 @@ import {
 	resolveBlockedByVisualStateForId,
 } from '../../core/blocked-by-visual-state';
 import type { TableTaskLookup } from './table-value-adapter';
-import { parseLocalDatetime } from '../../systems/tracker-utils';
+import { formatTableDetailedDatetimeValue } from './table-datetime-format';
+
+export { formatTableDetailedDatetimeValue } from './table-datetime-format';
 
 type TableCellChipSettings = Pick<OperonSettings, 'colorPalette' | 'keyMappings' | 'pipelines' | 'priorities' | 'timeFormat'>;
 const TABLE_DEPENDENCY_DESCRIPTION_MAX_LENGTH = 37;
-const TABLE_DETAILED_DATETIME_RE = /^(\d{4}-\d{2}-\d{2})[T ](\d{2}):(\d{2}):(\d{2})$/u;
 
 export interface TableCellChipRenderOptions {
 	column?: Pick<TableColumn, 'key' | 'colorMode'>;
@@ -163,28 +164,6 @@ function renderTableExternalLinkChip(
 		event.preventDefault();
 		event.stopPropagation();
 	});
-}
-
-export function formatTableDetailedDatetimeValue(
-	key: string,
-	value: string,
-	settings?: TableCellChipSettings,
-): string {
-	const isDatetime = settings
-		? getTableTaskField(key, settings)?.type === 'datetime'
-		: key === 'datetimeStart' || key === 'datetimeEnd';
-	if (!isDatetime) return value;
-
-	const trimmed = value.trim();
-	const match = TABLE_DETAILED_DATETIME_RE.exec(trimmed);
-	if (!match) return value;
-	const [, date, hourText, minute, second] = match;
-	if (!parseLocalDatetime(`${date}T${hourText}:${minute}:${second}`)) return value;
-	if (settings?.timeFormat !== '12h') return `${date} ${hourText}:${minute}:${second}`;
-
-	const hour = Number(hourText);
-	const displayHour = hour % 12 || 12;
-	return `${date} ${displayHour}:${minute}:${second} ${hour < 12 ? 'AM' : 'PM'}`;
 }
 
 function getTableCellChipItems(

--- a/src/ui/table/table-datetime-format.ts
+++ b/src/ui/table/table-datetime-format.ts
@@ -1,0 +1,65 @@
+import { parseLocalDatetime } from '../../systems/tracker-utils';
+import type { OperonSettings } from '../../types/settings';
+import { getTableTaskField } from './table-field-catalog';
+
+type TableDatetimeFormatSettings = Pick<OperonSettings, 'keyMappings' | 'timeFormat'>;
+
+const TABLE_DATETIME_RE = /^(\d{4}-\d{2}-\d{2})[T ](\d{2}):(\d{2}):(\d{2})$/u;
+
+interface ParsedTableDatetime {
+	date: string;
+	hour: number;
+	hourText: string;
+	minute: string;
+	second: string;
+}
+
+export function formatTableDetailedDatetimeValue(
+	key: string,
+	value: string,
+	settings?: TableDatetimeFormatSettings,
+): string {
+	const isDatetime = settings
+		? getTableTaskField(key, settings)?.type === 'datetime'
+		: key === 'datetimeStart' || key === 'datetimeEnd';
+	if (!isDatetime) return value;
+
+	const parsed = parseTableDatetime(value);
+	if (!parsed) return value;
+	if (settings?.timeFormat !== '12h') {
+		return `${parsed.date} ${parsed.hourText}:${parsed.minute}:${parsed.second}`;
+	}
+	return `${parsed.date} ${formatTwelveHour(parsed.hour)}:${parsed.minute}:${parsed.second} ${resolveDayPeriod(parsed.hour)}`;
+}
+
+export function formatTableCompactDatetimeValue(
+	value: string,
+	timeFormat: Pick<OperonSettings, 'timeFormat'>['timeFormat'] = '24h',
+): string {
+	const parsed = parseTableDatetime(value);
+	if (!parsed) return value.trim();
+	if (timeFormat !== '12h') return `${parsed.hourText}:${parsed.minute}`;
+	return `${String(formatTwelveHour(parsed.hour)).padStart(2, '0')}:${parsed.minute} ${resolveDayPeriod(parsed.hour)}`;
+}
+
+function parseTableDatetime(value: string): ParsedTableDatetime | null {
+	const match = TABLE_DATETIME_RE.exec(value.trim());
+	if (!match) return null;
+	const [, date, hourText, minute, second] = match;
+	if (!parseLocalDatetime(`${date}T${hourText}:${minute}:${second}`)) return null;
+	return {
+		date,
+		hour: Number(hourText),
+		hourText,
+		minute,
+		second,
+	};
+}
+
+function formatTwelveHour(hour: number): number {
+	return hour % 12 || 12;
+}
+
+function resolveDayPeriod(hour: number): 'AM' | 'PM' {
+	return hour < 12 ? 'AM' : 'PM';
+}

--- a/src/ui/table/table-header-interactions.ts
+++ b/src/ui/table/table-header-interactions.ts
@@ -256,7 +256,7 @@ export function applyInteractiveTableColumnTemplate(
 	currentRenderState: TableHeaderRenderState | null,
 	columns: readonly TableColumn[],
 ): TableColumnGeometry {
-	const columnGeometry = buildTableColumnGeometry(columns);
+	const columnGeometry = buildTableColumnGeometry(columns, currentRenderState?.settings);
 	const template = columnGeometry.columnTemplate;
 	const tableWidthPx = columnGeometry.tableWidthPx;
 	const tableWidth = `${tableWidthPx}px`;

--- a/src/ui/table/table-icon-only-cell.ts
+++ b/src/ui/table/table-icon-only-cell.ts
@@ -6,6 +6,9 @@ import type { OperonSettings } from '../../types/settings';
 import { bindOperonHoverTooltip } from '../operon-hover-tooltip';
 import { setAccessibleLabelWithoutTooltip } from '../accessibility-label';
 import type { WorkflowStatusIdentityIndex } from '../../core/workflow-status-identity';
+import { formatTableCompactDatetimeValue } from './table-datetime-format';
+
+export { formatTableCompactDatetimeValue } from './table-datetime-format';
 
 type TableValueIconSettings = Pick<OperonSettings, 'pipelines' | 'priorities'>;
 
@@ -24,12 +27,8 @@ export interface TableIconOnlyCellOptions {
 
 export type TableCompactDatetimeCellOptions = Omit<TableIconOnlyCellOptions, 'icon'> & {
 	value: string;
+	timeFormat: Pick<OperonSettings, 'timeFormat'>['timeFormat'];
 };
-
-export function formatTableCompactDatetimeValue(value: string): string {
-	const match = /(?:^|[T\s])(\d{2}):(\d{2})(?::\d{2})?(?:$|[.+-])/u.exec(value.trim());
-	return match ? `${match[1]}:${match[2]}` : value.trim();
-}
 
 export function renderTableCompactDatetimeCell(
 	cell: HTMLElement,
@@ -44,7 +43,7 @@ export function renderTableCompactDatetimeCell(
 		control.style.setProperty('--operon-live-hover-border', options.color);
 		control.style.setProperty('--operon-task-chip-hover-accent', options.color);
 	}
-	control.setText(formatTableCompactDatetimeValue(options.value));
+	control.setText(formatTableCompactDatetimeValue(options.value, options.timeFormat));
 	if (options.showTooltip !== false) {
 		bindOperonHoverTooltip(control, {
 			title: options.title,

--- a/src/ui/table/table-surface.ts
+++ b/src/ui/table/table-surface.ts
@@ -13,7 +13,7 @@ import {
 import type { OperonSettings } from '../../types/settings';
 import { createTableGroupPathKey, type TableQueryGroup, type TableQuerySubgroup } from '../../systems/table-query';
 import { t } from '../../core/i18n';
-import { buildTableTaskFieldCatalog } from './table-field-catalog';
+import { buildTableTaskFieldCatalog, getTableTaskField } from './table-field-catalog';
 import { orderTablePresetColumnsByPinState } from './table-preset-model';
 import { isTableFilePropertyColumnKey } from './table-file-property';
 
@@ -22,6 +22,7 @@ export const TABLE_COMFORTABLE_ROW_HEIGHT = 44;
 export const TABLE_OVERSCAN_ROWS = 8;
 export const TABLE_DEFAULT_BODY_HEIGHT = 520;
 export const TABLE_ICON_ONLY_COLUMN_WIDTH = 56;
+export const TABLE_COMPACT_DATETIME_12H_COLUMN_WIDTH = 76;
 export const TABLE_SUBGROUP_PARENT_LABEL_MAX_LENGTH = 15;
 
 export type TableRenderItem =
@@ -77,6 +78,8 @@ export interface TableColumnGeometry {
 	lastPinnedIndex: number;
 	signature: string;
 }
+
+type TableColumnWidthSettings = Pick<OperonSettings, 'keyMappings' | 'timeFormat'>;
 
 export function buildTableRenderItems(
 	rows: readonly IndexedTask[],
@@ -172,12 +175,12 @@ export function resolveTableRowHeight(preset: TablePreset): number {
 	return preset.display.density === 'comfortable' ? TABLE_COMFORTABLE_ROW_HEIGHT : TABLE_ROW_HEIGHT;
 }
 
-export function buildTableColumnTemplate(columns: readonly TableColumn[]): string {
-	return buildTableColumnGeometry(columns).columnTemplate;
+export function buildTableColumnTemplate(columns: readonly TableColumn[], settings?: TableColumnWidthSettings): string {
+	return buildTableColumnGeometry(columns, settings).columnTemplate;
 }
 
-export function calculateTableMinWidth(columns: readonly TableColumn[]): number {
-	return buildTableColumnGeometry(columns).tableWidthPx;
+export function calculateTableMinWidth(columns: readonly TableColumn[], settings?: TableColumnWidthSettings): number {
+	return buildTableColumnGeometry(columns, settings).tableWidthPx;
 }
 
 export function calculateTableLeadingAdminWidth(columns: readonly TableColumn[]): number {
@@ -189,13 +192,16 @@ export function calculateTableLeadingAdminWidth(columns: readonly TableColumn[])
 	return total;
 }
 
-export function buildTableColumnGeometry(columns: readonly TableColumn[]): TableColumnGeometry {
+export function buildTableColumnGeometry(
+	columns: readonly TableColumn[],
+	settings?: TableColumnWidthSettings,
+): TableColumnGeometry {
 	let tableWidthPx = 0;
 	let pinnedBoundaryPx = 0;
 	let lastPinnedIndex = -1;
 	let inPinnedSegment = true;
 	const entries: TableColumnGeometryEntry[] = columns.map((column, index): TableColumnGeometryEntry => {
-		const widthPx = resolveTableColumnWidth(column);
+		const widthPx = resolveTableColumnWidth(column, settings);
 		const stickyLeftPx = tableWidthPx;
 		const pinned = inPinnedSegment && isTableColumnRenderPinned(column);
 		if (pinned) {
@@ -254,8 +260,12 @@ export function measureTableScrollbarGutterPx(ownerDocument: Document): number {
 	return gutter;
 }
 
-export function resolveTableColumnWidth(column: TableColumn): number {
+export function resolveTableColumnWidth(column: TableColumn, settings?: TableColumnWidthSettings): number {
 	if (column.kind === 'task' && resolveTableColumnDisplayMode(column) === 'icon') {
+		if (
+			settings?.timeFormat === '12h'
+			&& getTableTaskField(column.key, settings)?.type === 'datetime'
+		) return TABLE_COMPACT_DATETIME_12H_COLUMN_WIDTH;
 		return TABLE_ICON_ONLY_COLUMN_WIDTH;
 	}
 	return column.widthPx ?? DEFAULT_TABLE_COLUMN_WIDTHS[column.key] ?? 150;

--- a/src/ui/table/table-surface.ts
+++ b/src/ui/table/table-surface.ts
@@ -23,6 +23,7 @@ export const TABLE_OVERSCAN_ROWS = 8;
 export const TABLE_DEFAULT_BODY_HEIGHT = 520;
 export const TABLE_ICON_ONLY_COLUMN_WIDTH = 56;
 export const TABLE_COMPACT_DATETIME_12H_COLUMN_WIDTH = 76;
+export const TABLE_DETAILED_DATETIME_12H_WIDTH_DELTA = 20;
 export const TABLE_SUBGROUP_PARENT_LABEL_MAX_LENGTH = 15;
 
 export type TableRenderItem =
@@ -268,7 +269,14 @@ export function resolveTableColumnWidth(column: TableColumn, settings?: TableCol
 		) return TABLE_COMPACT_DATETIME_12H_COLUMN_WIDTH;
 		return TABLE_ICON_ONLY_COLUMN_WIDTH;
 	}
-	return column.widthPx ?? DEFAULT_TABLE_COLUMN_WIDTHS[column.key] ?? 150;
+	if (column.widthPx !== undefined) return column.widthPx;
+	const defaultWidth = DEFAULT_TABLE_COLUMN_WIDTHS[column.key] ?? 150;
+	if (
+		column.kind === 'task'
+		&& settings?.timeFormat === '12h'
+		&& getTableTaskField(column.key, settings)?.type === 'datetime'
+	) return defaultWidth + TABLE_DETAILED_DATETIME_12H_WIDTH_DELTA;
+	return defaultWidth;
 }
 
 export function resolveTableColumnAlignment(column: TableColumn): TableColumnAlignment {

--- a/src/ui/table/table-task-type-button.ts
+++ b/src/ui/table/table-task-type-button.ts
@@ -1,14 +1,32 @@
 import { setIcon } from 'obsidian';
+import type { ContextualMenuActionHandler } from '../../core/contextual-menu-engine';
 import type { IndexedTask } from '../../types/fields';
+import type { OperonSettings } from '../../types/settings';
 import { resolveSubtaskActionIcon } from '../../core/subtask-action';
 import { t } from '../../core/i18n';
 import { setAccessibleLabelWithoutTooltip } from '../accessibility-label';
 import { isTaskSourceOpenModifierClick } from '../task-source-open-modifier';
+import { bindTableTaskContextualHoverMenu } from './table-task-icon-button';
 
 export interface TableTaskTypeButtonOptions {
 	task: IndexedTask;
 	onOpenTaskEditor?: (operonId: string) => void;
 	onOpenTaskSource?: (operonId: string) => void | Promise<void>;
+	settings?: OperonSettings;
+	onContextualAction?: ContextualMenuActionHandler;
+	isPinned?: (taskId: string) => boolean;
+	hasSubtasks?: (taskId: string) => boolean;
+}
+
+function bindTableTaskTypeContextualHoverMenu(trigger: HTMLElement, options: TableTaskTypeButtonOptions): void {
+	if (!options.settings || !options.onContextualAction) return;
+	bindTableTaskContextualHoverMenu(trigger, {
+		task: options.task,
+		settings: options.settings,
+		onContextualAction: options.onContextualAction,
+		isPinned: options.isPinned,
+		hasSubtasks: options.hasSubtasks,
+	});
 }
 
 function handleTableTaskTypeClick(event: MouseEvent, options: TableTaskTypeButtonOptions): void {
@@ -24,19 +42,21 @@ function handleTableTaskTypeClick(event: MouseEvent, options: TableTaskTypeButto
 }
 
 export function bindTableTaskTypeEditorOpen(trigger: HTMLElement, options: TableTaskTypeButtonOptions): void {
-	if (!options.onOpenTaskEditor && !options.onOpenTaskSource) return;
-	trigger.addClass('is-task-type-editor-trigger');
-	trigger.setAttribute('role', 'button');
-	setAccessibleLabelWithoutTooltip(trigger, t('tooltips', 'openTaskEditor'));
-	trigger.addEventListener('click', event => {
-		handleTableTaskTypeClick(event, options);
-	});
-	trigger.addEventListener('keydown', event => {
-		if (event.key !== 'Enter' && event.key !== ' ') return;
-		event.preventDefault();
-		event.stopPropagation();
-		options.onOpenTaskEditor?.(options.task.operonId);
-	});
+	if (options.onOpenTaskEditor || options.onOpenTaskSource) {
+		trigger.addClass('is-task-type-editor-trigger');
+		trigger.setAttribute('role', 'button');
+		setAccessibleLabelWithoutTooltip(trigger, t('tooltips', 'openTaskEditor'));
+		trigger.addEventListener('click', event => {
+			handleTableTaskTypeClick(event, options);
+		});
+		trigger.addEventListener('keydown', event => {
+			if (event.key !== 'Enter' && event.key !== ' ') return;
+			event.preventDefault();
+			event.stopPropagation();
+			options.onOpenTaskEditor?.(options.task.operonId);
+		});
+	}
+	bindTableTaskTypeContextualHoverMenu(trigger, options);
 }
 
 export function renderTableTaskTypeButton(container: HTMLElement, options: TableTaskTypeButtonOptions): void {
@@ -49,4 +69,5 @@ export function renderTableTaskTypeButton(container: HTMLElement, options: Table
 	button.addEventListener('click', event => {
 		handleTableTaskTypeClick(event, options);
 	});
+	bindTableTaskTypeContextualHoverMenu(button, options);
 }

--- a/styles.css
+++ b/styles.css
@@ -21612,6 +21612,10 @@ body .operon-calendar-root button.operon-calendar-lane-toggle-button:is(:hover, 
 	padding-right: 18px;
 }
 
+.operon-calendar-all-day-item.is-finished-date-draggable {
+	cursor: grab;
+}
+
 .operon-calendar-all-day-item.is-clickable,
 .operon-calendar-timed-item.is-clickable {
 	cursor: pointer;
@@ -21890,26 +21894,30 @@ body .operon-calendar-root button.operon-calendar-lane-toggle-button:is(:hover, 
 }
 
 .operon-calendar-multi-week-inday-item {
+	--operon-calendar-inday-surface-border-color: color-mix(in srgb, var(--operon-calendar-accent, var(--interactive-accent)) 20%, var(--background-modifier-border));
+	--operon-calendar-inday-surface-border-style: solid;
+	--operon-calendar-inday-surface-background: color-mix(in srgb, var(--operon-calendar-accent, var(--interactive-accent)) 12%, var(--background-secondary));
 	display: flex;
 	align-items: stretch;
 	min-width: 0;
 	padding: 6px 8px;
 	border-radius: 6px;
-	border: 1px solid color-mix(in srgb, var(--operon-calendar-accent, var(--interactive-accent)) 20%, var(--background-modifier-border));
-	background: color-mix(in srgb, var(--operon-calendar-accent, var(--interactive-accent)) 12%, var(--background-secondary));
+	border: 1px var(--operon-calendar-inday-surface-border-style) var(--operon-calendar-inday-surface-border-color);
+	background: var(--operon-calendar-inday-surface-background);
 	color: var(--text-normal);
 	font-size: var(--font-ui-smaller);
 }
 
 .operon-calendar-multi-week-inday-item.is-dashed {
-	background: color-mix(in srgb, var(--operon-calendar-accent, var(--interactive-accent)) 8%, transparent);
-	border-style: dashed;
+	--operon-calendar-inday-surface-border-style: dashed;
+	--operon-calendar-inday-surface-background: color-mix(in srgb, var(--operon-calendar-accent, var(--interactive-accent)) 8%, transparent);
 }
 
 .operon-calendar-multi-week-inday-item.is-projected {
+	--operon-calendar-inday-surface-border-color: color-mix(in srgb, var(--background-modifier-border) 88%, white 12%);
+	--operon-calendar-inday-surface-border-style: dashed;
+	--operon-calendar-inday-surface-background: color-mix(in srgb, var(--background-secondary) 18%, transparent);
 	opacity: 0.68;
-	background: color-mix(in srgb, var(--background-secondary) 18%, transparent);
-	border: 1px dashed color-mix(in srgb, var(--background-modifier-border) 88%, white 12%);
 }
 
 .operon-calendar-multi-week-inday-item.is-done {
@@ -21970,7 +21978,8 @@ body .operon-calendar-root button.operon-calendar-lane-toggle-button:is(:hover, 
 	gap: 4px;
 	padding: 2px 6px;
 	border-radius: 6px;
-	background: color-mix(in srgb, var(--interactive-accent) 10%, transparent);
+	border: 1px var(--operon-calendar-inday-surface-border-style) var(--operon-calendar-inday-surface-border-color);
+	background: var(--operon-calendar-inday-surface-background);
 	color: var(--text-muted);
 	font-size: 10px;
 	font-weight: 600;

--- a/styles.css
+++ b/styles.css
@@ -23856,6 +23856,25 @@ button.operon-kanban-toolbar-settings-button {
 	transition: background-color 120ms ease, border-color 120ms ease, color 120ms ease;
 }
 
+.operon-kanban-filter-popover-host {
+	position: relative;
+	display: flex;
+	flex: 0 0 34px;
+	width: 34px;
+	min-width: 34px;
+}
+
+button.operon-kanban-filter-popover-button {
+	width: 34px;
+	padding-right: 0;
+	padding-left: 0;
+}
+
+button.operon-kanban-filter-popover-button.is-active {
+	border-color: var(--interactive-accent);
+	color: var(--interactive-accent);
+}
+
 .operon-kanban-toolbar-search-wrap {
 	position: relative;
 	display: flex;
@@ -23936,6 +23955,10 @@ button.operon-kanban-toolbar-settings-button {
 	display: none;
 }
 
+.operon-kanban-toolbar.is-phone-preset-dropdown .operon-kanban-toolbar-preset-settings-button {
+	display: none;
+}
+
 .operon-kanban-toolbar.is-phone-preset-dropdown .operon-kanban-toolbar-start {
 	min-width: 0;
 	justify-content: flex-start;
@@ -23949,11 +23972,11 @@ button.operon-kanban-toolbar-settings-button {
 .operon-kanban-toolbar.is-phone-preset-dropdown .operon-kanban-toolbar-mobile-preset-select {
 	display: block;
 	width: min(100%, 180px);
-	max-width: 42vw;
+	max-width: 38vw;
 }
 
 .operon-kanban-toolbar.is-phone-preset-dropdown .operon-kanban-toolbar-search {
-	width: clamp(112px, 34vw, 160px);
+	width: clamp(96px, 30vw, 144px);
 }
 
 .operon-kanban-toolbar-search::-webkit-search-cancel-button,

--- a/styles.css
+++ b/styles.css
@@ -15167,6 +15167,7 @@ body:not(.is-mobile) .mod-root .workspace-leaf-content[data-type="operon-filter-
 }
 
 .operon-filter-set-modal-shell,
+.operon-preset-filter-popover,
 .operon-table-filter-popover {
 	--operon-filter-modal-control-border: color-mix(in srgb, var(--background-modifier-border) 84%, transparent);
 	--operon-filter-modal-control-hover-border: color-mix(in srgb, var(--interactive-accent) 78%, var(--background-modifier-border));
@@ -15892,10 +15893,10 @@ button.operon-field-picker-trigger,
 	box-shadow: 0 0 0 2px color-mix(in srgb, var(--text-error) 22%, transparent);
 }
 
-/* Shared neutral controls for full FilterSetModal and compact Table filter editors. */
+/* Shared neutral controls for full FilterSetModal and compact preset filter editors. */
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-table-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover .operon-filter-inline-editor
 ) :is(
 	select.operon-filter-select,
 	button.operon-filter-select,
@@ -15925,7 +15926,7 @@ body :is(
 
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-table-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover .operon-filter-inline-editor
 ) select.operon-filter-select {
 	background-image: var(--operon-filter-modal-control-chevron);
 	background-position:
@@ -15938,7 +15939,7 @@ body :is(
 
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-table-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover .operon-filter-inline-editor
 ) :is(
 	select.operon-filter-select,
 	button.operon-filter-select,
@@ -15961,11 +15962,11 @@ body :is(
 
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-table-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover .operon-filter-inline-editor
 ) .operon-filter-modal-logic-button.is-active,
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-table-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover .operon-filter-inline-editor
 ) .operon-preset-favorite-button:is(.is-active, [aria-pressed="true"]) {
 	border-color: color-mix(in srgb, var(--interactive-accent) 54%, var(--background-modifier-border));
 	background: color-mix(in srgb, var(--interactive-accent) 10%, transparent);
@@ -15976,11 +15977,11 @@ body :is(
 
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-table-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover .operon-filter-inline-editor
 ) .operon-filter-modal-logic-button.is-active:is(:hover, :focus, :focus-visible),
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-table-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover .operon-filter-inline-editor
 ) .operon-preset-favorite-button:is(.is-active, [aria-pressed="true"]):is(:hover, :focus, :focus-visible) {
 	border-color: var(--operon-filter-modal-control-hover-border);
 	background-color: var(--operon-filter-modal-control-hover-bg);
@@ -15990,7 +15991,7 @@ body :is(
 
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-table-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover .operon-filter-inline-editor
 ) .operon-filter-footer-action-button.is-danger {
 	border-color: color-mix(in srgb, var(--text-error) 42%, var(--background-modifier-border));
 	background: transparent;
@@ -16001,7 +16002,7 @@ body :is(
 
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-table-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover .operon-filter-inline-editor
 ) .operon-filter-footer-action-button.is-danger:is(:hover, :focus, :focus-visible) {
 	border-color: var(--text-error);
 	background-color: color-mix(in srgb, var(--text-error) 9%, transparent);
@@ -16012,7 +16013,7 @@ body :is(
 
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-table-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover .operon-filter-inline-editor
 ) :is(
 	select.operon-filter-select,
 	button.operon-filter-select,
@@ -16032,11 +16033,11 @@ body :is(
 
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-table-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover .operon-filter-inline-editor
 ) .operon-filter-modal-logic-button.is-active:focus-visible,
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-table-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover .operon-filter-inline-editor
 ) .operon-preset-favorite-button:is(.is-active, [aria-pressed="true"]):focus-visible {
 	border-color: var(--operon-filter-modal-control-hover-border);
 	box-shadow: var(--operon-filter-modal-control-focus-ring);
@@ -16044,7 +16045,7 @@ body :is(
 
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-table-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover .operon-filter-inline-editor
 ) .operon-filter-footer-action-button.is-danger:focus-visible {
 	border-color: var(--text-error);
 	box-shadow: 0 0 0 2px color-mix(in srgb, var(--text-error) 24%, transparent);
@@ -16052,7 +16053,7 @@ body :is(
 
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-table-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover .operon-filter-inline-editor
 ) :is(
 	select.operon-filter-select,
 	button.operon-filter-select,
@@ -30185,6 +30186,7 @@ button.operon-table-group-sort-add-button {
 	}
 }
 
+.operon-preset-filter-popover,
 .operon-table-filter-popover {
 	position: fixed;
 	z-index: var(--layer-popover);
@@ -30198,11 +30200,13 @@ button.operon-table-group-sort-add-button {
 	box-shadow: var(--shadow-l);
 }
 
+.operon-preset-filter-popover .operon-filter-inline-editor,
 .operon-table-filter-popover .operon-filter-inline-editor {
 	max-height: none;
 	overflow: visible;
 }
 
+.operon-preset-filter-popover .operon-filter-form-section:first-child,
 .operon-table-filter-popover .operon-filter-form-section:first-child {
 	margin-top: 0;
 }

--- a/styles.css
+++ b/styles.css
@@ -30223,7 +30223,6 @@ button.operon-table-group-sort-add-button {
 	box-shadow: var(--shadow-l);
 }
 
-.operon-preset-filter-popover.operon-filter-inline-editor,
 .operon-table-filter-popover .operon-filter-inline-editor {
 	max-height: none;
 	overflow: visible;

--- a/styles.css
+++ b/styles.css
@@ -15166,7 +15166,8 @@ body:not(.is-mobile) .mod-root .workspace-leaf-content[data-type="operon-filter-
 	box-sizing: border-box;
 }
 
-.operon-filter-set-modal-shell {
+.operon-filter-set-modal-shell,
+.operon-table-filter-popover {
 	--operon-filter-modal-control-border: color-mix(in srgb, var(--background-modifier-border) 84%, transparent);
 	--operon-filter-modal-control-hover-border: color-mix(in srgb, var(--interactive-accent) 78%, var(--background-modifier-border));
 	--operon-filter-modal-control-hover-bg: color-mix(in srgb, var(--interactive-accent) 9%, transparent);
@@ -15175,6 +15176,9 @@ body:not(.is-mobile) .mod-root .workspace-leaf-content[data-type="operon-filter-
 	--operon-filter-modal-control-chevron:
 		linear-gradient(45deg, transparent 50%, currentColor 50%),
 		linear-gradient(135deg, currentColor 50%, transparent 50%);
+}
+
+.operon-filter-set-modal-shell {
 	width: 780px;
 	max-width: 90vw;
 	max-height: calc(100dvh - 48px);
@@ -15888,8 +15892,11 @@ button.operon-field-picker-trigger,
 	box-shadow: 0 0 0 2px color-mix(in srgb, var(--text-error) 22%, transparent);
 }
 
-/* Full FilterSetModal neutral controls — inline Table editors intentionally excluded. */
-body .modal.operon-filter-set-modal-shell .operon-filter-set-modal :is(
+/* Shared neutral controls for full FilterSetModal and compact Table filter editors. */
+body :is(
+	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
+	.operon-table-filter-popover .operon-filter-inline-editor
+) :is(
 	select.operon-filter-select,
 	button.operon-filter-select,
 	button.operon-filter-direction-toggle,
@@ -15916,7 +15923,10 @@ body .modal.operon-filter-set-modal-shell .operon-filter-set-modal :is(
 	--button-shadow: none;
 }
 
-body .modal.operon-filter-set-modal-shell .operon-filter-set-modal select.operon-filter-select {
+body :is(
+	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
+	.operon-table-filter-popover .operon-filter-inline-editor
+) select.operon-filter-select {
 	background-image: var(--operon-filter-modal-control-chevron);
 	background-position:
 		calc(100% - 15px) 50%,
@@ -15926,7 +15936,10 @@ body .modal.operon-filter-set-modal-shell .operon-filter-set-modal select.operon
 	padding-inline-end: 28px;
 }
 
-body .modal.operon-filter-set-modal-shell .operon-filter-set-modal :is(
+body :is(
+	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
+	.operon-table-filter-popover .operon-filter-inline-editor
+) :is(
 	select.operon-filter-select,
 	button.operon-filter-select,
 	button.operon-filter-direction-toggle,
@@ -15946,8 +15959,14 @@ body .modal.operon-filter-set-modal-shell .operon-filter-set-modal :is(
 	outline: none;
 }
 
-body .modal.operon-filter-set-modal-shell .operon-filter-set-modal .operon-filter-modal-logic-button.is-active,
-body .modal.operon-filter-set-modal-shell .operon-filter-set-modal .operon-preset-favorite-button:is(.is-active, [aria-pressed="true"]) {
+body :is(
+	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
+	.operon-table-filter-popover .operon-filter-inline-editor
+) .operon-filter-modal-logic-button.is-active,
+body :is(
+	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
+	.operon-table-filter-popover .operon-filter-inline-editor
+) .operon-preset-favorite-button:is(.is-active, [aria-pressed="true"]) {
 	border-color: color-mix(in srgb, var(--interactive-accent) 54%, var(--background-modifier-border));
 	background: color-mix(in srgb, var(--interactive-accent) 10%, transparent);
 	background-color: color-mix(in srgb, var(--interactive-accent) 10%, transparent);
@@ -15955,15 +15974,24 @@ body .modal.operon-filter-set-modal-shell .operon-filter-set-modal .operon-prese
 	color: var(--interactive-accent);
 }
 
-body .modal.operon-filter-set-modal-shell .operon-filter-set-modal .operon-filter-modal-logic-button.is-active:is(:hover, :focus, :focus-visible),
-body .modal.operon-filter-set-modal-shell .operon-filter-set-modal .operon-preset-favorite-button:is(.is-active, [aria-pressed="true"]):is(:hover, :focus, :focus-visible) {
+body :is(
+	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
+	.operon-table-filter-popover .operon-filter-inline-editor
+) .operon-filter-modal-logic-button.is-active:is(:hover, :focus, :focus-visible),
+body :is(
+	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
+	.operon-table-filter-popover .operon-filter-inline-editor
+) .operon-preset-favorite-button:is(.is-active, [aria-pressed="true"]):is(:hover, :focus, :focus-visible) {
 	border-color: var(--operon-filter-modal-control-hover-border);
 	background-color: var(--operon-filter-modal-control-hover-bg);
 	box-shadow: var(--operon-filter-modal-control-focus-shadow);
 	outline: none;
 }
 
-body .modal.operon-filter-set-modal-shell .operon-filter-set-modal .operon-filter-footer-action-button.is-danger {
+body :is(
+	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
+	.operon-table-filter-popover .operon-filter-inline-editor
+) .operon-filter-footer-action-button.is-danger {
 	border-color: color-mix(in srgb, var(--text-error) 42%, var(--background-modifier-border));
 	background: transparent;
 	background-color: transparent;
@@ -15971,7 +15999,10 @@ body .modal.operon-filter-set-modal-shell .operon-filter-set-modal .operon-filte
 	color: var(--text-error);
 }
 
-body .modal.operon-filter-set-modal-shell .operon-filter-set-modal .operon-filter-footer-action-button.is-danger:is(:hover, :focus, :focus-visible) {
+body :is(
+	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
+	.operon-table-filter-popover .operon-filter-inline-editor
+) .operon-filter-footer-action-button.is-danger:is(:hover, :focus, :focus-visible) {
 	border-color: var(--text-error);
 	background-color: color-mix(in srgb, var(--text-error) 9%, transparent);
 	box-shadow: 0 0 0 1px color-mix(in srgb, var(--text-error) 12%, transparent);
@@ -15979,7 +16010,10 @@ body .modal.operon-filter-set-modal-shell .operon-filter-set-modal .operon-filte
 	outline: none;
 }
 
-body .modal.operon-filter-set-modal-shell .operon-filter-set-modal :is(
+body :is(
+	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
+	.operon-table-filter-popover .operon-filter-inline-editor
+) :is(
 	select.operon-filter-select,
 	button.operon-filter-select,
 	button.operon-filter-direction-toggle,
@@ -15996,18 +16030,30 @@ body .modal.operon-filter-set-modal-shell .operon-filter-set-modal :is(
 	outline: none;
 }
 
-body .modal.operon-filter-set-modal-shell .operon-filter-set-modal .operon-filter-modal-logic-button.is-active:focus-visible,
-body .modal.operon-filter-set-modal-shell .operon-filter-set-modal .operon-preset-favorite-button:is(.is-active, [aria-pressed="true"]):focus-visible {
+body :is(
+	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
+	.operon-table-filter-popover .operon-filter-inline-editor
+) .operon-filter-modal-logic-button.is-active:focus-visible,
+body :is(
+	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
+	.operon-table-filter-popover .operon-filter-inline-editor
+) .operon-preset-favorite-button:is(.is-active, [aria-pressed="true"]):focus-visible {
 	border-color: var(--operon-filter-modal-control-hover-border);
 	box-shadow: var(--operon-filter-modal-control-focus-ring);
 }
 
-body .modal.operon-filter-set-modal-shell .operon-filter-set-modal .operon-filter-footer-action-button.is-danger:focus-visible {
+body :is(
+	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
+	.operon-table-filter-popover .operon-filter-inline-editor
+) .operon-filter-footer-action-button.is-danger:focus-visible {
 	border-color: var(--text-error);
 	box-shadow: 0 0 0 2px color-mix(in srgb, var(--text-error) 24%, transparent);
 }
 
-body .modal.operon-filter-set-modal-shell .operon-filter-set-modal :is(
+body :is(
+	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
+	.operon-table-filter-popover .operon-filter-inline-editor
+) :is(
 	select.operon-filter-select,
 	button.operon-filter-select,
 	button.operon-filter-direction-toggle,
@@ -30148,7 +30194,7 @@ button.operon-table-group-sort-add-button {
 	padding: 14px;
 	border: 1px solid var(--background-modifier-border);
 	border-radius: 10px;
-	background: var(--background-secondary);
+	background: var(--modal-background, var(--background-primary));
 	box-shadow: var(--shadow-l);
 }
 

--- a/styles.css
+++ b/styles.css
@@ -15896,7 +15896,7 @@ button.operon-field-picker-trigger,
 /* Shared neutral controls for full FilterSetModal and compact preset filter editors. */
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-preset-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover.operon-filter-inline-editor
 ) :is(
 	select.operon-filter-select,
 	button.operon-filter-select,
@@ -15926,7 +15926,7 @@ body :is(
 
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-preset-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover.operon-filter-inline-editor
 ) select.operon-filter-select {
 	background-image: var(--operon-filter-modal-control-chevron);
 	background-position:
@@ -15939,7 +15939,7 @@ body :is(
 
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-preset-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover.operon-filter-inline-editor
 ) :is(
 	select.operon-filter-select,
 	button.operon-filter-select,
@@ -15962,11 +15962,11 @@ body :is(
 
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-preset-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover.operon-filter-inline-editor
 ) .operon-filter-modal-logic-button.is-active,
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-preset-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover.operon-filter-inline-editor
 ) .operon-preset-favorite-button:is(.is-active, [aria-pressed="true"]) {
 	border-color: color-mix(in srgb, var(--interactive-accent) 54%, var(--background-modifier-border));
 	background: color-mix(in srgb, var(--interactive-accent) 10%, transparent);
@@ -15977,11 +15977,11 @@ body :is(
 
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-preset-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover.operon-filter-inline-editor
 ) .operon-filter-modal-logic-button.is-active:is(:hover, :focus, :focus-visible),
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-preset-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover.operon-filter-inline-editor
 ) .operon-preset-favorite-button:is(.is-active, [aria-pressed="true"]):is(:hover, :focus, :focus-visible) {
 	border-color: var(--operon-filter-modal-control-hover-border);
 	background-color: var(--operon-filter-modal-control-hover-bg);
@@ -15991,7 +15991,7 @@ body :is(
 
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-preset-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover.operon-filter-inline-editor
 ) .operon-filter-footer-action-button.is-danger {
 	border-color: color-mix(in srgb, var(--text-error) 42%, var(--background-modifier-border));
 	background: transparent;
@@ -16002,7 +16002,7 @@ body :is(
 
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-preset-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover.operon-filter-inline-editor
 ) .operon-filter-footer-action-button.is-danger:is(:hover, :focus, :focus-visible) {
 	border-color: var(--text-error);
 	background-color: color-mix(in srgb, var(--text-error) 9%, transparent);
@@ -16013,7 +16013,7 @@ body :is(
 
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-preset-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover.operon-filter-inline-editor
 ) :is(
 	select.operon-filter-select,
 	button.operon-filter-select,
@@ -16033,11 +16033,11 @@ body :is(
 
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-preset-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover.operon-filter-inline-editor
 ) .operon-filter-modal-logic-button.is-active:focus-visible,
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-preset-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover.operon-filter-inline-editor
 ) .operon-preset-favorite-button:is(.is-active, [aria-pressed="true"]):focus-visible {
 	border-color: var(--operon-filter-modal-control-hover-border);
 	box-shadow: var(--operon-filter-modal-control-focus-ring);
@@ -16045,7 +16045,7 @@ body :is(
 
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-preset-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover.operon-filter-inline-editor
 ) .operon-filter-footer-action-button.is-danger:focus-visible {
 	border-color: var(--text-error);
 	box-shadow: 0 0 0 2px color-mix(in srgb, var(--text-error) 24%, transparent);
@@ -16053,7 +16053,7 @@ body :is(
 
 body :is(
 	.modal.operon-filter-set-modal-shell .operon-filter-set-modal,
-	.operon-preset-filter-popover .operon-filter-inline-editor
+	.operon-preset-filter-popover.operon-filter-inline-editor
 ) :is(
 	select.operon-filter-select,
 	button.operon-filter-select,
@@ -30223,7 +30223,7 @@ button.operon-table-group-sort-add-button {
 	box-shadow: var(--shadow-l);
 }
 
-.operon-preset-filter-popover .operon-filter-inline-editor,
+.operon-preset-filter-popover.operon-filter-inline-editor,
 .operon-table-filter-popover .operon-filter-inline-editor {
 	max-height: none;
 	overflow: visible;

--- a/styles.css
+++ b/styles.css
@@ -31556,11 +31556,15 @@ button.operon-table-summary-picker-action:focus-visible {
 	width: auto;
 	height: var(--operon-task-chip-height);
 	min-width: 0;
+	max-width: 100%;
 	min-height: var(--operon-task-chip-height);
 	padding: 0 6px;
 	font-size: 12px;
 	line-height: 1.25;
 	font-variant-numeric: tabular-nums;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .operon-table-icon-only-button:hover,


### PR DESCRIPTION
## Summary

- improve Calendar drag behavior for multi-day all-day tasks and Finished-date corrections
- standardize Calendar in-day colors, Table datetime cells/tooltips, and Table task-type hover actions
- introduce a shared preset Filter Popover used by workspace Table, embedded Table, and Kanban
- remove the redundant Reading Mode `Go to task` tooltip
- update the integrated Unreleased changelog while preserving current-main entries

## Root causes and design

- multi-day Calendar drag geometry and Finished-row persistence were handled inconsistently
- preset filter editing duplicated lifecycle and styling across surfaces
- datetime rendering paths formatted built-in and custom fields differently and ignored the 12-hour display preference in some Table cells
- the Table task-type icon did not share the existing task action hover trigger

The filter editor now uses a surface-independent popover lifecycle with persistence adapters. Existing `FilterSet` and `filterSetId` storage contracts are retained; no schema, migration, manifest, version, or public Runtime V1 changes are included.

## Validation

- strict lint
- production build and bundle guard
- Runtime and Developer API suites
- index, storage, persistence, hydration, incremental, sync, and maintenance suites
- release guard
- Phase 5 regression: 1,526 / 1,526 passed, including the shared Filter Popover scroll assertion
- `git diff --check`
- focused correctness, persistence, regression, and UI review; no remaining production blocker

The published 3.1.0 release-freeze artifact comparison remains intentionally unchanged and reports expected Unreleased artifact drift.
