### PR TITLE
Update Operon docs package

### DIFF
--- a/docs/operon-docs/DOCS-001 Operon Docs MOC.md
+++ b/docs/operon-docs/DOCS-001 Operon Docs MOC.md
@@ -82,6 +82,7 @@ Follow these in order. They are enough to go from "what is this?" to doing real 
 - [[DOCS-086 Create file task|Create file task]]
 - [[DOCS-087 Edit or convert to file task|Edit or convert to file task]]
 - [[DOCS-088 Convert file task to inline task|Convert file task to inline task]]
+- [[DOCS-135 Convert task to plain|Convert task to plain]]
 - [[DOCS-089 Move an inline task here|Move an inline task here]]
 - [[DOCS-090 Toggle task completion|Toggle task completion]]
 - [[DOCS-091 Rebuild full index|Rebuild full index]]

--- a/docs/operon-docs/DOCS-015 Task identity and operonId.md
+++ b/docs/operon-docs/DOCS-015 Task identity and operonId.md
@@ -54,6 +54,8 @@ Treat `operonId` as read-only in normal use:
 - **Do not edit it.** Changing it makes Operon see a different task.
 - **Do not delete it.** Removing it strips the task of its durable identity.
 
+There is one deliberate exception: [[DOCS-135 Convert task to plain|Convert task to plain]] removes an `operonId` through a confirmed command when you want to keep the Markdown content but stop treating it as an Operon task. Do not imitate that operation by deleting the field by hand.
+
 Copying is the interesting case. If you copy a task line, you copy its id too, and now two lines claim one identity. You are allowed to do this; it is not a trap. The moment it happens, Operon detects the clash and the **Operon ID Conflict** manager steps in so the duplication never quietly corrupts your data. From the manager you give one copy a fresh id (or delete it), and the conflict is resolved. So if you simply want a second task, let Operon create it and it starts with its own id; if you deliberately copy one, expect the manager and use it to split the two apart. See [[DOCS-055 Duplicate IDs|Duplicate IDs]].
 
 ## FAQ

--- a/docs/operon-docs/DOCS-019 Converting inline and file tasks.md
+++ b/docs/operon-docs/DOCS-019 Converting inline and file tasks.md
@@ -38,6 +38,12 @@ The reason conversion is safe is the `operonId`. Both directions keep it, so the
 
 So the conversion is about the task's *container*, not its meaning.
 
+## Leave Operon instead of changing shape
+
+[[DOCS-135 Convert task to plain|Convert task to plain]] is a different action. It does not move the same task between inline and file containers. Instead, it removes the `operonId` and ends the task's Operon identity: an inline task becomes a plain checkbox, while a File Task can become a normal note with only the managed properties you select removed.
+
+Use it when you want to keep the Markdown content but stop managing the task in Operon. It has its own confirmation, property picker, and safety checks for relationships, timers, recurrence, and reminders.
+
 ## FAQ
 
 **Will I lose my fields when converting?** No. Operon carries the canonical fields across both directions. Only the container changes.

--- a/docs/operon-docs/DOCS-022 Command palette reference.md
+++ b/docs/operon-docs/DOCS-022 Command palette reference.md
@@ -27,6 +27,7 @@ This page is the index. The action commands link to a dedicated page with their 
 
 - [[DOCS-087 Edit or convert to file task|Edit or convert to file task]]: edits the current file task, or converts a normal note into one.
 - [[DOCS-088 Convert file task to inline task|Convert file task to inline task]]: collapses a file task back into a single inline task, then moves the old note to the Obsidian trash. See [[DOCS-019 Converting inline and file tasks|Converting inline and file tasks]].
+- [[DOCS-135 Convert task to plain|Convert task to plain]]: picks an inline or file task with Task Finder, then removes its Operon identity while keeping a plain checkbox or normal note.
 - **Convert Tasks emoji line to inline task**: migrates a line written in the Obsidian Tasks emoji format into an Operon inline task. See [[DOCS-049 Obsidian Tasks migration|Obsidian Tasks migration]].
 - **Convert Selection to Operon Tasks**: turns several selected lines into tasks at once. See [[DOCS-023 Create tasks from selected text|Create tasks from selected text]].
 

--- a/docs/operon-docs/DOCS-088 Convert file task to inline task.md
+++ b/docs/operon-docs/DOCS-088 Convert file task to inline task.md
@@ -36,7 +36,7 @@ Because the `operonId` and fields survive, the task stays the same task in a lig
 
 ## When to use it
 
-Use it when a note no longer needs its own body, and the task would be easier to handle as a line again. If you only want to keep the note but stop treating it as a task, that is a different action; this command is specifically for collapsing back to inline.
+Use it when a note no longer needs its own body, and the task would be easier to handle as a line again. If you only want to keep the note but stop treating it as a task, use [[DOCS-135 Convert task to plain|Convert task to plain]] instead. This command is specifically for collapsing back to inline while preserving the same Operon task.
 
 ## Related
 

--- a/docs/operon-docs/DOCS-135 Convert task to plain.md
+++ b/docs/operon-docs/DOCS-135 Convert task to plain.md
@@ -1,0 +1,89 @@
+---
+Notes: Command that removes a task from Operon while keeping its plain Markdown content
+Icon: unlink
+Color: "#475569"
+Updated: 2026-08-15T10:34:43
+---
+
+# Convert task to plain
+
+**Convert task to plain** removes an existing Operon task from Operon while keeping its useful Markdown content. It is for the moment a task no longer needs Operon's identity, fields, views, scheduling, or tracking, but you want to keep it as an ordinary checkbox or note.
+
+This is different from [[DOCS-019 Converting inline and file tasks|converting inline and file tasks]], which changes a task's container while preserving its `operonId` and task identity. Convert task to plain deliberately removes that identity.
+
+## How it works
+
+Run **Convert task to plain** from the command palette. [[DOCS-027 Task Finder|Task Finder]] opens so you can choose the task. It includes inline and file tasks, including completed and cancelled tasks.
+
+The command then follows the selected task's shape:
+
+- **Inline task:** shows a confirmation, then turns the line into a plain Markdown checkbox.
+- **File task:** opens a property picker so you choose which managed Operon properties to remove. The file itself stays in your vault as a normal note.
+
+## Before you start
+
+Close the [[DOCS-021 Task Editor|Task Editor]] before running the command. If the source note is open, save it first. Operon stops rather than overwriting an unsaved source buffer or a task source that changed while the command was open.
+
+Some task states must be removed before a task can leave Operon:
+
+- a parent task link
+- direct subtasks
+- blocking or blocked-by dependencies
+- an active timer
+- active recurrence or a recurrence series
+- reminder dates or reminder rules
+
+The command names every blocker it finds. It does not remove relationships, stop timers, or clear recurrence and reminders for you. Resolve those states first, then run the command again.
+
+## Convert an inline task to a plain checkbox
+
+After you choose an inline task, Operon explains that the change is permanent and asks you to confirm. The resulting line keeps its indentation, checkbox state, description, and tags:
+
+```md
+Before:
+  - [x] Send the draft #release {{operonId:: abc1234}} {{status:: Project.Done}} {{priority:: A}}
+
+After:
+  - [x] Send the draft #release
+```
+
+Open tasks stay `- [ ]`, completed tasks stay `- [x]`, and cancelled tasks stay `- [-]`. The time prefix, `operonId`, canonical and custom task fields, and other Operon metadata containers are removed. The line remains ordinary Markdown, but it is no longer an Operon task.
+
+## Convert a File Task to a plain file
+
+After you choose a file task, **Convert to plain file** opens a searchable list of managed properties that are physically present in that file. `operonId` is selected and locked because removing it is what detaches the file from Operon. Other managed properties begin unselected, so you choose exactly what to remove.
+
+The picker lists only current Operon-managed built-in, key-mapped, custom, and internal properties. It does not list ordinary vault properties. When you select properties and choose **Remove selected**, Operon removes the selected property names and their recognized aliases together in one operation.
+
+The note is not deleted, moved, or renamed. Its body, tags, unmanaged properties, and managed properties you leave unselected stay as they are. After `operonId` is removed, the note is an ordinary Markdown note rather than a File Task.
+
+## What happens after conversion
+
+After a successful conversion, the task no longer appears in Operon task surfaces because it no longer has an Operon identity. Operon also removes its pin if it was pinned.
+
+The command fails closed when the task is missing, has a duplicate `operonId`, its source changes, or a required write cannot be confirmed. Review the notice, save or resolve the reported condition, and try again. There is no Undo promise for removing Operon metadata; keep a copy first if you may need the original task record.
+
+## When to use the other conversion command
+
+Use [[DOCS-088 Convert file task to inline task|Convert file task to inline task]] when you want to keep the same Operon task but collapse its File Task note into an inline task. That command preserves the `operonId` and fields, then moves the old note to trash. Use **Convert task to plain** when you want to keep an ordinary checkbox or note and stop managing it in Operon.
+
+## FAQ
+
+**Does this delete my note?** No. Converting a File Task to a plain file keeps the note, its body, tags, unmanaged properties, and any managed properties you leave unselected. Only [[DOCS-088 Convert file task to inline task|Convert file task to inline task]] moves the old note to trash.
+
+**Will the task still appear in Operon?** No. Removing `operonId` removes the task's Operon identity, so it no longer appears in Operon views, Task Finder, Calendar, Kanban, filters, or pinned tasks.
+
+**Can I keep some File Task properties?** Yes. In the File Task picker, only `operonId` is required. Other managed properties begin unselected and remain as ordinary frontmatter when you leave them unselected.
+
+**Why can't I convert a task with subtasks, dependencies, recurrence, reminders, or a running timer?** Those states rely on the task's Operon identity. Resolve them first so the command does not leave broken task relationships or active automation behind.
+
+**Can I undo the conversion?** Operon does not provide an Undo action for this command. Keep a copy first if you may need the original Operon metadata later.
+
+**Why must I close Task Editor and save the source note first?** The command only changes a current, saved source. This avoids overwriting an open edit or converting a task whose source changed while you were choosing it.
+
+## Related
+
+- [[DOCS-001 Operon Docs MOC|Operon Docs MOC]]
+- [[DOCS-019 Converting inline and file tasks|Converting inline and file tasks]]
+- [[DOCS-015 Task identity and operonId|Task identity and operonId]]
+- [[DOCS-022 Command palette reference|Command palette reference]]

--- a/docs/operon-docs/manifest.json
+++ b/docs/operon-docs/manifest.json
@@ -1,7 +1,6 @@
 {
   "schemaVersion": 1,
   "packageId": "operon-docs",
-  "generatedAt": "2026-08-12T15:37:56.353Z",
   "source": {
     "branch": "main",
     "docsBasePath": "docs/operon-docs",
@@ -10,8 +9,8 @@
   "files": [
     {
       "path": "DOCS-001 Operon Docs MOC.md",
-      "sha256": "491124e48c57ce73fdfdbf56eced4e803759439ed0c23e56e0965a5fe3f4ed71",
-      "bytes": 10526
+      "sha256": "52d83da1a3a3526d99603f7005301097e4c53c426400de6f3f4e48ea004df008",
+      "bytes": 10585
     },
     {
       "path": "DOCS-002 How to use these docs.md",
@@ -80,8 +79,8 @@
     },
     {
       "path": "DOCS-015 Task identity and operonId.md",
-      "sha256": "8105b91283b94260693bde125c912f09753e995f2d49e3b766d47f0e2a69f461",
-      "bytes": 4330
+      "sha256": "a4de277049c676da95b396e0e7945534bb217bb5c8ddea1ccc0697260a3d032c",
+      "bytes": 4617
     },
     {
       "path": "DOCS-016 Parent and sub-tasks.md",
@@ -100,8 +99,8 @@
     },
     {
       "path": "DOCS-019 Converting inline and file tasks.md",
-      "sha256": "a8db08af71f3b260d4cad8729be9e0c353051ebf2206595cd54e50dc38addf0e",
-      "bytes": 4898
+      "sha256": "6e1facc61ee37585c8c98dfc02292fb7f66321eba0da0e73fd40ae8b2003b00d",
+      "bytes": 5505
     },
     {
       "path": "DOCS-020 Task Creator.md",
@@ -115,8 +114,8 @@
     },
     {
       "path": "DOCS-022 Command palette reference.md",
-      "sha256": "612c2bc98cd2b713154d962cdb419981d94c3bac38f06a01d39e83a716e414e0",
-      "bytes": 5332
+      "sha256": "5531b4f88c7b12b7a5a6163ec5e7b0ddd7cbf8e3c361d8673d31cdab8d0f6ec1",
+      "bytes": 5519
     },
     {
       "path": "DOCS-023 Create tasks from selected text.md",
@@ -445,8 +444,8 @@
     },
     {
       "path": "DOCS-088 Convert file task to inline task.md",
-      "sha256": "86b5c37228645a0078dd4fb3888005c669d651bd07d82c2ff7440735b027aa81",
-      "bytes": 2415
+      "sha256": "2e83bc82ce192621f52ec5cbfcffa7ab70e748246661ac872e053f20e2f4ed8a",
+      "bytes": 2495
     },
     {
       "path": "DOCS-089 Move an inline task here.md",
@@ -677,6 +676,12 @@
       "path": "DOCS-134 Backup and restore settings.md",
       "sha256": "8512761ebaa89201549bc631fc2178c9f834e6ce84056eb63859b00bbd553395",
       "bytes": 5599
+    },
+    {
+      "path": "DOCS-135 Convert task to plain.md",
+      "sha256": "17c473d6d10557a41cb3c0c7378bb49085c59278b14d329e2e5c0ebf09555db2",
+      "bytes": 6058
     }
-  ]
+  ],
+  "generatedAt": "2026-08-15T08:58:44.665Z"
 }


### PR DESCRIPTION
## What changed

- Synced the generated Operon docs package from the canonical Vault sources.
- Added DOCS-135 and refreshed the five changed documents plus the manifest.
- Media was already current, so no media files changed.

## Validation

- `npm run docs:sync-runtime:test`
- `OPERON_DOCS_SOURCE_ROOT=<Vault source> npm run docs:package:test` (3/3)
- `git diff --check -- docs/operon-docs docs/media`

This PR is intentionally limited to `docs/operon-docs/**`.