### PR TITLE
Fix Developer API confirmation binding on current main

### DIFF
--- a/scripts/agent-runtime/developer-api/recovery-store.test.ts
+++ b/scripts/agent-runtime/developer-api/recovery-store.test.ts
@@ -64,6 +64,51 @@ test('production recovery store persists, isolates, lists, and retains terminal 
 	assert.deepEqual(await store.list(refused.consumerId), []);
 });
 
+test('production recovery store accepts host confirmation bound to the sealed target', async () => {
+	const factory = new FakeIndexedDbFactory();
+	const store = createStore(factory);
+	const base = recoveryRecord(77);
+	const sealed = structuredClone(base.sealed);
+	sealed.riskLevel = 'elevated';
+	sealed.requiresConfirmation = true;
+	sealed.requiredAcknowledgements = ['terminal-transition'];
+	sealed.planHash = computeSealedMutationPlanHashV1(sealed);
+	const record: DeveloperMutationRecoveryRecordV1 = {
+		...base,
+		planDigest: sealed.planHash,
+		sealed,
+		binding: {
+			...base.binding,
+			planHash: sealed.planHash,
+		},
+		authorization: { basis: 'user-explicit-confirmation' },
+		acknowledgements: [{
+			code: 'terminal-transition',
+			planHash: sealed.planHash,
+			targetDigest: sealed.targets[0].targetDigest,
+			acknowledgedAt: sealed.createdAt,
+		}],
+	};
+
+	await store.putPrepared(record);
+
+	const aggregateBound: DeveloperMutationRecoveryRecordV1 = {
+		...structuredClone(record),
+		recoveryRef: `dvr1_${'4e'.padStart(48, '0')}`,
+		acknowledgements: record.acknowledgements.map(acknowledgement => ({
+			...acknowledgement,
+			targetDigest: sealed.receiptTargetDigest,
+		})),
+	};
+	await assert.rejects(
+		store.putPrepared(aggregateBound),
+		(error: unknown) => (
+			error instanceof DeveloperMutationRecoveryStoreErrorV1
+			&& error.code === 'recovery-store-corrupt'
+		),
+	);
+});
+
 test('production recovery store prunes expired records and protects 256 live records', async () => {
 	let now = BASE_TIME;
 	const factory = new FakeIndexedDbFactory();

--- a/scripts/agent-runtime/developer-api/security/security-policy.test.ts
+++ b/scripts/agent-runtime/developer-api/security/security-policy.test.ts
@@ -18,6 +18,16 @@ const session: DeveloperSecuritySessionV1 = {
 	sessionId: 'session-1',
 };
 
+const confirmationTargets: SealedMutationPlanV1['targets'] = [{
+	operonId: 'abc1234',
+	locator: {
+		representation: 'inline',
+		filePath: 'Tasks.md',
+		lineNumber: 0,
+	},
+	targetDigest: 'primary-target-digest',
+}];
+
 function grant(
 	capabilities: CapabilityIdV1[],
 	overrides: Partial<DeveloperCapabilityGrantV1> = {},
@@ -37,6 +47,7 @@ function plan(options: {
 	riskLevel?: RiskLevelV1;
 	planHash?: string;
 	requiredAcknowledgements?: string[];
+	targets?: SealedMutationPlanV1['targets'];
 } = {}): SealedMutationPlanV1 {
 	const capability = options.capability ?? 'tasks.update.preview';
 	const mutationKind = options.mutationKind ?? 'task.update';
@@ -53,7 +64,7 @@ function plan(options: {
 		mutationKind,
 		createdAt: '2026-07-29T10:00:00.000Z',
 		expiresAt: '2026-07-29T10:10:00.000Z',
-		targets: [],
+		targets: options.targets ?? [],
 		contextRevision: {
 			index: {
 				sessionId: 'index-session',
@@ -198,6 +209,18 @@ test('mints host-owned destructive confirmation and target-bound acknowledgement
 		mutationKind: 'task.delete',
 		riskLevel: 'destructive',
 		requiredAcknowledgements: ['destructive-delete', 'attached-checkboxes'],
+		targets: [
+			...confirmationTargets,
+			{
+				operonId: 'def5678',
+				locator: {
+					representation: 'inline',
+					filePath: 'Tasks.md',
+					lineNumber: 1,
+				},
+				targetDigest: 'secondary-target-digest',
+			},
+		],
 	});
 	const activeGrant = grant([sealed.capability, 'tasks.delete.apply']);
 	const binding = bindPlan(policy, activeGrant, sealed);
@@ -215,22 +238,54 @@ test('mints host-owned destructive confirmation and target-bound acknowledgement
 		{
 			code: 'destructive-delete',
 			planHash: sealed.planHash,
-			targetDigest: sealed.receiptTargetDigest,
+			targetDigest: sealed.targets[0].targetDigest,
 			acknowledgedAt: '2026-07-29T10:01:00.000Z',
 		},
 		{
 			code: 'attached-checkboxes',
 			planHash: sealed.planHash,
-			targetDigest: sealed.receiptTargetDigest,
+			targetDigest: sealed.targets[0].targetDigest,
 			acknowledgedAt: '2026-07-29T10:01:00.000Z',
 		},
 	]);
-	assert.equal(prompts.length, 1);
+	assert.deepEqual(prompts, [{
+		consumerId: session.consumerId,
+		capability: 'tasks.delete.apply',
+		mutationKind: sealed.mutationKind,
+		riskLevel: sealed.riskLevel,
+		planHash: sealed.planHash,
+		targetDigest: sealed.receiptTargetDigest,
+		targetCount: 2,
+		predictedEffects: sealed.predictedEffects,
+		acknowledgementCodes: sealed.requiredAcknowledgements,
+	}]);
+});
+
+test('fails closed before consent when a confirmation plan has no sealed target', async () => {
+	const { policy, prompts } = harness(['approved']);
+	const sealed = plan({
+		riskLevel: 'elevated',
+		requiredAcknowledgements: ['terminal-transition'],
+	});
+	const activeGrant = grant([sealed.capability, 'tasks.update.apply']);
+	const binding = bindPlan(policy, activeGrant, sealed);
+
+	const denied = await policy.admitApply({
+		session,
+		grant: activeGrant,
+		binding,
+		plan: sealed,
+	});
+
+	assert.equal(denied.ok, false);
+	assert.equal(denied.ok ? undefined : denied.code, 'invalid-request');
+	assert.equal(denied.ok ? undefined : denied.reasonCode, 'plan-binding-mismatch');
+	assert.deepEqual(prompts, []);
 });
 
 test('blocks consent replay after cancellation and fails closed when UI throws', async () => {
 	const cancelledHarness = harness(['denied', 'approved']);
-	const sealed = plan({ riskLevel: 'elevated' });
+	const sealed = plan({ riskLevel: 'elevated', targets: confirmationTargets });
 	const activeGrant = grant([sealed.capability, 'tasks.update.apply']);
 	const binding = bindPlan(cancelledHarness.policy, activeGrant, sealed);
 
@@ -283,7 +338,7 @@ test('rechecks grant revision after consent and preserves only same-plan recover
 		isGrantCurrent: candidate => candidate.revision === currentGrantRevision,
 		now: () => new Date(),
 	});
-	const sealed = plan({ riskLevel: 'elevated' });
+	const sealed = plan({ riskLevel: 'elevated', targets: confirmationTargets });
 	const activeGrant = grant([sealed.capability, 'tasks.update.apply']);
 	const binding = bindPlan(policy, activeGrant, sealed);
 

--- a/src/agent-runtime/developer-api/security/policy.ts
+++ b/src/agent-runtime/developer-api/security/policy.ts
@@ -82,6 +82,14 @@ export class DeveloperMutationSecurityPolicyV1 {
 				consent: 'standing-grant',
 			};
 		}
+		const acknowledgementTargetDigest = input.plan.targets[0]?.targetDigest;
+		if (!acknowledgementTargetDigest) {
+			return denialResult(
+				'invalid-request',
+				'plan-binding-mismatch',
+				'The sealed plan does not expose a target for confirmation.',
+			);
+		}
 
 		const consentKey = planKey(input.session.consumerId, input.plan.planHash);
 		if (this.deniedConsentPlans.has(consentKey)) {
@@ -147,7 +155,7 @@ export class DeveloperMutationSecurityPolicyV1 {
 			acknowledgements: input.plan.requiredAcknowledgements.map(code => ({
 				code,
 				planHash: input.plan.planHash,
-				targetDigest: input.plan.receiptTargetDigest,
+				targetDigest: acknowledgementTargetDigest,
 				acknowledgedAt,
 			})),
 			consent: 'fresh-user-confirmation',


### PR DESCRIPTION
## Summary

- bind host-minted Developer API acknowledgements to the primary sealed target
- reject targetless confirmation plans before presenting consent
- preserve the aggregate receipt digest in the consent summary and plan/session binding
- cover multi-target confirmation and canonical production recovery-store admission

## Root cause

The Developer API security policy minted each acknowledgement with `plan.receiptTargetDigest`, which represents the aggregate target set. The unchanged Runtime V1 apply decoder requires every acknowledgement target digest to belong to `plan.targets`. Confirmation-gated applies could therefore pass consent but fail while persisting the prepared recovery proof, before Runtime dispatch.

This repair keeps the public V1 contract unchanged and makes the host policy satisfy the existing decoder invariant.

## Current-main repair

This is an independent repair based on current `main` at `087dfa9f36ad8264b38afe735599c5c178e0f787`. It is intended to supersede the stale implementation in #117 after review; #117 has not been modified or closed.

## Validation

- Node `24.18.0` / npm `11.12.1`
- `npm run check:candidate`
- `npm run agent-runtime:contracts`
- Developer API runner: 85/85 passed
- security policy runner: 7/7 passed
- production build and Agent Runtime bundle guard
- Runtime/CLI public V1 baseline, schema, fixture, historical freeze, and published CLI binding checks
- three independent reviews covering security correctness, recovery/test coverage, and contract/CLI parity: no actionable findings
- production bundle: 4,349,330 bytes, +157 bytes from the exact current-main baseline

The local-only Phase 5 harness is not included in the public repository worktree, so that optional smoke suite was not executed here. No live-vault deployment or manual acceptance was performed because no Developer API consumer is available locally.

Closes #121.