### PR TITLE
Bind Developer API consent to its owning Obsidian window

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -321,6 +321,7 @@ import {
 	type DeveloperConsentPromptV1,
 	type DeveloperSecuritySessionV1,
 } from './src/agent-runtime/developer-api/security';
+import { requestBoundedDeveloperConsentV1 } from './src/agent-runtime/developer-api/security/bounded-consent';
 import type {
 	OperonDeveloperApiAccessRequestV1,
 	OperonDeveloperApiAccessResultV1,
@@ -1420,8 +1421,15 @@ export default class OperonPlugin extends Plugin {
 		if (!this.startupReady || this.agentRuntimeLifecycle?.getPhase() !== 'ready') {
 			return Promise.resolve('unavailable');
 		}
-		return new Promise(resolve => {
-			new ConfirmActionModal(this.app, {
+		const ownerDocument = this.app.workspace.containerEl.ownerDocument;
+		const ownerWindow = ownerDocument.defaultView;
+		if (!ownerWindow) return Promise.resolve('unavailable');
+		return requestBoundedDeveloperConsentV1({
+			ownerWindow,
+			ownerDocument,
+			timeoutMs: 45_000,
+			show: onDecision => {
+				const modal = new ConfirmActionModal(this.app, {
 				title: t('settings', 'developerApiConsentTitle'),
 				message: t('settings', 'developerApiConsentDesc'),
 				confirmText: t('settings', 'developerApiConsentApprove'),
@@ -1459,7 +1467,10 @@ export default class OperonPlugin extends Plugin {
 						after: '',
 					},
 				],
-			}, confirmed => resolve(confirmed ? 'approved' : 'denied')).open();
+				}, onDecision);
+				modal.open();
+				return () => modal.close();
+			},
 		});
 	}
 

--- a/scripts/agent-runtime/developer-api/security/security-policy.test.ts
+++ b/scripts/agent-runtime/developer-api/security/security-policy.test.ts
@@ -11,6 +11,89 @@ import {
 	type DeveloperConsentDecisionV1,
 	type DeveloperSecuritySessionV1,
 } from '../../../../src/agent-runtime/developer-api/security';
+import { requestBoundedDeveloperConsentV1 } from '../../../../src/agent-runtime/developer-api/security/bounded-consent';
+
+class FakeConsentWindow {
+	focused = false;
+	activeWindow: FakeConsentWindow = this;
+	activeDocument: Document = { marker: 'previous' } as unknown as Document;
+	private nextHandle = 1;
+	private readonly timers = new Map<number, { handler: () => void; timeoutMs: number }>();
+
+	focus(): void {
+		this.focused = true;
+	}
+
+	setTimeout(handler: () => void, timeoutMs: number): number {
+		const handle = this.nextHandle++;
+		this.timers.set(handle, { handler, timeoutMs });
+		return handle;
+	}
+
+	clearTimeout(handle: number): void {
+		this.timers.delete(handle);
+	}
+
+	run(timeoutMs: number): void {
+		const matches = [...this.timers.entries()]
+			.filter(([, timer]) => timer.timeoutMs === timeoutMs);
+		for (const [handle, timer] of matches) {
+			this.timers.delete(handle);
+			timer.handler();
+		}
+	}
+}
+
+test('opens Developer API consent in the owning window and returns the decision', async () => {
+	const ownerWindow = new FakeConsentWindow();
+	const ownerDocument = { marker: 'owner' } as unknown as Document;
+	const previousWindow = new FakeConsentWindow();
+	const previousDocument = ownerWindow.activeDocument;
+	ownerWindow.activeWindow = previousWindow;
+	let decide: ((confirmed: boolean) => void) | undefined;
+	let openedAgainstOwner = false;
+	const decisionPromise = requestBoundedDeveloperConsentV1({
+		ownerWindow,
+		ownerDocument,
+		timeoutMs: 45_000,
+		show: onDecision => {
+			openedAgainstOwner = ownerWindow.activeWindow === ownerWindow
+				&& ownerWindow.activeDocument === ownerDocument;
+			decide = onDecision;
+			return () => {};
+		},
+	});
+	assert.equal(ownerWindow.focused, true);
+	ownerWindow.run(0);
+	assert.equal(openedAgainstOwner, true);
+	assert.equal(ownerWindow.activeWindow, previousWindow);
+	assert.equal(ownerWindow.activeDocument, previousDocument);
+	decide?.(true);
+	assert.equal(await decisionPromise, 'approved');
+});
+
+test('closes unavailable Developer API consent after a bounded timeout', async () => {
+	const ownerWindow = new FakeConsentWindow();
+	const ownerDocument = { marker: 'owner' } as unknown as Document;
+	let closed = false;
+	let decide: ((confirmed: boolean) => void) | undefined;
+	const decisionPromise = requestBoundedDeveloperConsentV1({
+		ownerWindow,
+		ownerDocument,
+		timeoutMs: 45_000,
+		show: onDecision => {
+			decide = onDecision;
+			return () => {
+				closed = true;
+			};
+		},
+	});
+	ownerWindow.run(0);
+	ownerWindow.run(45_000);
+	assert.equal(await decisionPromise, 'unavailable');
+	assert.equal(closed, true);
+	decide?.(true);
+});
 
 const session: DeveloperSecuritySessionV1 = {
 	consumerId: 'obsidian-plugin:test.consumer',

--- a/src/agent-runtime/developer-api/security/bounded-consent.ts
+++ b/src/agent-runtime/developer-api/security/bounded-consent.ts
@@ -1,0 +1,86 @@
+export type BoundedDeveloperConsentDecisionV1 =
+	| 'approved'
+	| 'denied'
+	| 'unavailable';
+
+export interface DeveloperConsentOwnerWindowV1 {
+	activeWindow: DeveloperConsentOwnerWindowV1;
+	activeDocument: Document;
+	focus(): void;
+	setTimeout(handler: () => void, timeoutMs: number): number;
+	clearTimeout(handle: number): void;
+}
+
+export interface BoundedDeveloperConsentOptionsV1 {
+	ownerWindow: DeveloperConsentOwnerWindowV1;
+	ownerDocument: Document;
+	timeoutMs: number;
+	show: (onDecision: (confirmed: boolean) => void) => () => void;
+}
+
+/**
+ * Presents host-owned consent in the plugin's owning window and guarantees that
+ * a missing or hidden UI cannot leave a Developer API request pending forever.
+ */
+export function requestBoundedDeveloperConsentV1(
+	options: BoundedDeveloperConsentOptionsV1,
+): Promise<BoundedDeveloperConsentDecisionV1> {
+	return new Promise(resolve => {
+		let settled = false;
+		let closePrompt: (() => void) | null = null;
+		let openHandle: number | null = null;
+		let timeoutHandle: number | null = null;
+
+		const clearTimers = (): void => {
+			if (openHandle !== null) options.ownerWindow.clearTimeout(openHandle);
+			if (timeoutHandle !== null) options.ownerWindow.clearTimeout(timeoutHandle);
+			openHandle = null;
+			timeoutHandle = null;
+		};
+		const settle = (decision: BoundedDeveloperConsentDecisionV1): void => {
+			if (settled) return;
+			settled = true;
+			clearTimers();
+			resolve(decision);
+		};
+
+		try {
+			options.ownerWindow.focus();
+		} catch {
+			// Some window managers can reject focus requests. Opening still remains
+			// useful, and the bounded timeout preserves fail-closed behavior.
+		}
+
+		openHandle = options.ownerWindow.setTimeout(() => {
+			openHandle = null;
+			if (settled) return;
+			const previousActiveWindow = options.ownerWindow.activeWindow;
+			const previousActiveDocument = options.ownerWindow.activeDocument;
+			try {
+				// Obsidian's Modal API targets the global active window. A Developer
+				// API request can originate from a background vault window, so scope
+				// that global only while the modal is constructed and opened.
+				options.ownerWindow.activeWindow = options.ownerWindow;
+				options.ownerWindow.activeDocument = options.ownerDocument;
+				closePrompt = options.show(confirmed => {
+					settle(confirmed ? 'approved' : 'denied');
+				});
+			} catch {
+				settle('unavailable');
+			} finally {
+				options.ownerWindow.activeWindow = previousActiveWindow;
+				options.ownerWindow.activeDocument = previousActiveDocument;
+			}
+		}, 0);
+		timeoutHandle = options.ownerWindow.setTimeout(() => {
+			if (settled) return;
+			settled = true;
+			clearTimers();
+			try {
+				closePrompt?.();
+			} finally {
+				resolve('unavailable');
+			}
+		}, options.timeoutMs);
+	});
+}


### PR DESCRIPTION
## Summary

- present Developer API consent in the Obsidian window that owns the Operon plugin instance;
- temporarily scope Obsidian's global active window and document only while the modal is opened, then restore both;
- resolve fail-closed as `unavailable` and close the prompt after a 45-second timeout;
- ignore late decisions after the consent request has settled;
- add focused security tests for owner-window binding, global restoration, approval, timeout cleanup, and late decisions.

Fixes #136.

## Root cause

`ConfirmActionModal` follows Obsidian's global active window. A Developer API request can originate from an Operon instance in a different or background vault window, so the prompt could appear in the wrong place. The original promise also had no bounded timeout, allowing an unseen or missing prompt to keep an apply request pending indefinitely.

## Safety boundary

The host still owns the prompt and decision. The patch does not broaden grants or bypass consent: it only selects the correct owner window and adds a fail-closed timeout. Global window bindings are restored immediately after modal creation, and a late callback cannot change a settled result.

## Validation

- `npm run agent-runtime:developer-api` - 85 Developer API tests, 9 security tests, 6 integration tests, and 7 native-consumer tests passed
- `npm run lint:strict` - passed
- `npm run build` - passed
- bundle-size and Agent Runtime bundle guards - passed
- live reproduction originally observed with Operon 3.1.1, Obsidian 1.13.6, and multiple Obsidian windows