### PR TITLE
Bound settlement evidence refresh for inline task updates

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -248,7 +248,10 @@ import {
 	runtimeSemanticTransitionStepIdsV1,
 	verifyRuntimeSemanticTransitionPostflightV1,
 	getRuntimeTaskFieldMutationPostflightRequirementsV1,
+	refreshRuntimeInlineTaskUpdateSettlementEvidenceV1,
+	resolveRuntimeInlineTaskUpdateSettlementEvidenceV1,
 	resolveRuntimeTaskFieldMutationPostflightEvidenceV1,
+	runtimeInlineTaskUpdateSettlementEvidenceSourceV1,
 	verifyRuntimeTaskFieldMutationPrimaryPostflightV1,
 	guardRuntimeTimerControlV1,
 	guardRuntimeInlineRelocationV1,
@@ -5757,6 +5760,20 @@ export default class OperonPlugin extends Plugin {
 			commitMutation: async (request, prepared, effectiveAt) => (
 				await this.commitAgentRuntimeTaskMutation(request.plan.spec, prepared, effectiveAt)
 			),
+			refreshMutationCommitEvidence: async (preparedMutation, commit) => {
+				const source = runtimeInlineTaskUpdateSettlementEvidenceSourceV1(
+					preparedMutation,
+					commit,
+				);
+				if (!source) return commit;
+				const observed = await this.readAgentRuntimeMutationSource(source.resourceKey);
+				return refreshRuntimeInlineTaskUpdateSettlementEvidenceV1(
+					preparedMutation,
+					commit,
+					observed.content,
+					this.settings.keyMappings,
+				);
+			},
 				verifyMutation: async (request, prepared, _postflightRevision, commit) => (
 					await this.verifyAgentRuntimeTaskMutation(request.plan.createdAt, prepared, commit)
 				),
@@ -8452,6 +8469,7 @@ export default class OperonPlugin extends Plugin {
 			};
 		}
 		const committedContent = writeResult.committedContent ?? prepared.task.sourceContent;
+		const committedRevision = sourceRevisionForTaskCreationV1(filePath, committedContent);
 		const groupResults: RuntimePreparedMutationCommitV1['groupResults'][number][] = [{
 			groupId,
 			status: 'committed',
@@ -8466,7 +8484,7 @@ export default class OperonPlugin extends Plugin {
 				{
 					resourceKind: 'task-source',
 					resourceKey: filePath,
-					revision: sourceRevisionForTaskCreationV1(filePath, committedContent),
+					revision: committedRevision,
 				},
 			],
 		}];
@@ -8553,6 +8571,17 @@ export default class OperonPlugin extends Plugin {
 				groupResults,
 			),
 			affectedFilePaths,
+			...(prepared.operation === 'update'
+			&& prepared.task.locator.representation === 'inline'
+			&& writeResult.committedContent !== undefined
+				? {
+					primaryTaskSourceCommitEvidence: {
+						resourceKey: filePath,
+						content: committedContent,
+						revision: committedRevision,
+					},
+				}
+				: {}),
 			};
 		}
 
@@ -9186,11 +9215,29 @@ export default class OperonPlugin extends Plugin {
 		const observedPrimarySource = await this.readAgentRuntimeMutationSource(
 			prepared.task.locator.filePath,
 		);
-		const primaryPostflightEvidence = resolveRuntimeTaskFieldMutationPostflightEvidenceV1(
+		const exactPrimaryPostflightEvidence = resolveRuntimeTaskFieldMutationPostflightEvidenceV1(
 			prepared.task.locator.filePath,
 			commit.groupResults.flatMap(group => group.resourceRevisions ?? []),
 			observedPrimarySource.content,
 		);
+		const settlementEvidence = commit.primaryTaskSourceCommitEvidence
+			&& observedPrimarySource.content !== null
+			? resolveRuntimeInlineTaskUpdateSettlementEvidenceV1(
+				prepared,
+				commit.primaryTaskSourceCommitEvidence.content,
+				commit.primaryTaskSourceCommitEvidence.revision,
+				observedPrimarySource.content,
+				this.settings.keyMappings,
+			)
+			: null;
+		const primaryPostflightEvidence = exactPrimaryPostflightEvidence
+			? {
+				...exactPrimaryPostflightEvidence,
+				...(settlementEvidence?.datetimeModified
+					? { settlementDatetimeModified: settlementEvidence.datetimeModified }
+					: {}),
+			}
+			: null;
 		if (!primaryPostflightEvidence) return false;
 		if (!verifyRuntimeTaskFieldMutationPrimaryPostflightV1(
 			prepared,

--- a/scripts/agent-runtime/mutation/mutation-gateway.test.ts
+++ b/scripts/agent-runtime/mutation/mutation-gateway.test.ts
@@ -34,7 +34,11 @@ import {
 } from '../../../src/agent-runtime/runtime/task-creation-adapter';
 import {
 	buildRuntimeConversionAncestorPredictedEffectsV1,
+	refreshRuntimeInlineTaskUpdateSettlementEvidenceV1,
+	resolveRuntimeInlineTaskUpdateSettlementEvidenceV1,
 	resolveRuntimeTaskFieldMutationPostflightEvidenceV1,
+	type RuntimeTaskFieldMutationPreparationV1,
+	verifyRuntimeTaskFieldMutationPrimaryPostflightV1,
 } from '../../../src/agent-runtime/runtime/task-mutation-adapter';
 import {
 	GRAPH_TRANSACTION_JOURNAL_MAX_BYTES_V1,
@@ -3172,9 +3176,11 @@ async function characterizePreparedTaskUpdateSettlement(
 	caseId: string,
 	committedContent: string,
 	settledContent: string,
+	options: { refreshThrows?: boolean } = {},
 ) {
 	const filePath = 'Tasks.md';
 	let durableContent = committedContent;
+	let commitCount = 0;
 	const events: string[] = [];
 	const updateRequest: MutationPreviewRequestV1 = {
 		contractVersion: 1,
@@ -3195,6 +3201,28 @@ async function characterizePreparedTaskUpdateSettlement(
 		authorization: { basis: 'user-explicit-request' },
 	};
 	const committedRevision = sha256HexV1(committedContent);
+	const taskFieldPreparation: RuntimeTaskFieldMutationPreparationV1 = {
+		kind: 'task-fields',
+		operation: 'update',
+		task: {
+			operonId: 'abc1234',
+			locator: { representation: 'inline', filePath, lineNumber: 2 },
+			description: 'Before update',
+			checkbox: 'open',
+			fieldValues: { datetimeModified: '2026-07-24T11:59:59' },
+			tags: [],
+			sourceContent: committedContent,
+			duplicate: false,
+		},
+		fieldValues: {
+			_description: 'Updated description',
+			datetimeModified: '2026-07-24T12:00:00',
+		},
+		sourceRevision: 'a'.repeat(64),
+		targetDigest: 'd'.repeat(64),
+		summary: 'Update the task description.',
+		noChange: false,
+	};
 	const prepared = {
 		target: {
 			operonId: 'abc1234',
@@ -3213,12 +3241,16 @@ async function characterizePreparedTaskUpdateSettlement(
 			summary: 'Update the task description.',
 		}],
 		warnings: [],
-		token: { kind: 'task-fields' as const },
+		token: taskFieldPreparation,
 	};
+	let persistedReceipt: MutationReceiptV1 | null = null;
 	const receiptStore = {
 		health: async () => ({ healthy: true }),
-		lookup: async () => null,
-		persist: async () => ({ expiredDeleted: 0, overflowDeleted: 0, retained: 1 }),
+		lookup: async () => persistedReceipt,
+		persist: async (receipt: MutationReceiptV1) => {
+			persistedReceipt = receipt;
+			return { expiredDeleted: 0, overflowDeleted: 0, retained: 1 };
+		},
 	} as unknown as IndexedDbMutationReceiptStoreV1;
 	const gateway = new RuntimeMutationGatewayV1({
 		isReady: () => true,
@@ -3233,7 +3265,9 @@ async function characterizePreparedTaskUpdateSettlement(
 		reconcileCreatedHierarchy: async () => ({ ok: true, resourceRevisions: [] }),
 		verifyCreatedTasks: async () => false,
 		prepareMutation: async () => ({ ok: true, value: prepared }),
-		commitMutation: async () => ({
+		commitMutation: async () => {
+			commitCount += 1;
+			return ({
 			status: 'committed',
 			groupResults: [{
 				groupId: `task-source:${filePath}`,
@@ -3241,15 +3275,59 @@ async function characterizePreparedTaskUpdateSettlement(
 				resourceRevisions: prepared.affectedResources,
 			}],
 			affectedFilePaths: [filePath],
-		}),
-		verifyMutation: async (_request, _prepared, _postflightRevision, commit) => {
+			primaryTaskSourceCommitEvidence: {
+				resourceKey: filePath,
+				content: committedContent,
+				revision: committedRevision,
+			},
+			});
+		},
+		refreshMutationCommitEvidence: async (preparedMutation, commit) => {
+			events.push('refresh');
+			if (options.refreshThrows) throw new Error('simulated source read failure');
+			return refreshRuntimeInlineTaskUpdateSettlementEvidenceV1(
+				preparedMutation,
+				commit,
+				durableContent,
+				DEFAULT_SETTINGS.keyMappings,
+			);
+		},
+		verifyMutation: async (_request, preparedMutation, _postflightRevision, commit) => {
 			events.push('postflight');
 			assert.match(durableContent, /Updated description/u);
-			return resolveRuntimeTaskFieldMutationPostflightEvidenceV1(
+			const exactEvidence = resolveRuntimeTaskFieldMutationPostflightEvidenceV1(
 				filePath,
 				commit.groupResults.flatMap(group => group.resourceRevisions ?? []),
 				durableContent,
-			) !== null;
+			);
+			const evidence = commit.primaryTaskSourceCommitEvidence;
+			const preparation = preparedMutation.token as RuntimeTaskFieldMutationPreparationV1;
+			const settlementEvidence = evidence
+				? resolveRuntimeInlineTaskUpdateSettlementEvidenceV1(
+					preparation,
+					evidence.content,
+					evidence.revision,
+					durableContent,
+					DEFAULT_SETTINGS.keyMappings,
+				)
+				: null;
+			const observedModified = /\{\{datetimeModified:: ([^}]+)\}\}/u.exec(
+				durableContent,
+			)?.[1] ?? '';
+			return exactEvidence !== null && verifyRuntimeTaskFieldMutationPrimaryPostflightV1(
+				preparation,
+				{
+					...preparation.task,
+					description: 'Updated description',
+					fieldValues: { datetimeModified: observedModified },
+				},
+				{
+					...exactEvidence,
+					...(settlementEvidence?.datetimeModified
+						? { settlementDatetimeModified: settlementEvidence.datetimeModified }
+						: {}),
+				},
+			);
 		},
 		receiptStore: () => receiptStore,
 		vaultIdentityHash: async () => 'c'.repeat(64),
@@ -3259,7 +3337,7 @@ async function characterizePreparedTaskUpdateSettlement(
 	const preview = await gateway.preview(updateRequest);
 	assert.equal(preview.ok, true);
 	if (!preview.ok) throw new Error('Characterization preview must succeed.');
-	const result = await gateway.apply({
+	const applyRequest = {
 		contractVersion: 1,
 		requestId: `phase8-update-apply-${caseId}`,
 		kind: 'mutation-apply',
@@ -3267,13 +3345,16 @@ async function characterizePreparedTaskUpdateSettlement(
 		authorization: { basis: 'user-explicit-request' },
 		idempotencyKey: updateRequest.idempotencyKey,
 		acknowledgements: [],
-	});
-	return { events, result };
+	} as const;
+	const result = await gateway.apply(applyRequest);
+	const replayResult = await gateway.apply(applyRequest);
+	return { commitCount, events, replayResult, result };
 }
 
 test('prepared task update verifies Runtime-owned datetimeModified settlement drift', async () => {
 	const committedContent = [
 		'# Tasks',
+		'',
 		'- [ ] Updated description {{operonId:: abc1234}} {{datetimeModified:: 2026-07-24T12:00:00}}',
 		'',
 	].join('\n');
@@ -3281,29 +3362,59 @@ test('prepared task update verifies Runtime-owned datetimeModified settlement dr
 		'2026-07-24T12:00:00',
 		'2026-07-24T12:00:01',
 	);
-	const { events, result } = await characterizePreparedTaskUpdateSettlement(
+	const { commitCount, events, replayResult, result } = await characterizePreparedTaskUpdateSettlement(
 		'settlement-metadata',
 		committedContent,
 		settledContent,
 	);
-	assert.deepEqual(events, ['reindex', 'settlement', 'postflight']);
+	assert.deepEqual(events, ['reindex', 'settlement', 'refresh', 'postflight']);
 	assert.equal(result.status, 'applied', JSON.stringify(result));
+	assert.doesNotMatch(
+		JSON.stringify(result),
+		/primaryTaskSourceCommitEvidence|# Tasks/u,
+		'Internal committed source evidence must not enter the public result.',
+	);
+	assert.equal(replayResult.status, 'already-applied', JSON.stringify(replayResult));
+	assert.equal(commitCount, 1);
 });
 
 test('prepared task update does not verify unrelated same-source settlement drift', async () => {
 	const committedContent = [
 		'# Tasks',
+		'',
 		'- [ ] Updated description {{operonId:: abc1234}} {{datetimeModified:: 2026-07-24T12:00:00}}',
 		'- [ ] Unrelated task {{operonId:: def5678}}',
 		'',
 	].join('\n');
-	const { result } = await characterizePreparedTaskUpdateSettlement(
+	const { commitCount, replayResult, result } = await characterizePreparedTaskUpdateSettlement(
 		'unrelated-settlement-drift',
 		committedContent,
 		committedContent.replace('Unrelated task', 'Concurrent unrelated edit'),
 	);
 	assert.equal(result.status, 'outcome-unknown', JSON.stringify(result));
 	assert.equal(result.retryAllowed, false);
+	assert.equal(replayResult.status, 'outcome-unknown', JSON.stringify(replayResult));
+	assert.equal(commitCount, 1, 'Outcome-unknown replay must not invoke the writer again.');
+});
+
+test('prepared task update source-read failure remains uncertain and replay-fenced', async () => {
+	const committedContent = [
+		'# Tasks',
+		'',
+		'- [ ] Updated description {{operonId:: abc1234}} {{datetimeModified:: 2026-07-24T12:00:00}}',
+		'',
+	].join('\n');
+	const { commitCount, events, replayResult, result } = await characterizePreparedTaskUpdateSettlement(
+		'settlement-read-failure',
+		committedContent,
+		committedContent.replace('2026-07-24T12:00:00', '2026-07-24T12:00:01'),
+		{ refreshThrows: true },
+	);
+	assert.deepEqual(events, ['reindex', 'settlement', 'refresh']);
+	assert.equal(result.status, 'outcome-unknown', JSON.stringify(result));
+	assert.equal(result.retryAllowed, false);
+	assert.equal(replayResult.status, 'outcome-unknown', JSON.stringify(replayResult));
+	assert.equal(commitCount, 1, 'A failed refresh must still fence writer replay.');
 });
 
 test('file-to-inline postflight failure preserves its durable same-plan recovery journal', async () => {

--- a/scripts/agent-runtime/mutation/mutation-gateway.test.ts
+++ b/scripts/agent-runtime/mutation/mutation-gateway.test.ts
@@ -3176,7 +3176,7 @@ async function characterizePreparedTaskUpdateSettlement(
 	caseId: string,
 	committedContent: string,
 	settledContent: string,
-	options: { refreshThrows?: boolean } = {},
+	options: { postRefreshContent?: string; refreshThrows?: boolean } = {},
 ) {
 	const filePath = 'Tasks.md';
 	let durableContent = committedContent;
@@ -3285,12 +3285,26 @@ async function characterizePreparedTaskUpdateSettlement(
 		refreshMutationCommitEvidence: async (preparedMutation, commit) => {
 			events.push('refresh');
 			if (options.refreshThrows) throw new Error('simulated source read failure');
-			return refreshRuntimeInlineTaskUpdateSettlementEvidenceV1(
+			const refreshedCommit = refreshRuntimeInlineTaskUpdateSettlementEvidenceV1(
 				preparedMutation,
 				commit,
 				durableContent,
 				DEFAULT_SETTINGS.keyMappings,
 			);
+			if (options.postRefreshContent !== undefined) {
+				assert.equal(
+					refreshedCommit.groupResults.flatMap(
+						group => group.resourceRevisions ?? [],
+					).find(resource => (
+						resource.resourceKind === 'task-source'
+						&& resource.resourceKey === filePath
+					))?.revision,
+					sha256HexV1(durableContent),
+					'The race fixture must first prove that settlement evidence was refreshed.',
+				);
+				durableContent = options.postRefreshContent;
+			}
+			return refreshedCommit;
 		},
 		verifyMutation: async (_request, preparedMutation, _postflightRevision, commit) => {
 			events.push('postflight');
@@ -3415,6 +3429,36 @@ test('prepared task update source-read failure remains uncertain and replay-fenc
 	assert.equal(result.retryAllowed, false);
 	assert.equal(replayResult.status, 'outcome-unknown', JSON.stringify(replayResult));
 	assert.equal(commitCount, 1, 'A failed refresh must still fence writer replay.');
+});
+
+test('prepared task update rejects same-source drift after evidence refresh and fences replay', async () => {
+	const committedContent = [
+		'# Tasks',
+		'',
+		'- [ ] Updated description {{operonId:: abc1234}} {{datetimeModified:: 2026-07-24T12:00:00}}',
+		'- [ ] Unrelated task {{operonId:: def5678}}',
+		'',
+	].join('\n');
+	const settledContent = committedContent.replace(
+		'2026-07-24T12:00:00',
+		'2026-07-24T12:00:01',
+	);
+	const { commitCount, events, replayResult, result } = await characterizePreparedTaskUpdateSettlement(
+		'post-refresh-source-drift',
+		committedContent,
+		settledContent,
+		{
+			postRefreshContent: settledContent.replace(
+				'Unrelated task',
+				'Concurrent post-refresh edit',
+			),
+		},
+	);
+	assert.deepEqual(events, ['reindex', 'settlement', 'refresh', 'postflight']);
+	assert.equal(result.status, 'outcome-unknown', JSON.stringify(result));
+	assert.equal(result.retryAllowed, false);
+	assert.equal(replayResult.status, 'outcome-unknown', JSON.stringify(replayResult));
+	assert.equal(commitCount, 1, 'Post-refresh drift must not authorize writer replay.');
 });
 
 test('file-to-inline postflight failure preserves its durable same-plan recovery journal', async () => {

--- a/scripts/agent-runtime/mutation/mutation-gateway.test.ts
+++ b/scripts/agent-runtime/mutation/mutation-gateway.test.ts
@@ -32,7 +32,10 @@ import {
 	prepareRuntimeTaskCreationV1,
 	type RuntimeTaskCreationPreparationV1,
 } from '../../../src/agent-runtime/runtime/task-creation-adapter';
-import { buildRuntimeConversionAncestorPredictedEffectsV1 } from '../../../src/agent-runtime/runtime/task-mutation-adapter';
+import {
+	buildRuntimeConversionAncestorPredictedEffectsV1,
+	resolveRuntimeTaskFieldMutationPostflightEvidenceV1,
+} from '../../../src/agent-runtime/runtime/task-mutation-adapter';
 import {
 	GRAPH_TRANSACTION_JOURNAL_MAX_BYTES_V1,
 	type GraphTransactionJournalV1,
@@ -3163,6 +3166,144 @@ test('prepared mutation postflight failure persists an uncertain receipt and fen
 	assert.equal(replay.status, 'outcome-unknown');
 	assert.equal(replay.receipt?.terminalOutcome, 'outcome-unknown');
 	assert.equal(commitCount, 1);
+});
+
+async function characterizePreparedTaskUpdateSettlement(
+	caseId: string,
+	committedContent: string,
+	settledContent: string,
+) {
+	const filePath = 'Tasks.md';
+	let durableContent = committedContent;
+	const events: string[] = [];
+	const updateRequest: MutationPreviewRequestV1 = {
+		contractVersion: 1,
+		requestId: `phase8-update-preview-${caseId}`,
+		kind: 'mutation-preview',
+		clientInstanceId: 'test-client',
+		idempotencyKey: `phase8-update-${caseId}`,
+		capability: 'tasks.update.preview',
+		mutationKind: 'task.update',
+		target: {
+			operonId: 'abc1234',
+			locator: { representation: 'inline', filePath, lineNumber: 2 },
+		},
+		spec: {
+			operation: 'update',
+			changes: [{ field: 'description', valueType: 'text', value: 'Updated description' }],
+		},
+		authorization: { basis: 'user-explicit-request' },
+	};
+	const committedRevision = sha256HexV1(committedContent);
+	const prepared = {
+		target: {
+			operonId: 'abc1234',
+			locator: { representation: 'inline' as const, filePath, lineNumber: 2 },
+			targetDigest: 'd'.repeat(64),
+		},
+		affectedResources: [{
+			resourceKind: 'task-source' as const,
+			resourceKey: filePath,
+			revision: committedRevision,
+		}],
+		predictedEffects: [{
+			resourceKind: 'task-source' as const,
+			resourceKey: filePath,
+			action: 'update' as const,
+			summary: 'Update the task description.',
+		}],
+		warnings: [],
+		token: { kind: 'task-fields' as const },
+	};
+	const receiptStore = {
+		health: async () => ({ healthy: true }),
+		lookup: async () => null,
+		persist: async () => ({ expiredDeleted: 0, overflowDeleted: 0, retained: 1 }),
+	} as unknown as IndexedDbMutationReceiptStoreV1;
+	const gateway = new RuntimeMutationGatewayV1({
+		isReady: () => true,
+		sampleContextRevision: () => revision,
+		prepareCreation: async () => preparation(),
+		commitCreation: async () => ({ status: 'failed', groups: [], remainingGroupIds: [] }),
+		reindexAffectedSources: async () => { events.push('reindex'); },
+		settleAfterMutation: async () => {
+			events.push('settlement');
+			durableContent = settledContent;
+		},
+		reconcileCreatedHierarchy: async () => ({ ok: true, resourceRevisions: [] }),
+		verifyCreatedTasks: async () => false,
+		prepareMutation: async () => ({ ok: true, value: prepared }),
+		commitMutation: async () => ({
+			status: 'committed',
+			groupResults: [{
+				groupId: `task-source:${filePath}`,
+				status: 'committed',
+				resourceRevisions: prepared.affectedResources,
+			}],
+			affectedFilePaths: [filePath],
+		}),
+		verifyMutation: async (_request, _prepared, _postflightRevision, commit) => {
+			events.push('postflight');
+			assert.match(durableContent, /Updated description/u);
+			return resolveRuntimeTaskFieldMutationPostflightEvidenceV1(
+				filePath,
+				commit.groupResults.flatMap(group => group.resourceRevisions ?? []),
+				durableContent,
+			) !== null;
+		},
+		receiptStore: () => receiptStore,
+		vaultIdentityHash: async () => 'c'.repeat(64),
+		nowEpochMs: () => Date.parse('2026-07-24T12:00:02.000Z'),
+		randomId: () => `phase8-update-${caseId}-plan`,
+	});
+	const preview = await gateway.preview(updateRequest);
+	assert.equal(preview.ok, true);
+	if (!preview.ok) throw new Error('Characterization preview must succeed.');
+	const result = await gateway.apply({
+		contractVersion: 1,
+		requestId: `phase8-update-apply-${caseId}`,
+		kind: 'mutation-apply',
+		plan: preview.plan,
+		authorization: { basis: 'user-explicit-request' },
+		idempotencyKey: updateRequest.idempotencyKey,
+		acknowledgements: [],
+	});
+	return { events, result };
+}
+
+test('prepared task update verifies Runtime-owned datetimeModified settlement drift', async () => {
+	const committedContent = [
+		'# Tasks',
+		'- [ ] Updated description {{operonId:: abc1234}} {{datetimeModified:: 2026-07-24T12:00:00}}',
+		'',
+	].join('\n');
+	const settledContent = committedContent.replace(
+		'2026-07-24T12:00:00',
+		'2026-07-24T12:00:01',
+	);
+	const { events, result } = await characterizePreparedTaskUpdateSettlement(
+		'settlement-metadata',
+		committedContent,
+		settledContent,
+	);
+	assert.deepEqual(events, ['reindex', 'settlement', 'postflight']);
+	assert.equal(result.status, 'applied', JSON.stringify(result));
+});
+
+test('prepared task update does not verify unrelated same-source settlement drift', async () => {
+	const committedContent = [
+		'# Tasks',
+		'- [ ] Updated description {{operonId:: abc1234}} {{datetimeModified:: 2026-07-24T12:00:00}}',
+		'- [ ] Unrelated task {{operonId:: def5678}}',
+		'',
+	].join('\n');
+	const { result } = await characterizePreparedTaskUpdateSettlement(
+		'unrelated-settlement-drift',
+		committedContent,
+		committedContent.replace('Unrelated task', 'Concurrent unrelated edit'),
+	);
+	assert.equal(result.status, 'outcome-unknown', JSON.stringify(result));
+	assert.equal(result.retryAllowed, false);
 });
 
 test('file-to-inline postflight failure preserves its durable same-plan recovery journal', async () => {

--- a/scripts/agent-runtime/mutation/task-mutation-adapter.test.ts
+++ b/scripts/agent-runtime/mutation/task-mutation-adapter.test.ts
@@ -9,9 +9,13 @@ import {
 	buildRuntimeTaskUpdateBatchEffectsV1,
 	prepareRuntimeTaskFieldMutationV1,
 	prepareRuntimeTaskUpdateBatchV1,
+	refreshRuntimeInlineTaskUpdateSettlementEvidenceV1,
 	reminderItemIdV1,
+	resolveRuntimeInlineTaskUpdateSettlementEvidenceV1,
+	resolveRuntimeInlineTaskUpdateSettlementRevisionV1,
 	resolveRuntimeTaskFieldMutationPostflightEvidenceV1,
 	type RuntimeExactTaskMutationSnapshotV1,
+	type RuntimeTaskFieldMutationPreparationV1,
 	verifyRuntimeTaskFieldMutationPrimaryPostflightV1,
 } from '../../../src/agent-runtime/runtime/task-mutation-adapter';
 import { sha256HexV1 } from '../../../src/agent-runtime/contracts/v1/canonical';
@@ -949,7 +953,7 @@ test('File Task postflight evidence requires one exact committed revision and an
 	].join('\n');
 	const committedRevision = sha256HexV1(committedContent);
 	const exactRevision = {
-		resourceKind: 'task-source',
+		resourceKind: 'task-source' as const,
 		resourceKey: filePath,
 		revision: committedRevision,
 	};
@@ -1010,6 +1014,7 @@ test('inline task exact-byte evidence records metadata settlement and unrelated 
 	const filePath = 'Tasks.md';
 	const committedContent = [
 		'# Tasks',
+		'',
 		'- [ ] Updated description {{operonId:: abc1234}} {{datetimeModified:: 2026-07-24T12:00:00}}',
 		'- [ ] Unrelated task {{operonId:: def5678}}',
 		'',
@@ -1023,8 +1028,26 @@ test('inline task exact-byte evidence records metadata settlement and unrelated 
 		'Concurrent unrelated edit',
 	);
 	const committedRevision = sha256HexV1(committedContent);
+	const prepared: RuntimeTaskFieldMutationPreparationV1 = {
+		kind: 'task-fields',
+		operation: 'update',
+		task: {
+			...task,
+			locator: { representation: 'inline', filePath, lineNumber: 2 },
+			description: 'Before update',
+			sourceContent: committedContent,
+		},
+		fieldValues: {
+			_description: 'Updated description',
+			datetimeModified: '2026-07-24T12:00:00',
+		},
+		sourceRevision: 'a'.repeat(64),
+		targetDigest: 'b'.repeat(64),
+		summary: 'Update the task description.',
+		noChange: false,
+	};
 	const exactRevision = {
-		resourceKind: 'task-source',
+		resourceKind: 'task-source' as const,
 		resourceKey: filePath,
 		revision: committedRevision,
 	};
@@ -1033,6 +1056,202 @@ test('inline task exact-byte evidence records metadata settlement and unrelated 
 		sha256HexV1(unrelatedDriftContent),
 		sha256HexV1(metadataSettledContent),
 	);
+	assert.equal(
+		resolveRuntimeInlineTaskUpdateSettlementRevisionV1(
+			prepared,
+			committedContent,
+			committedRevision,
+			committedContent,
+			DEFAULT_SETTINGS.keyMappings,
+		),
+		committedRevision,
+		'An unchanged exact reread remains valid without refreshing evidence.',
+	);
+	assert.equal(
+		resolveRuntimeInlineTaskUpdateSettlementRevisionV1(
+			prepared,
+			committedContent,
+			committedRevision,
+			metadataSettledContent,
+			DEFAULT_SETTINGS.keyMappings,
+		),
+		sha256HexV1(metadataSettledContent),
+		'Only the exact target datetimeModified value may advance after settlement.',
+	);
+	const rejectedObservedSources = [
+		metadataSettledContent.replace('2026-07-24T12:00:01', '2026-07-24T11:59:59'),
+		metadataSettledContent.replace('2026-07-24T12:00:01', 'not-a-datetime'),
+		metadataSettledContent.replace(
+			' {{datetimeModified:: 2026-07-24T12:00:01}}',
+			'',
+		),
+		metadataSettledContent.replace(
+			'{{datetimeModified:: 2026-07-24T12:00:01}}',
+			'{{datetimeModified:: 2026-07-24T12:00:01}} {{datetimeModified:: 2026-07-24T12:00:02}}',
+		),
+		metadataSettledContent.replace('Updated description', 'Concurrent description edit'),
+		unrelatedDriftContent,
+	];
+	for (const observedContent of rejectedObservedSources) {
+		assert.equal(
+			resolveRuntimeInlineTaskUpdateSettlementRevisionV1(
+				prepared,
+				committedContent,
+				committedRevision,
+				observedContent,
+				DEFAULT_SETTINGS.keyMappings,
+			),
+			null,
+		);
+	}
+	assert.equal(
+		resolveRuntimeInlineTaskUpdateSettlementRevisionV1(
+			{
+				...prepared,
+				task: {
+					...prepared.task,
+					locator: { representation: 'inline', filePath, lineNumber: 1 },
+				},
+			},
+			committedContent,
+			committedRevision,
+			metadataSettledContent,
+			DEFAULT_SETTINGS.keyMappings,
+		),
+		null,
+		'A shifted target locator must not authorize evidence refresh.',
+	);
+	assert.equal(
+		resolveRuntimeInlineTaskUpdateSettlementRevisionV1(
+			prepared,
+			committedContent,
+			'c'.repeat(64),
+			metadataSettledContent,
+			DEFAULT_SETTINGS.keyMappings,
+		),
+		null,
+		'The exact committed content must remain bound to its writer revision.',
+	);
+	const preparedMutation = {
+		target: {
+			operonId: prepared.task.operonId,
+			locator: prepared.task.locator,
+			targetDigest: prepared.targetDigest,
+		},
+		affectedResources: [exactRevision],
+		predictedEffects: [],
+		warnings: [],
+		token: prepared,
+	};
+	const commit = {
+		status: 'committed' as const,
+		groupResults: [{
+			groupId: `task-source:${filePath}`,
+			status: 'committed' as const,
+			resourceRevisions: [
+				{ resourceKind: 'pinned' as const, resourceKey: 'abc1234', revision: 'd'.repeat(64) },
+				exactRevision,
+				{ resourceKind: 'task-source' as const, resourceKey: 'Other.md', revision: 'e'.repeat(64) },
+			],
+		}],
+		affectedFilePaths: [filePath],
+		primaryTaskSourceCommitEvidence: {
+			resourceKey: filePath,
+			content: committedContent,
+			revision: committedRevision,
+		},
+	};
+	const refreshedCommit = refreshRuntimeInlineTaskUpdateSettlementEvidenceV1(
+		preparedMutation,
+		commit,
+		metadataSettledContent,
+		DEFAULT_SETTINGS.keyMappings,
+	);
+	assert.equal(
+		refreshedCommit.groupResults[0]?.resourceRevisions?.[1]?.revision,
+		sha256HexV1(metadataSettledContent),
+	);
+	assert.deepEqual(
+		refreshedCommit.groupResults[0]?.resourceRevisions?.filter((_, index) => index !== 1),
+		commit.groupResults[0]?.resourceRevisions?.filter((_, index) => index !== 1),
+		'Non-primary and non-source revisions must be preserved exactly.',
+	);
+	assert.equal(
+		refreshRuntimeInlineTaskUpdateSettlementEvidenceV1(
+			preparedMutation,
+			commit,
+			null,
+			DEFAULT_SETTINGS.keyMappings,
+		),
+		commit,
+		'A missing source reread must leave commit evidence unchanged.',
+	);
+	for (const guardedCommit of [{
+		...commit,
+		groupResults: [{
+			...commit.groupResults[0],
+			resourceRevisions: [...(commit.groupResults[0]?.resourceRevisions ?? []), exactRevision],
+		}],
+	}, {
+		...commit,
+		groupResults: [{
+			...commit.groupResults[0],
+			resourceRevisions: commit.groupResults[0]?.resourceRevisions?.map(resource => (
+				resource === exactRevision ? { ...resource, revision: 'f'.repeat(64) } : resource
+			)),
+		}],
+	}, {
+		...commit,
+		primaryTaskSourceCommitEvidence: {
+			...commit.primaryTaskSourceCommitEvidence,
+			revision: '0'.repeat(64),
+		},
+	}]) {
+		assert.equal(
+			refreshRuntimeInlineTaskUpdateSettlementEvidenceV1(
+				preparedMutation,
+				guardedCommit,
+				metadataSettledContent,
+				DEFAULT_SETTINGS.keyMappings,
+			),
+			guardedCommit,
+			'Duplicate, stale, or hash-mismatched source evidence must remain unchanged.',
+		);
+	}
+	const boundedSettlement = resolveRuntimeInlineTaskUpdateSettlementEvidenceV1(
+		prepared,
+		committedContent,
+		committedRevision,
+		metadataSettledContent,
+		DEFAULT_SETTINGS.keyMappings,
+	);
+	assert.equal(boundedSettlement?.datetimeModified, '2026-07-24T12:00:01');
+	assert.equal(verifyRuntimeTaskFieldMutationPrimaryPostflightV1(
+		prepared,
+		{
+			...prepared.task,
+			description: 'Updated description',
+			fieldValues: { datetimeModified: '2026-07-24T12:00:01' },
+		},
+		{
+			committedSourceRevision: sha256HexV1(metadataSettledContent),
+			observedSourceRevision: sha256HexV1(metadataSettledContent),
+			settlementDatetimeModified: boundedSettlement?.datetimeModified,
+		},
+	), true, 'The real inline semantic verifier accepts only the bounded settlement timestamp.');
+	assert.equal(verifyRuntimeTaskFieldMutationPrimaryPostflightV1(
+		prepared,
+		{
+			...prepared.task,
+			description: 'Updated description',
+			fieldValues: { datetimeModified: '2026-07-24T12:00:02' },
+		},
+		{
+			committedSourceRevision: sha256HexV1(metadataSettledContent),
+			observedSourceRevision: sha256HexV1(metadataSettledContent),
+			settlementDatetimeModified: boundedSettlement?.datetimeModified,
+		},
+	), false, 'A later indexed value not proven by the bounded source evidence is rejected.');
 	assert.equal(
 		resolveRuntimeTaskFieldMutationPostflightEvidenceV1(
 			filePath,

--- a/scripts/agent-runtime/mutation/task-mutation-adapter.test.ts
+++ b/scripts/agent-runtime/mutation/task-mutation-adapter.test.ts
@@ -1005,3 +1005,50 @@ test('File Task postflight evidence requires one exact committed revision and an
 		'A missing canonical reread must fail closed.',
 	);
 });
+
+test('inline task exact-byte evidence records metadata settlement and unrelated source drift separately', () => {
+	const filePath = 'Tasks.md';
+	const committedContent = [
+		'# Tasks',
+		'- [ ] Updated description {{operonId:: abc1234}} {{datetimeModified:: 2026-07-24T12:00:00}}',
+		'- [ ] Unrelated task {{operonId:: def5678}}',
+		'',
+	].join('\n');
+	const metadataSettledContent = committedContent.replace(
+		'2026-07-24T12:00:00',
+		'2026-07-24T12:00:01',
+	);
+	const unrelatedDriftContent = metadataSettledContent.replace(
+		'Unrelated task',
+		'Concurrent unrelated edit',
+	);
+	const committedRevision = sha256HexV1(committedContent);
+	const exactRevision = {
+		resourceKind: 'task-source',
+		resourceKey: filePath,
+		revision: committedRevision,
+	};
+	assert.notEqual(sha256HexV1(metadataSettledContent), committedRevision);
+	assert.notEqual(
+		sha256HexV1(unrelatedDriftContent),
+		sha256HexV1(metadataSettledContent),
+	);
+	assert.equal(
+		resolveRuntimeTaskFieldMutationPostflightEvidenceV1(
+			filePath,
+			[exactRevision],
+			metadataSettledContent,
+		),
+		null,
+		'Current exact-byte evidence exposes the false uncertainty after metadata settlement.',
+	);
+	assert.equal(
+		resolveRuntimeTaskFieldMutationPostflightEvidenceV1(
+			filePath,
+			[exactRevision],
+			unrelatedDriftContent,
+		),
+		null,
+		'Unrelated same-source drift must remain unverified.',
+	);
+});

--- a/src/agent-runtime/runtime/mutation-gateway.ts
+++ b/src/agent-runtime/runtime/mutation-gateway.ts
@@ -121,6 +121,12 @@ export interface RuntimePreparedMutationCommitV1 {
 	readonly groupResults: AtomicGroupResultV1[];
 	readonly affectedFilePaths: string[];
 	readonly reason?: string;
+	/** Internal exact writer evidence. Never serialized into a public result or receipt. */
+	readonly primaryTaskSourceCommitEvidence?: {
+		readonly resourceKey: string;
+		readonly content: string;
+		readonly revision: string;
+	};
 }
 
 export interface RuntimeGraphTransactionCheckpointV1 {
@@ -243,6 +249,11 @@ export interface RuntimeMutationGatewayPortsV1 {
 		request: MutationApplyRequestV1,
 		prepared: RuntimePreparedMutationV1,
 		effectiveAt: string,
+	): Promise<RuntimePreparedMutationCommitV1>;
+	/** Read-only, same-apply evidence reconciliation after Runtime settlement. */
+	refreshMutationCommitEvidence?(
+		prepared: RuntimePreparedMutationV1,
+		commit: RuntimePreparedMutationCommitV1,
 	): Promise<RuntimePreparedMutationCommitV1>;
 	verifyMutation?(
 		request: MutationApplyRequestV1,
@@ -1984,6 +1995,9 @@ export class RuntimeMutationGatewayV1 {
 				undefined,
 				() => this.ports.settleAfterMutation(request.requestId),
 			);
+			if (this.ports.refreshMutationCommitEvidence) {
+				commit = await this.ports.refreshMutationCommitEvidence(prepared.value, commit);
+			}
 				postflightRevision = await this.ports.sampleContextRevision();
 				if (!(await this.measureMutation(
 					request.requestId,

--- a/src/agent-runtime/runtime/task-mutation-adapter.ts
+++ b/src/agent-runtime/runtime/task-mutation-adapter.ts
@@ -28,6 +28,37 @@ import {
 } from '../../core/reminder-rules';
 import { composeStatusValue } from '../../core/workflow-status-value';
 import { canonicalizeLocalDatetime } from '../../core/local-time';
+import { parseTaskLine } from '../../core/parser';
+import type { KeyMapping } from '../../types/settings';
+import type {
+	RuntimePreparedMutationCommitV1,
+	RuntimePreparedMutationV1,
+} from './mutation-gateway';
+
+const STRICT_LOCAL_DATETIME_RE = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$/u;
+
+function parseStrictCanonicalLocalDatetime(value: string): string | null {
+	const match = STRICT_LOCAL_DATETIME_RE.exec(value);
+	if (!match) return null;
+	const year = Number(match[1]);
+	const month = Number(match[2]);
+	const day = Number(match[3]);
+	const hour = Number(match[4]);
+	const minute = Number(match[5]);
+	const second = Number(match[6] ?? 0);
+	if (
+		year < 1
+		|| month < 1
+		|| month > 12
+		|| hour > 23
+		|| minute > 59
+		|| second > 59
+	) return null;
+	const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+	const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1] ?? 0;
+	if (day < 1 || day > daysInMonth) return null;
+	return `${match[1]}-${match[2]}-${match[3]}T${match[4]}:${match[5]}:${String(second).padStart(2, '0')}`;
+}
 
 export interface RuntimeExactTaskMutationSnapshotV1 {
 	readonly operonId: string;
@@ -85,6 +116,8 @@ export interface RuntimeTaskFieldMutationPostflightRequirementsV1 {
 export interface RuntimeTaskFieldMutationPostflightEvidenceV1 {
 	readonly committedSourceRevision: string;
 	readonly observedSourceRevision: string;
+	/** Exact later inline timestamp proven by bounded settlement reconciliation. */
+	readonly settlementDatetimeModified?: string;
 }
 
 export interface RuntimeTaskUpdateBatchItemPreparationV1 {
@@ -137,6 +170,155 @@ export function resolveRuntimeTaskFieldMutationPostflightEvidenceV1(
 	return {
 		committedSourceRevision,
 		observedSourceRevision,
+	};
+}
+
+export function resolveRuntimeInlineTaskUpdateSettlementEvidenceV1(
+	prepared: RuntimeTaskFieldMutationPreparationV1,
+	committedSourceContent: string,
+	committedSourceRevision: string,
+	observedSourceContent: string,
+	keyMappings: readonly KeyMapping[],
+): { revision: string; datetimeModified?: string } | null {
+	if (
+		prepared.operation !== 'update'
+		|| prepared.task.locator.representation !== 'inline'
+		|| sha256HexV1(committedSourceContent) !== committedSourceRevision
+	) return null;
+	if (observedSourceContent === committedSourceContent) {
+		return { revision: sha256HexV1(observedSourceContent) };
+	}
+	const lineNumber = prepared.task.locator.lineNumber;
+	const committedLines = committedSourceContent.split('\n');
+	const observedLines = observedSourceContent.split('\n');
+	if (
+		committedLines.length !== observedLines.length
+		|| lineNumber < 0
+		|| lineNumber >= committedLines.length
+	) return null;
+	for (let index = 0; index < committedLines.length; index++) {
+		if (index !== lineNumber && committedLines[index] !== observedLines[index]) return null;
+	}
+	const filePath = prepared.task.locator.filePath;
+	const committedLine = committedLines[lineNumber] ?? '';
+	const observedLine = observedLines[lineNumber] ?? '';
+	const committedTask = parseTaskLine(committedLine, lineNumber, filePath, [...keyMappings]);
+	const observedTask = parseTaskLine(observedLine, lineNumber, filePath, [...keyMappings]);
+	if (
+		!committedTask
+		|| !observedTask
+		|| committedTask.operonId !== prepared.task.operonId
+		|| observedTask.operonId !== prepared.task.operonId
+	) return null;
+	const committedModified = committedTask.fields.filter(field => field.key === 'datetimeModified');
+	const observedModified = observedTask.fields.filter(field => field.key === 'datetimeModified');
+	if (committedModified.length !== 1 || observedModified.length !== 1) return null;
+	const committedField = committedModified[0];
+	const observedField = observedModified[0];
+	const expectedModified = prepared.fieldValues['datetimeModified'] ?? '';
+	const committedCanonical = committedField
+		? parseStrictCanonicalLocalDatetime(committedField.value)
+		: null;
+	const observedCanonical = observedField
+		? parseStrictCanonicalLocalDatetime(observedField.value)
+		: null;
+	if (
+		!committedField
+		|| !observedField
+		|| committedField.sourceKey !== observedField.sourceKey
+		|| committedCanonical !== expectedModified
+		|| observedCanonical !== observedField.value
+		|| observedCanonical.localeCompare(committedCanonical) <= 0
+	) return null;
+	const restoredObservedLine = [
+		observedLine.slice(0, observedField.valueRange.from),
+		committedField.rawValue,
+		observedLine.slice(observedField.valueRange.to),
+	].join('');
+	return restoredObservedLine === committedLine
+		? {
+			revision: sha256HexV1(observedSourceContent),
+			datetimeModified: observedCanonical,
+		}
+		: null;
+}
+
+export function resolveRuntimeInlineTaskUpdateSettlementRevisionV1(
+	prepared: RuntimeTaskFieldMutationPreparationV1,
+	committedSourceContent: string,
+	committedSourceRevision: string,
+	observedSourceContent: string,
+	keyMappings: readonly KeyMapping[],
+): string | null {
+	return resolveRuntimeInlineTaskUpdateSettlementEvidenceV1(
+		prepared,
+		committedSourceContent,
+		committedSourceRevision,
+		observedSourceContent,
+		keyMappings,
+	)?.revision ?? null;
+}
+
+export function runtimeInlineTaskUpdateSettlementEvidenceSourceV1(
+	preparedMutation: RuntimePreparedMutationV1,
+	commit: RuntimePreparedMutationCommitV1,
+): { preparation: RuntimeTaskFieldMutationPreparationV1; resourceKey: string } | null {
+	const prepared = preparedMutation.token as RuntimeTaskFieldMutationPreparationV1;
+	const evidence = commit.primaryTaskSourceCommitEvidence;
+	if (
+		!prepared
+		|| prepared.kind !== 'task-fields'
+		|| prepared.operation !== 'update'
+		|| prepared.task.locator.representation !== 'inline'
+		|| !evidence
+		|| evidence.resourceKey !== prepared.task.locator.filePath
+		|| sha256HexV1(evidence.content) !== evidence.revision
+	) return null;
+	const matchingResources = commit.groupResults.flatMap(
+		group => group.resourceRevisions ?? [],
+	).filter(resource => (
+		resource.resourceKind === 'task-source'
+		&& resource.resourceKey === evidence.resourceKey
+	));
+	if (
+		matchingResources.length !== 1
+		|| matchingResources[0]?.revision !== evidence.revision
+	) return null;
+	return { preparation: prepared, resourceKey: evidence.resourceKey };
+}
+
+export function refreshRuntimeInlineTaskUpdateSettlementEvidenceV1(
+	preparedMutation: RuntimePreparedMutationV1,
+	commit: RuntimePreparedMutationCommitV1,
+	observedSourceContent: string | null,
+	keyMappings: readonly KeyMapping[],
+): RuntimePreparedMutationCommitV1 {
+	const source = runtimeInlineTaskUpdateSettlementEvidenceSourceV1(preparedMutation, commit);
+	const evidence = commit.primaryTaskSourceCommitEvidence;
+	if (!source || !evidence || observedSourceContent === null) return commit;
+	const revision = resolveRuntimeInlineTaskUpdateSettlementRevisionV1(
+		source.preparation,
+		evidence.content,
+		evidence.revision,
+		observedSourceContent,
+		keyMappings,
+	);
+	if (!revision || revision === evidence.revision) return commit;
+	return {
+		...commit,
+		groupResults: commit.groupResults.map(group => ({
+			...group,
+			...(group.resourceRevisions
+				? {
+					resourceRevisions: group.resourceRevisions.map(resource => (
+						resource.resourceKind === 'task-source'
+						&& resource.resourceKey === evidence.resourceKey
+							? { ...resource, revision }
+							: resource
+					)),
+				}
+				: {}),
+		})),
 	};
 }
 
@@ -901,15 +1083,23 @@ export function verifyRuntimeTaskFieldMutationPrimaryPostflightV1(
 			if (task.checkbox !== expected) return false;
 		} else {
 			const observed = task.fieldValues[field] ?? '';
+			const boundedInlineSettlement = field === 'datetimeModified'
+				&& task.locator.representation === 'inline'
+				&& evidence?.settlementDatetimeModified === observed;
 			if (
 				observed !== expected
 				&& !(
 					field === 'datetimeModified'
-					&& task.locator.representation === 'file'
-					&& observed.localeCompare(expected) > 0
 					&& evidence !== undefined
 					&& /^[a-f0-9]{64}$/u.test(evidence.committedSourceRevision)
 					&& evidence.observedSourceRevision === evidence.committedSourceRevision
+					&& parseStrictCanonicalLocalDatetime(observed) === observed
+					&& parseStrictCanonicalLocalDatetime(expected) === expected
+					&& observed.localeCompare(expected) > 0
+					&& (
+						task.locator.representation === 'file'
+						|| boundedInlineSettlement
+					)
 				)
 			) return false;
 		}


### PR DESCRIPTION
## Summary

- fix false `outcome-unknown` results after a successful inline `task.update`
- reconcile commit evidence only when Runtime settlement changed the target task's single `datetimeModified` value monotonically
- preserve fail-closed behavior for every other same-source byte change, read/parser failure, stale or duplicate evidence, and post-refresh drift
- fence replay after uncertain postflight outcomes

## Root cause

The writer sealed exact task-source evidence before Runtime settlement. Obsidian-managed settlement could then advance only the target inline task's `datetimeModified` metadata, leaving the requested update intact but changing the durable source hash. Semantic postflight compared the settled source with the pre-settlement hash and reported a successful mutation as uncertain.

## Evidence policy

This does not use PR #116's generic post-settlement rehash. Evidence is refreshed only for `task-fields + update + inline` when:

- the writer's committed content still hashes to its sealed revision
- exactly one matching primary `task-source` revision exists
- the target locator line and Operon ID remain exact
- both lines contain exactly one `datetimeModified`
- only that timestamp value changed, to a valid strictly later local datetime
- every other line, field, byte, and line ending remains unchanged

Any mismatch leaves the original commit evidence untouched, so existing semantic postflight returns `outcome-unknown`.

## Validation

Exact candidate: `27eae9d52484f8149f57a35fc3f80259da5c7dd4`

- `npm run agent-runtime:mutation` — 138/138
- `npm run agent-runtime:runtime` — passed
- `npm run agent-runtime:developer-api` — passed
- `npm run agent-runtime:transport:test` — passed
- `npm run check:candidate` with canonical Node 24.18.0 — passed
- candidate freeze registry — verified
- two independent read-only evidence/contract reviews — no blocking findings

Manual live Obsidian acceptance was intentionally waived because this defect has no meaningful visual acceptance surface. No vault deployment was performed.

Supersedes #116.

Fixes #120
