### PR TITLE
Fix the 3.2.1 candidate freeze identity

### DIFF
--- a/scripts/release/check-candidate-freeze-registry.mjs
+++ b/scripts/release/check-candidate-freeze-registry.mjs
@@ -18,17 +18,17 @@ const mutableAliases = new Set([
 const registryBytes = await readRegularFileNoFollow(path.join(pluginRoot, registryRelativePath), pluginRoot);
 assert.equal(
 	sha256(registryBytes),
-	'15c3714c98e8d233af7ab5d5ed8ed2ac4dd331e1fd14103a0e527a5c61a81013',
+	'6bb087ff18b25860ad6829aefb8626eec5591dd9dcf81320bff2e7b365be6623',
 	'OPERON_PUBLIC_V1_CANDIDATE_REGISTRY_DRIFT',
 );
 const registry = JSON.parse(registryBytes.toString('utf8'));
 assert.deepEqual(Object.keys(registry).sort(), ['currentPluginVersion', 'kind', 'registryVersion', 'releases']);
 assert.equal(registry.registryVersion, 1);
 assert.equal(registry.kind, 'operon-public-v1-release-freeze-registry');
-assert.equal(registry.currentPluginVersion, '3.2.0');
+assert.equal(registry.currentPluginVersion, '3.2.1');
 assert.deepEqual(
 	registry.releases.map(release => release.pluginVersion),
-	['3.0.2', '3.1.0', '3.1.1', '3.2.0'],
+	['3.0.2', '3.1.0', '3.1.1', '3.2.0', '3.2.1'],
 );
 for (const release of registry.releases) {
 	assert.deepEqual(Object.keys(release).sort(), ['cliVersion', 'evidenceKind', 'files', 'pluginVersion']);
@@ -46,4 +46,4 @@ assert.equal(binding.package.version, '1.1.0');
 assert.equal(binding.source.tag, 'cli-v1.1.0');
 assert.equal(binding.provenance.publishRunAttempt, 2);
 
-console.log('Operon 3.2.0 / CLI 1.1.0 candidate evidence registry verified.');
+console.log('Operon 3.2.1 / CLI 1.1.0 candidate evidence registry verified.');


### PR DESCRIPTION
## Summary

Advance the preserved historical candidate-freeze checker to the exact 3.2.1 evidence registry already sealed on `main`.

The 3.2.1 seal appended the new release to `public-v1-release-freezes.json`, but the checker remained pinned to the 3.2.0 registry identity. The checker therefore fails with `OPERON_PUBLIC_V1_CANDIDATE_REGISTRY_DRIFT` when invoked against the sealed 3.2.1 registry.

After #149, this checker is no longer part of the active candidate or release pipeline and is exposed only as `candidate:freeze:check:historical`. This PR no longer unblocks ordinary PR CI; it keeps the preserved historical/manual verifier internally consistent.

This patch updates only the exact authenticated registry SHA-256, current plugin version, monotonic release list, and success message. It does not weaken or bypass the historical freeze guard.

Closes #147.

## Validation

- `npm run candidate:freeze:check` on the pre-#149 branch identity ✅
- current PR Validation, Windows, and CodeQL checks ✅
- `npm ci` / audit: 0 vulnerabilities ✅
- `git diff --check` ✅