### PR TITLE
Update Operon docs package

### DIFF
--- a/docs/operon-docs/DOCS-007 Install and enable Operon.md
+++ b/docs/operon-docs/DOCS-007 Install and enable Operon.md
@@ -2,7 +2,7 @@
 Notes: Install the plugin and turn it on
 Icon: download
 Color: "#16a34a"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-18T18:41:15
 ---
 
 # Install and enable Operon
@@ -37,6 +37,23 @@ For a gentle first action, create one small inline task. A real workflow can wai
 
 Operon can check GitHub for a newer compatible release once each time it starts, and shows a notice pointing you to Community Plugins when one is available. This is on by default; turn it off in **Settings → Operon → Core → General** if you would rather update on your own schedule. The check itself never installs anything, it only tells you an update exists.
 
+## Language packs
+
+English is built into Operon and is available immediately. The following interface languages are available as downloadable packs from **Settings → Operon → Core → General → Language**:
+
+- Turkish
+- German
+- French
+- Spanish
+- Simplified Chinese
+- Traditional Chinese
+- Japanese
+- Russian
+- Italian
+- Brazilian Portuguese
+
+Operon downloads, validates, and caches the selected pack before changing the interface. If that download or validation fails, the previous active language and its saved selection stay in place; Operon does not switch you to a partial or fallback interface. A cached pack can be used again without downloading it first.
+
 ## Compatibility
 
 Operon does not require another community plugin. Some workflows lean on Obsidian core features: Daily Notes can support date-based capture, and Page Preview improves hover previews when task titles or wikilinks are shown.
@@ -54,6 +71,8 @@ The main compatibility risk is another task plugin that also rewrites checkbox l
 **Do I need another plugin?** No. Operon stands on its own. It can optionally use Obsidian core features like Daily Notes and Page Preview, and the community **Maps** plugin, which adds a visual map preview to location chips.
 
 **Does Operon update itself?** No. It can check GitHub on startup and notify you when a newer compatible release is out, but you still update it yourself through Community Plugins. See **Settings → Operon → Core → General** to turn the check off.
+
+**Which interface languages are available?** English is built in. Downloadable packs are available for Turkish, German, French, Spanish, Simplified Chinese, Traditional Chinese, Japanese, Russian, Italian, and Brazilian Portuguese. Select one in **Settings → Operon → Core → General → Language**. If its pack cannot be downloaded or validated, Operon keeps the language already active.
 
 ## Next step
 

--- a/docs/operon-docs/DOCS-012 Inline task syntax.md
+++ b/docs/operon-docs/DOCS-012 Inline task syntax.md
@@ -2,7 +2,7 @@
 Notes: Complete reference for inline task field syntax and property types, with copy-paste ready examples
 Icon: braces
 Color: "#7c3aed"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-18T18:18:29
 ---
 
 # Inline task syntax
@@ -80,7 +80,7 @@ These are the fields you choose and edit, directly or through the Task Creator a
 | `contexts` | List | Environment or condition. | `[[Home]]` |
 | `taskIcon` | Text | Icon name (Lucide). | `flag` |
 | `taskColor` | Text | Hex color, without the `#`. | `4987a7` |
-| `note` | Text | A short annotation. | `waiting on review` |
+| `note` | Text | An annotation that can contain multiple lines. | `waiting on review` |
 | `location` | Text | Coordinates as latitude, longitude. See [[DOCS-041 Task chips display and behavior\|Task chips]]. | `52.52, 13.40` |
 | `links` | List | External web links. | `https://example.com` |
 
@@ -122,6 +122,18 @@ The last several (`repeatSeriesId`, `repeatOccurrenceDate`, `timezone`, `activeT
 - **Time fields** (`estimate`, `duration`, and the totals) are stored in seconds, but you normally set them through the Task Editor rather than typing seconds.
 - **List fields** (`assignees`, `contexts`, `links`, `blocking`, `blockedBy`) hold one or more values separated by a semicolon and a space (`; `). To keep a literal semicolon inside a single value, escape it as `\;`.
 - **Task links** (`parentTask`, `blocking`, `blockedBy`) reference other tasks by their `operonId`, not by title or path.
+
+## Notes: multiline text on one task line
+
+The task **description** is the one-line readable text after the checkbox. The separate `note` field is the place for a longer, multiline annotation. Even when a note has several visual lines, an inline task remains **one physical Markdown line**. Operon stores each note line break as the two-character escape `\n` inside the field:
+
+```md
+- [ ] Review the proposal {{operonId:: {{operonId}}}} {{note:: Check the budget\nAsk for the revised timeline\n\nShare the decision with the team}}
+```
+
+When Operon reads that task, the note has three text lines: “Check the budget”, “Ask for the revised timeline”, and “Share the decision with the team”, with a blank line before the last. If you need the visible characters `\n` in the note instead of a line break, write `\\n`; the doubled backslash keeps it literal.
+
+Use the [[DOCS-021 Task Editor|Task Editor]] or the shared [[DOCS-113 Text field editor popover|text field editor popover]] for normal editing. They accept **Shift+Enter** and multiline paste for Notes, including empty lines. The description remains a single-line task field.
 
 ## Copy-paste ready examples
 

--- a/docs/operon-docs/DOCS-021 Task Editor.md
+++ b/docs/operon-docs/DOCS-021 Task Editor.md
@@ -2,7 +2,7 @@
 Notes: The dialog for editing every task field
 Icon: square-pen
 Color: "#ea580c"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-18T18:18:29
 ---
 
 # Task Editor
@@ -36,7 +36,7 @@ The Task Editor exposes the canonical fields as proper controls:
 - Reminders, both kinds. See [[DOCS-116 Reminders|Reminders]].
 - Pinning. See [[DOCS-032 Pinned Task Dock|Pinned Task Dock]].
 - Time tracking, including session history. See [[DOCS-034 Time tracking|Time tracking]].
-- Icon, color, and a short note.
+- Icon, color, and a Note that can contain multiple lines.
 
 For a file task, the editor can also show the Markdown body alongside the fields, so you edit the work and its metadata together. For an inline task, it can reveal the source note when you need the surrounding context. It can also **Show checkboxes** for the task's [[DOCS-017 Plain checkbox lists|plain checklist]].
 
@@ -67,6 +67,12 @@ Both rows are **hidden by default.** Turn them on in **Settings → Operon → I
 
 The Task Editor autosaves your changes two seconds after your last edit, so you do not press a save button while working through a task's fields. Closing the editor, with its close control, a keyboard shortcut, or the backdrop, saves any pending change immediately rather than waiting out that two seconds. This timing is fixed and not a setting.
 
+## Description and Notes
+
+The **Description** is the task's one-line title. **Notes** are a separate multiline field for the detail that belongs with the task but does not belong in its title. In the Notes control, use **Shift+Enter** to insert a line break; pasted multiline text and intentional blank lines are kept. Normal **Enter** keeps the existing action for the surface instead of becoming a second line-break command. In the mobile Task Editor, normal Enter keeps its one-line behavior by inserting a space, while Shift+Enter inserts a note line break.
+
+For an inline task, those visual line breaks are stored as `\n` escapes inside the `note` field, keeping the entire task on one physical Markdown line. A literal `\n` is written as `\\n`. See [[DOCS-012 Inline task syntax|Inline task syntax]] for the on-disk form and [[DOCS-113 Text field editor popover|Text field editor popover]] for the shared compact editor.
+
 ## Why edit here instead of in Markdown
 
 You can always edit the raw `{{key:: value}}` text, and Operon will read it. But the Task Editor is safer: it writes fields in the right format, keeps `operonId` intact, and updates rollups and links for you. Hand-editing is best for quick text tweaks; the editor is best for anything structural. See [[DOCS-015 Task identity and operonId|Task identity and operonId]].
@@ -82,6 +88,8 @@ You can always edit the raw `{{key:: value}}` text, and Operon will read it. But
 **Why can I not add a reminder rule to this task?** A rule counts back from one of the task's dates, and this task has none yet. Add a due, scheduled, or start date, or a timed block, first.
 
 **I do not see reminder rows in the editor.** They are hidden by default. Turn them on under **Settings → Operon → Interface → Task Editor**, in **Workflow Pickers**.
+
+**Can I write a multiline description?** No. The Description remains the task's one-line title. Use Notes for line breaks, paragraphs, and pasted multiline detail.
 
 ## Settings
 

--- a/docs/operon-docs/DOCS-035 FlowTime focus sessions.md
+++ b/docs/operon-docs/DOCS-035 FlowTime focus sessions.md
@@ -2,7 +2,7 @@
 Notes: Run a countdown focus session on a task, with breaks and overtime
 Icon: hourglass
 Color: "#9333ea"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-18T18:18:29
 ---
 
 # FlowTime focus sessions
@@ -23,7 +23,7 @@ A session is not all-or-nothing. You can **Start break** to pause the focus cloc
 
 ## Reaching zero, and overtime
 
-When the countdown hits zero, FlowTime marks the **target reached** and can show a small notice, so you know the planned time is up without staring at the timer. It does not cut you off: it rolls into **Overtime** and keeps counting, so if you are in flow you can keep going and still see how far past your target you have gone.
+When the countdown hits zero, FlowTime marks the **target reached** and can show a small notice, so you know the planned time is up without staring at the timer. It does not cut you off: it rolls into **Overtime** and keeps counting, so if you are in flow you can keep going and still see how far past your target you have gone. The notice is independent of the optional completion sound described below.
 
 > **MEDIA-DOCS-035-2:** FlowTime in overtime after the countdown reached zero, with a break control available.
 
@@ -47,6 +47,12 @@ So the length you set is a soft target, not a deadline. If you want no target at
 
 Both record to the same task, so the choice is about how you want to work, not where the time lands. To review what you recorded, open the [[DOCS-053 Time session history|Time session history]].
 
+## Completion sound
+
+**Play reminder sound when FlowTime reaches zero** is off by default. When you turn it on, FlowTime plays the vault audio file selected under **Settings → Operon → Tasks → Reminders → Reminder sound** once when either a focus session or an active break reaches zero. It does not replay in overtime, when you open an already-elapsed timer, or when you enable the setting after the boundary has passed.
+
+This sound setting is separate from **Notify when FlowTime reaches zero**: you can use the notice, the sound, both, or neither. It applies only to FlowTime focus and break completions; it does not change TrackTime's count-up behavior.
+
 ## FAQ
 
 **Does FlowTime stop me when the timer ends?** No. It marks the target reached and continues into overtime, so you decide when to stop.
@@ -55,11 +61,13 @@ Both record to the same task, so the choice is about how you want to work, not w
 
 **Can I take breaks?** Yes. Start and end breaks from the panel; the focus clock pauses while a break is active.
 
+**Can FlowTime play a sound when time is up?** Yes. Turn on **Play reminder sound when FlowTime reaches zero**. It uses the audio file selected under **Reminders → Reminder sound** and plays once for a FlowTime focus or break completion.
+
 **Is there a Pomodoro timer?** No. Operon has no fixed Pomodoro cycle. FlowTime is a flexible focus session instead: set your own length, take breaks on demand, and continue into overtime past the target. Use TrackTime when you just want to count up.
 
 ## Settings
 
-Operon settings for this live in **Settings → Operon → Tasks → Tracker**, in the TrackTime & FlowTime section: the default session length, the break (pause) duration, whether to reuse your last chosen length, the numeric timer, and the notice when the countdown reaches zero.
+Operon settings for this live in **Settings → Operon → Tasks → Tracker**, in the TrackTime & FlowTime section: the default session length, the break (pause) duration, whether to reuse your last chosen length, the numeric timer, the notice when the countdown reaches zero, and the optional FlowTime completion sound. The sound uses **Settings → Operon → Tasks → Reminders → Reminder sound** as its file source.
 
 ## Related
 

--- a/docs/operon-docs/DOCS-046 Plugin data and state files.md
+++ b/docs/operon-docs/DOCS-046 Plugin data and state files.md
@@ -2,7 +2,7 @@
 Notes: Where Operon keeps its settings, working state, and rebuildable index
 Icon: folder-cog
 Color: "#0891b2"
-Updated: 2026-08-12T17:21:45
+Updated: 2026-08-18T18:18:29
 ---
 
 # Plugin data and state files
@@ -13,7 +13,7 @@ Apart from your tasks, which live in your Markdown, Operon keeps its own configu
 
 The plugin's main data file holds your Operon configuration: [[DOCS-039 Key mappings|key mappings]], [[DOCS-037 Pipelines and statuses|pipelines]], [[DOCS-038 Task priorities|priorities]], saved [[DOCS-025 Filter View|filters]], Calendar and Kanban presets, contextual menu setup, and the rest of your settings.
 
-**Table presets are the exception.** Each one lives as its own `.table` file in your vault, by default under `Operon/Tables`, rather than inside the plugin's data. The plugin's data still records small bookkeeping about them, such as their order and which one is the default, but the preset itself is the vault file. See [[DOCS-114 Table files|Table files]].
+**Table presets are the exception.** Each one lives as its own `.table` file in your vault rather than inside the plugin's data. **Settings → Operon → Views → Tables → Table default folder** chooses where *new* Table files are created. The historical default is `Operon/Tables`; choose another vault-relative folder to organize new files elsewhere, or leave the setting blank to create them at the vault root. Changing it never moves existing `.table` files. The plugin's data still records small bookkeeping about presets, such as their order and which one is the default, but the preset itself is the vault file. See [[DOCS-114 Table files|Table files]].
 
 Alongside it, Operon keeps working state and caches in subfolders:
 

--- a/docs/operon-docs/DOCS-063 Date and time picker.md
+++ b/docs/operon-docs/DOCS-063 Date and time picker.md
@@ -2,7 +2,7 @@
 Notes: Set dates and times by typing them in words or picking from a calendar
 Icon: calendar-days
 Color: "#db2777"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-18T18:18:29
 ---
 
 # Date and time picker
@@ -32,6 +32,12 @@ The suggestions are intentionally broad while you are still typing, so a short q
 
 The placeholder itself reminds you of the idea: "Type a date like next tuesday." Pick a suggestion to set the field.
 
+## Brazilian Portuguese dates
+
+When the interface language is **Brazilian Portuguese** (`pt-BR`), the picker uses its own Portuguese grammar. Verified examples include `Hoje`, `Amanhã`, `terça-feira`, `daqui a 3 dias`, `15 agosto`, and `15/08/2026`. Accents and letter case in supported Portuguese words are accepted, and `15 de agosto` is also valid.
+
+This grammar fails closed. An unrecognized English phrase such as `next Tuesday` or `august 15`, and incomplete or unsupported Portuguese such as `há 3 sem`, produces no date suggestion. Operon does not fall back to English parsing or `nldates` for `pt-BR`; that avoids silently interpreting a phrase from the wrong language.
+
 ## Or pick from the calendar
 
 If you would rather see the month, the picker also shows a calendar grid. Move by month or year, click a day, and use **Today** to jump to the current day or **Clear** to empty the field. Typing and clicking are two ways into the same control; use whichever is faster for the date you want.
@@ -57,6 +63,8 @@ A date field can be emptied. When a field already has a value, the picker offers
 **Why doesn't `aug 3` work?** The day always comes before the month, so write `3 aug`, not `aug 3`. Operon reads a typed date number-first, even though the suggestion it shows may read month-first.
 
 **Why does `3 m` show months and calendar dates together?** While you type, Operon reads a short query both ways: `3 m` as an offset (3 months) and as a day with a month starting with m (March 3, May 3). Type more, such as `3 march`, to narrow it to one.
+
+**Which Portuguese date phrases work?** With Brazilian Portuguese selected, use complete Portuguese forms such as `Hoje`, `Amanhã`, `terça-feira`, `daqui a 3 dias`, `15 agosto`, or `15/08/2026`. Unsupported or partial phrases are rejected instead of being interpreted through English.
 
 **Why can't I set an end time?** A timed end needs a start first. Set `datetimeStart`, then the end.
 

--- a/docs/operon-docs/DOCS-105 Table overview.md
+++ b/docs/operon-docs/DOCS-105 Table overview.md
@@ -2,7 +2,7 @@
 Notes: See tasks as rows and columns on the Operon Table
 Icon: table
 Color: "#0284c7"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-18T18:18:29
 ---
 
 # Table overview
@@ -61,6 +61,7 @@ A table does not have to stay in its own tab:
 
 - **Embed a table in a note** with an `operon-table` code block, so a live, editable table renders inside a daily note, a project page, or a dashboard. See [[DOCS-110 Embed a table in a note|Embed a table in a note]].
 - An embedded table can switch presets from its toolbar, and its visible row count can come from the global Table setting or a local `rows` value in the code block.
+- An embedded table uses the global default width unless its code block supplies a valid local `width:` percentage. The global default is `175%`; a local width always wins. See [[DOCS-110 Embed a table in a note|Embed a table in a note]].
 - **Export the table** as a Markdown table or CSV, or copy the embed code, from the export control in the toolbar. See [[DOCS-111 Export a table|Export a table]].
 
 ## When the table fits
@@ -100,7 +101,7 @@ If your work is mostly date-driven, the [[DOCS-028 Calendar overview|Calendar]] 
 
 ## Settings
 
-Operon settings for the Table live in **Settings → Operon → Views → Tables**, where you set the default preset, the maximum visible rows for embedded tables, and whether rows show the global line number, task icon helper, and task type helper columns. Each preset's own filter, columns, grouping, sorting, and summaries are edited from the table itself. See [[DOCS-109 Table presets|Table presets]].
+Operon settings for the Table live in **Settings → Operon → Views → Tables**, where you set the default preset; the destination for new Table files; the maximum visible rows; and the default embedded-table width. New files start in `Operon/Tables` unless you choose another vault-relative folder; leave that folder blank to create new files at the vault root. The folder setting never moves existing Table files. Embedded tables default to `175%` width, with `50%`, `75%`, `100%`, `125%`, `150%`, `175%`, `200%`, `225%`, and `250%` choices; a valid local `width:` in an embed takes precedence. You also choose whether rows show the global line number, task icon helper, and task type helper columns. Each preset's own filter, columns, grouping, sorting, and summaries are edited from the table itself. See [[DOCS-109 Table presets|Table presets]].
 
 ## Related
 

--- a/docs/operon-docs/DOCS-109 Table presets.md
+++ b/docs/operon-docs/DOCS-109 Table presets.md
@@ -2,14 +2,14 @@
 Notes: Save a table as a preset and switch between several tables
 Icon: table-2
 Color: "#0284c7"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-18T18:18:29
 ---
 
 # Table presets
 
 A preset saves a table layout and scope. It bundles which tasks appear, which task-field columns show and in what order, how the rows are grouped and sorted, which summaries roll up, how dense the rows are, and which search scopes are saved with the preset, all under a name. Presets are what let you keep several tables for different questions and switch between them from the toolbar, and the **default preset** is the one a new table opens with or the **Insert Operon Table embed** command uses.
 
-Each preset is also a real file in your vault, with a `.table` extension. Editing a preset here writes straight to that file. See [[DOCS-114 Table files|Table files]] for the file itself: where it lives, what happens when you rename or move it, and what a broken or duplicate file looks like.
+Each preset is also a real file in your vault, with a `.table` extension. Editing a preset here writes straight to that file. New files use the configurable **Table default folder** in **Settings → Operon → Views → Tables**: `Operon/Tables` is the historical default, and a blank setting means the vault root. Changing that destination affects only files created afterward; it does not move any existing preset. See [[DOCS-114 Table files|Table files]] for the file itself: where it lives, what happens when you rename or move it, and what a broken or duplicate file looks like.
 
 > **MEDIA-DOCS-109-1:** The table preset settings, with the Filtering, Grouping, Sort, Summaries, Display, and Columns sections.
 
@@ -94,7 +94,7 @@ The **default preset** is chosen in **Settings → Operon → Views → Tables**
 
 ## Settings
 
-Table presets and the default preset live in **Settings → Operon → Views → Tables**, alongside the maximum visible rows setting for embedded tables and the toggles for the line number, task icon, and task type columns. Each preset's own filter, columns, grouping, sorting, summaries, and density are edited from the preset settings, reached with **Edit preset**.
+Table presets and the default preset live in **Settings → Operon → Views → Tables**, alongside the destination for new Table files, the maximum visible rows and default width for embedded tables, and the toggles for the line number, task icon, and task type columns. The Table-file destination is applied only when Operon creates a new `.table` file; leave it blank for the vault root, and changing it never relocates an existing preset. Each preset's own filter, columns, grouping, sorting, summaries, and density are edited from the preset settings, reached with **Edit preset**.
 
 ## Related
 

--- a/docs/operon-docs/DOCS-110 Embed a table in a note.md
+++ b/docs/operon-docs/DOCS-110 Embed a table in a note.md
@@ -2,7 +2,7 @@
 Notes: Render a preset's live, editable table inside any note
 Icon: panel-top
 Color: "#0284c7"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-18T18:18:29
 ---
 
 # Embed a table in a note
@@ -28,9 +28,20 @@ rows: 35
 ```
 ````
 
-Operon replaces the block with the preset's table: its filter, columns, grouping, sorting, summaries, and visible row count, all live. The table is always referenced by `presetId`; `rows` only controls the local embed height.
+You can also set the width for one embed:
+
+````md
+```operon-table
+presetId: "tp_2pv2ls9"
+width: 125%
+```
+````
+
+Operon replaces the block with the preset's table: its filter, columns, grouping, sorting, summaries, visible row count, and width, all live. The table is always referenced by `presetId`; `rows` only controls the local embed height, while `width` only controls the local embed width.
 
 `rows` is optional. When it is a positive whole number, it controls how many rows this embedded table shows before the table body scrolls. This local value is not limited to the settings dropdown options. If `rows` is missing or invalid, the embed uses the global setting in **Settings → Operon → Views → Tables → Maximum visible rows in embedded tables**. The global default is `20`, with settings options for `10`, `20`, `30`, `40`, `50`, `75`, and `100` rows.
+
+`width` is optional. A valid local value is any whole-number percentage of at least `50%`, such as `width: 125%` or `width: 300%`; it overrides the global **Default width for embedded tables** setting for that one code block. The Settings dropdown offers `50%`, `75%`, `100%`, `125%`, `150%`, `175%`, `200%`, `225%`, and `250%`, but those choices do not limit local syntax. Operon keeps the rendered table within the available pane geometry. If `width` is missing or invalid, the global setting applies; its default is `175%`. A valid local `width:` always takes precedence over the global setting.
 
 ## Fast insert command
 
@@ -50,6 +61,7 @@ An embedded table is not a snapshot. It behaves like the full view:
 - Its **scope buttons** and parent scope are saved back to the shared preset, so changing those choices can affect other tables that use the same preset.
 - It can **switch to another preset** from its toolbar without changing the default preset or other embeds.
 - It respects the global embedded-table row limit, or a local `rows` value in the code block.
+- It respects the global embedded-table width, or a valid local `width` value in the code block.
 - It renders in both **Reading View** and **Live Preview**.
 
 Because the embed follows the preset, editing the preset later, adding a column or changing the grouping, updates every note that embeds it.
@@ -77,7 +89,7 @@ Two messages can appear in place of the table:
 - **Invalid table embed syntax**: the block is missing a valid `presetId` line. Use **Copy embed code** from preset settings, or **Copy table embed code** from the export menu, to get a correct block.
 - **Table preset not found**: the `presetId` does not match any saved preset, usually because the preset was deleted or the id was mistyped. Copy a fresh embed code from the preset you want.
 
-An invalid `rows` value does not break the embed. Operon ignores it and uses the global visible-row setting instead.
+An invalid `rows` or `width` value does not break the embed. Operon ignores that value and uses the corresponding global setting instead.
 
 ## Tips
 
@@ -99,6 +111,8 @@ An invalid `rows` value does not break the embed. Operon ignores it and uses the
 **What if I change the preset later?** Every note that embeds that preset shows the change, because the embed follows the preset rather than a copy of it.
 
 **How many rows does an embedded table show?** By default it uses **Settings → Operon → Views → Tables → Maximum visible rows in embedded tables**, which starts at `20`. Add `rows: 35` or another positive whole number to one code block when that embed needs a different visible height.
+
+**How wide is an embedded table?** It uses the **Default width for embedded tables** setting, which starts at `175%`. Add any whole-number local percentage of at least `50%`, such as `width: 125%`, when one embed needs another width; local `width:` overrides the global setting. The Settings dropdown is limited to `50%` through `250%`, but that does not limit local values.
 
 **Does changing the embed preset affect my default preset?** No. The toolbar switcher changes only the `presetId` in that one embedded code block.
 

--- a/docs/operon-docs/DOCS-112 Table cells display and behavior.md
+++ b/docs/operon-docs/DOCS-112 Table cells display and behavior.md
@@ -2,7 +2,7 @@
 Notes: What each table cell shows and does on click, hover, and keyboard, in detailed and compact cell modes
 Icon: square-mouse-pointer
 Color: "#0284c7"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-18T18:18:29
 ---
 
 # Table cells: display and behavior
@@ -87,9 +87,9 @@ From the keyboard, focus an editable picker cell and press **Enter** or **Space*
 
 ## Editing text in compact cells
 
-A text field behaves a little differently when it is collapsed to a compact icon. When the **description** or a **note** column is in compact cell mode, clicking its cell does not open a field picker; it opens a **text editor popover**, a small floating panel for editing that field's text in place. The panel carries the field's name and the task's description as a heading, and it saves what you type when you dismiss it, by clicking away, pressing **Escape**, or using its close button. In Table and embedded Table cells, saved line breaks are normalized to spaces.
+A text field behaves a little differently when it is collapsed to a compact icon. When a **description** or a **note** column is in compact cell mode, clicking its cell does not open a field picker; it opens a **text editor popover**, a small floating panel for editing that field's text in place. The panel carries the field's name and the task's description as a heading, and it saves what you type when you dismiss it, by clicking away, pressing **Escape**, or using its close button.
 
-This is how you keep a wordy column, such as description or note, collapsed to a narrow icon yet still edit its full text without widening the column or opening the Task Editor. The same popover opens for text cells in an [[DOCS-110 Embed a table in a note|embedded table]] and on the [[DOCS-030 Kanban overview|Kanban]]. See [[DOCS-113 Text field editor popover|Text field editor popover]] for the control itself.
+The two text fields have deliberately different policies. A **description** is the task's single-line title. A **note** can contain several visual lines: use **Shift+Enter** to add a line break, or paste multiline text including blank lines. For an inline task, Operon serializes those note breaks as `\n` inside the `note` field, so editing never splits the physical Markdown task line. The same popover behavior is available in an [[DOCS-110 Embed a table in a note|embedded table]] and on the [[DOCS-030 Kanban overview|Kanban]]. See [[DOCS-113 Text field editor popover|Text field editor popover]] for the control itself.
 
 > **MEDIA-DOCS-112-4:** The text editor popover open over a compact description cell, with its multi-line editor.
 

--- a/docs/operon-docs/DOCS-113 Text field editor popover.md
+++ b/docs/operon-docs/DOCS-113 Text field editor popover.md
@@ -2,7 +2,7 @@
 Notes: A floating editor for a single free-text field, opened in place across surfaces
 Icon: square-pen
 Color: "#db2777"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-18T18:18:29
 ---
 
 # Text field editor popover
@@ -18,7 +18,7 @@ The text field editor popover is a small floating panel for editing a task's **d
 The popover is a compact panel with three parts:
 
 - A **heading** with the field's name and, beneath it, the task's description so you know which task you are editing.
-- A **multi-line editor** for the text, focused and ready to type, with the cursor at the end of the current value.
+- An editor for the text, focused and ready to type, with the cursor at the end of the current value. Notes can use several lines; descriptions remain one-line task titles.
 - A **close** control in the corner.
 
 It picks up the task's color as an accent, and it floats above the surface you opened it from, so the table or board stays in place behind it.
@@ -37,10 +37,10 @@ Because it is one control, learning the panel once covers the places it appears.
 
 The popover is built for a quick edit and out:
 
-- Type freely; the editor accepts multiple lines while it is open.
+- The **Note** editor accepts multiple lines. Use **Shift+Enter** for a line break, and paste multiline text when that is faster; intentional blank lines are preserved. The **Description** remains a single-line task title.
 - It **saves when you dismiss it**, by clicking away, pressing **Escape**, or using the close control. There is no separate save step; closing commits your text.
-- In the Table and embedded Table, saved line breaks are normalized to spaces before the change is written back. On the Kanban, internal line breaks can be preserved.
-- The change is written straight back to the task's Markdown, the same as any other edit, so it shows everywhere the task appears.
+- Normal **Enter** keeps the existing submit or save behavior of the surface; it is not a second line-break command. In the mobile Task Editor, normal Enter retains its one-line behavior by inserting a space, while Shift+Enter inserts a Note line break.
+- The change is written straight back to the task's Markdown, the same as any other edit, so it shows everywhere the task appears. For inline tasks, a Note's line breaks are stored as `\n` escapes inside the field, which keeps the whole task on one physical Markdown line. To store the visible characters `\n`, write `\\n`.
 
 ## When to use it
 
@@ -58,9 +58,9 @@ When you need to change several fields at once, or work with the note as a full 
 
 **How do I save?** Just close the popover, by clicking away, pressing Escape, or using the close control. Closing saves what you typed.
 
-**Is it the same on the Table and the Kanban?** It is the same shared control, but the saved text is normalized by the surface that opened it. Table and embedded Table turn saved line breaks into spaces; Kanban can preserve internal line breaks.
+**Is it the same on the Table and the Kanban?** It is the same shared control. Notes preserve their line breaks across those surfaces; Descriptions remain one-line task titles.
 
-**Can I write more than one line?** You can type more than one line in the editor. In the Table and embedded Table, those lines save back as one line with spaces between them.
+**Can I write more than one line?** Yes, in Notes. Press Shift+Enter or paste multiline text, including blank lines. Descriptions remain single-line.
 
 ## Related
 

--- a/docs/operon-docs/DOCS-114 Table files.md
+++ b/docs/operon-docs/DOCS-114 Table files.md
@@ -2,7 +2,7 @@
 Notes: How a saved table lives as its own portable .table file in your vault
 Icon: file-cog
 Color: "#0284c7"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-18T18:18:29
 ---
 
 # Table files
@@ -21,12 +21,12 @@ Because the format is versioned and validated, Operon is strict about what it ac
 
 ## Where Table files live
 
-New Table files are created in an **Operon/Tables** folder at the root of your vault. This happens automatically whenever Operon needs to create one:
+New Table files use the configurable **Table default folder** in **Settings → Operon → Views → Tables**. The historical default is `Operon/Tables` at the root of your vault. Choose any canonical vault-relative folder when new presets belong somewhere else, or leave the setting blank to create new `.table` files directly at the vault root. This destination applies only when Operon creates a new file; it does **not** move, rename, or reorganize existing Table files. Creation happens automatically whenever Operon needs a new file:
 
 - **New** or **Duplicate** from a preset's settings.
 - A **related view** created from a Calendar, Kanban, or Filter View that spins up a new Table preset. See [[DOCS-025 Filter View|Filter View]].
 
-`Operon/Tables` is a starting point, not a cage. Once a file exists, you can move it anywhere in the vault, rename it, or organize it alongside the project it belongs to, and Operon keeps tracking the same preset at its new location.
+The configured folder is a starting point, not a cage. Once a file exists, you can move it anywhere in the vault, rename it, or organize it alongside the project it belongs to, and Operon keeps tracking the same preset at its new location.
 
 ## Opening a Table file
 
@@ -90,8 +90,8 @@ A `.table` file is an ordinary vault file as far as Obsidian's linking is concer
 
 ## Tips
 
-> [!tip] Treat Operon/Tables like any other vault folder
-> Because a Table file is a real file, everything you already do with vault files works on it: move it into the project folder it belongs to, rename it to match your own naming convention, back it up, or version it alongside your notes. Nothing about editing the table, its presets, or its embeds depends on the file living in any particular folder.
+> [!tip] Treat the Table default folder like any other vault folder
+> The setting chooses where *new* Table files begin, not where every Table file must stay. Because a Table file is a real file, everything you already do with vault files works on it: move it into the project folder it belongs to, rename it to match your own naming convention, back it up, or version it alongside your notes. Nothing about editing the table, its presets, or its embeds depends on the file living in any particular folder.
 
 ## FAQ
 

--- a/docs/operon-docs/DOCS-116 Reminders.md
+++ b/docs/operon-docs/DOCS-116 Reminders.md
@@ -2,7 +2,7 @@
 Notes: Get notified about a task, either at a fixed moment or at an offset from one of its dates
 Icon: alarm-clock
 Color: "#ca8a04"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-18T18:18:29
 ---
 
 # Reminders
@@ -140,6 +140,8 @@ Operon can play an audio file from your vault when reminders are delivered. Poin
 
 The sound plays **once per batch**, not once per reminder, so three reminders arriving together do not stack three overlapping sounds. Playback stops after ten seconds, so a long file cannot keep going.
 
+The same **Reminder sound** file can also be used by FlowTime, but it is a separate setting. **Play reminder sound when FlowTime reaches zero** is off by default under **Settings → Operon → Tasks → Tracker**. When enabled, it plays this file once when a FlowTime focus session or break reaches zero. It is independent of FlowTime's target-reached notice and does not affect TrackTime. See [[DOCS-035 FlowTime focus sessions|FlowTime focus sessions]].
+
 ## Pinning a task when its reminder arrives
 
 Reminder settings carries one optional automation: **Pin task when its reminder time arrives** adds the task to your [[DOCS-032 Pinned Task Dock|Pinned Task Dock]] as Operon processes its due reminder. It applies to open tasks only and never pins a task twice.
@@ -182,7 +184,7 @@ Both use your real notification and sound settings, and neither creates or opens
 
 ## Settings
 
-Operon settings for this live in **Settings → Operon → Tasks → Reminders**: the missed-reminder catch-up window, how long an in-app notification stays visible, the pin-on-reminder automation, system notifications, the mobile notification snapshot, reminder sound, and the two test notifications.
+Operon settings for this live in **Settings → Operon → Tasks → Reminders**: the missed-reminder catch-up window, how long an in-app notification stays visible, the pin-on-reminder automation, system notifications, the mobile notification snapshot, reminder sound, and the two test notifications. FlowTime's optional completion-sound toggle is separate, under **Settings → Operon → Tasks → Tracker**, but uses this Reminder sound file.
 
 Where reminders are *shown* is configured separately, under **Settings → Operon → Interface**, in **Task Editor** for the editor's picker rows and **Task Chips** for every chip surface. The two fields' property names and icons are set in **Settings → Operon → Core → Keymapping**. See [[DOCS-039 Key mappings|Key mappings]].
 

--- a/docs/operon-docs/DOCS-129 In-process Developer API overview.md
+++ b/docs/operon-docs/DOCS-129 In-process Developer API overview.md
@@ -2,7 +2,7 @@
 Notes: Connect an Obsidian plugin to Operon's typed in-process API and choose it instead of the CLI when appropriate
 Icon: plug-zap
 Color: "#059669"
-Updated: 2026-08-03T10:31:15
+Updated: 2026-08-18T18:18:29
 ---
 
 # In-process Developer API overview
@@ -46,6 +46,33 @@ if (!operon || typeof operon.getDeveloperApiV1 !== "function") {
 ```
 
 The consumer passed to the accessor must be your actual plugin instance. A copied object with the same manifest fields is not accepted as identity proof.
+
+## Task workflow extension
+
+The base `getDeveloperApiV1()` accessor remains frozen. It does not accept task-workflow extension capabilities, and its existing read and mutation examples stay on that base surface. For saved-filter reads and inline-task adoption, use the separate, additive `getTaskWorkflowDeveloperApiV1()` accessor on the same verified Operon plugin instance:
+
+```ts
+interface OperonTaskWorkflowDeveloperApiAccessorV1 {
+  getTaskWorkflowDeveloperApiV1(
+    consumerPlugin: object,
+    request: {
+      contractVersion: 1;
+      runtimeApi: { min: 1; max: 1 };
+      requestedCapabilities: readonly string[];
+    },
+  ): unknown;
+}
+
+const workflowOperon = hostApp.plugins.getPlugin("operon") as
+  | OperonTaskWorkflowDeveloperApiAccessorV1
+  | undefined;
+
+if (!workflowOperon || typeof workflowOperon.getTaskWorkflowDeveloperApiV1 !== "function") {
+  throw new Error("Operon's task-workflow extension is unavailable.");
+}
+```
+
+This extension has its own narrow, capability-projected API. Its exact grants are `tasks.filter-query`, `tasks.adopt.preview`, and `tasks.adopt.apply`; requesting one capability does not expose the others. See [[DOCS-130 Developer API identity and capability grants|Developer API identity and capability grants]] and [[DOCS-131 Developer API reads and typed mutations|Developer API reads and typed mutations]].
 
 ## Open a discovery-only session
 
@@ -96,6 +123,8 @@ The Developer API is desktop-only and local to the current Obsidian process. It 
 **What invalidates a session?** Reloading either plugin, because the instance epoch changes and the retained session becomes stale. Grant changes do too: a grant that is not active, one whose revision moved, or a capability that is no longer granted all close further work. Reacquire the instance and open a new session rather than holding one across a reload.
 
 **Can I use this from mobile, or from outside Obsidian?** No. It is desktop-only and local to the current Obsidian process. It is not a remote API, an HTTP or MCP server, a mobile API, or a sandbox for untrusted plugins. For anything outside the app, use `operon-cli`.
+
+**Why is there a second accessor for task workflows?** It keeps the established Developer API V1 surface unchanged while adding a separately granted extension for saved-filter reads and inline-task adoption. Do not send extension capability names to `getDeveloperApiV1()`; call `getTaskWorkflowDeveloperApiV1()` instead.
 
 ## Related
 

--- a/docs/operon-docs/DOCS-130 Developer API identity and capability grants.md
+++ b/docs/operon-docs/DOCS-130 Developer API identity and capability grants.md
@@ -2,7 +2,7 @@
 Notes: Understand registry-derived plugin identity, exact capability requests, user approval, suspension, and revocation
 Icon: key-round
 Color: "#059669"
-Updated: 2026-07-30T19:55:17
+Updated: 2026-08-18T18:18:29
 ---
 
 # Developer API identity and capability grants
@@ -30,6 +30,30 @@ const access = operon.getDeveloperApiV1(this, {
 The public consumer type contains only `manifest.id`, `manifest.name`, and `manifest.version`, but those strings are metadata. Operon verifies that the object itself is the current instance in Obsidian's enabled plugin registry. A fabricated object, a disabled instance, or an instance left over from a reload is refused.
 
 The persistent consumer identity is the plugin ID. Operon also creates a new instance epoch for each plugin load and a new session ID for each successful connection. Callers cannot supply or override any of these values.
+
+## Task workflow extension grants
+
+Saved-filter reads and inline-task adoption are on the additive `getTaskWorkflowDeveloperApiV1()` accessor, not the frozen base `getDeveloperApiV1()` accessor. Ask that accessor for exactly the task-workflow capabilities your feature needs:
+
+```ts
+const workflowAccess = operon.getTaskWorkflowDeveloperApiV1(this, {
+  contractVersion: 1,
+  runtimeApi: { min: 1, max: 1 },
+  requestedCapabilities: [
+    "tasks.filter-query",
+    "tasks.adopt.preview",
+    "tasks.adopt.apply",
+  ],
+});
+```
+
+| Capability | Allows |
+| --- | --- |
+| `tasks.filter-query` | Evaluate one saved FilterSet against the live task index. |
+| `tasks.adopt.preview` | Preview adoption of one exact inline source line. |
+| `tasks.adopt.apply` | Apply or recover the sealed adoption plan from that preview. |
+
+The capability names, order, and uniqueness are exact. A request for any unsupported name, duplicate, or out-of-order subset is refused. The user reviews the same exact requested set in **Settings → Operon → Core → General → Developer API Integrations**. Base Developer API grants do not imply these extension grants, and extension grants do not widen the base API.
 
 ## Exact capability grants
 
@@ -78,6 +102,8 @@ Developer API access and mutation preview, apply, and recovery inputs must not a
 **What happens to work in flight when a grant is revoked?** The grant revision changes, and sessions and plan handles that have not reached dispatch become invalid at once. A mutation that had already been dispatched keeps its recovery evidence, and only the same registry-verified consumer may continue that one operation. That is a way to finish something uncertain, not a way to start something new.
 
 **Can I supply my own identity, consent, or idempotency values?** No. Those fields belong to Operon, and mutation input containing host-owned fields is rejected as an invalid request rather than being ignored. The one identifier you generate is the `requestId` on Runtime read DTOs, which is a correlation value and not a claim of authority.
+
+**Can I ask `getDeveloperApiV1()` for `tasks.adopt.preview`?** No. The base accessor remains unchanged and rejects task-workflow extension capabilities. Request `tasks.adopt.preview` and `tasks.adopt.apply` through `getTaskWorkflowDeveloperApiV1()` instead.
 
 ## Related
 

--- a/docs/operon-docs/DOCS-131 Developer API reads and typed mutations.md
+++ b/docs/operon-docs/DOCS-131 Developer API reads and typed mutations.md
@@ -2,7 +2,7 @@
 Notes: Use capability-gated reads and the typed preview, apply, receipt, and replay mutation flow
 Icon: code-xml
 Color: "#059669"
-Updated: 2026-07-30T19:55:17
+Updated: 2026-08-18T18:18:29
 ---
 
 # Developer API reads and typed mutations
@@ -44,6 +44,58 @@ if (!result.ok) {
 
 console.log(result.task.description, result.task.locator);
 ```
+
+## Saved-filter reads and inline-task adoption
+
+The task-workflow extension is a separate capability-projected API. Open it with `getTaskWorkflowDeveloperApiV1()` and request only the grants required by the operation:
+
+```ts
+const workflowAccess = operon.getTaskWorkflowDeveloperApiV1(this, {
+  contractVersion: 1,
+  runtimeApi: { min: 1, max: 1 },
+  requestedCapabilities: [
+    "tasks.filter-query",
+    "tasks.adopt.preview",
+    "tasks.adopt.apply",
+  ],
+});
+
+if (!workflowAccess.ok) {
+  console.error(workflowAccess.error.code);
+  return;
+}
+
+const workflow = workflowAccess.api;
+const matches = await workflow.tasks.filterQuery({
+  contractVersion: 1,
+  requestId: crypto.randomUUID(),
+  kind: "task-filter-query",
+  consistency: "live-verified",
+  filterSetId: "active-projects",
+});
+```
+
+To adopt a plain inline checkbox, preview the exact source first. `lineNumber` is **zero-based**, and `expectedLine` is the complete line currently at that path and line. It is a source precondition, not text to search for elsewhere in the file:
+
+```ts
+const preview = await workflow.tasks.adopt.preview({
+  operation: "adopt-inline",
+  source: {
+    filePath: "Projects/Launch.md",
+    lineNumber: 0,
+    expectedLine: "- [ ] Review the launch checklist",
+  },
+});
+
+if (!preview.ok) {
+  console.error(preview.error.code);
+  return;
+}
+
+const execution = await workflow.tasks.adopt.apply({ plan: preview.plan });
+```
+
+Preview produces a session-bound, opaque plan handle. Apply only that unchanged handle: do not clone it, reconstruct it from fields, pass it to another session or consumer, or make a fresh preview as a retry. If the file, line number, or expected line changes before apply, Operon fails closed before writing. A successful replay returns `already-applied` without another source write.
 
 ## Preview a typed mutation
 
@@ -108,6 +160,8 @@ If the result is `partial` or `outcome-unknown`, ordinary apply and replacement 
 **When does `recoveryRef` become useful?** Only after the apply has been durably dispatched. Before that point there is nothing uncertain to recover, so treat the reference as a way back to an operation already in flight rather than as a token you hold from the start.
 
 **An apply failed. Can I preview the same change again?** Not as a retry. A failure is a result, not an invitation to reissue: if dispatch may have occurred, continue with the same plan through recovery. Creating a fresh preview would risk applying the same change twice.
+
+**How do I adopt an inline task at line 1?** Use `lineNumber: 0`; task-workflow source line numbers are zero-based. Supply the complete current line in `expectedLine`, preview it, and apply that preview's unchanged opaque handle.
 
 ## Related
 

--- a/docs/operon-docs/DOCS-132 Developer API recovery, errors and audit.md
+++ b/docs/operon-docs/DOCS-132 Developer API recovery, errors and audit.md
@@ -2,7 +2,7 @@
 Notes: Recover only the same dispatched mutation and interpret Developer API errors, receipts, and redacted audit records
 Icon: shield-alert
 Color: "#059669"
-Updated: 2026-07-30T19:58:24
+Updated: 2026-08-18T18:18:29
 ---
 
 # Developer API recovery, errors and audit
@@ -38,6 +38,35 @@ if (pending.ok) {
 
 The `recoveryRef` is not authority, not a sealed plan, and not the CLI's `planRef`. It is bound to the private plan digest, consumer identity, and host-owned idempotency state.
 
+## Task-workflow adoption recovery
+
+Inline-task adoption uses the same rule through its separate task-workflow accessor: recover the **same** opaque adoption plan, never a replacement preview. In the session that made the preview, keep and pass the original handle:
+
+```ts
+const recovered = await workflow.tasks.adopt.recover({
+  plan: preview.plan,
+});
+```
+
+After Operon or the consumer plugin reloads, the session-bound handle cannot be reused. Reacquire Operon, open a new `getTaskWorkflowDeveloperApiV1()` session with the required adoption grants, then recover with the original plan's `recoveryRef`:
+
+```ts
+const reopened = operon.getTaskWorkflowDeveloperApiV1(this, {
+  contractVersion: 1,
+  runtimeApi: { min: 1, max: 1 },
+  requestedCapabilities: ["tasks.adopt.apply"],
+});
+
+if (reopened.ok) {
+  const recovered = await reopened.api.tasks.adopt.recover({
+    recoveryRef: preview.plan.recoveryRef,
+  });
+  console.log(recovered.status);
+}
+```
+
+`recoveryRef` is only a reference to the original plan's recovery evidence. It is bound to the same registry-verified consumer and cannot authorize a different target, a modified `expectedLine`, or a new adoption. Use `workflow.tasks.adopt.pendingRecoveries()` to list the current consumer's dispatched unresolved adoption operations.
+
 ## When recovery is required
 
 A result with status `partial` or `outcome-unknown` reports:
@@ -49,6 +78,8 @@ A result with status `partial` or `outcome-unknown` reports:
 - recovery metadata for the same plan.
 
 Do not re-preview, call ordinary apply again, change the target, or mint a new idempotency value. Use `recover({ plan })` or `recover({ recoveryRef })` for that exact operation. If recovery still cannot verify the outcome, keep the operation uncertain.
+
+For inline adoption, those calls are `workflow.tasks.adopt.recover({ plan })` or `workflow.tasks.adopt.recover({ recoveryRef })`. Do not switch to a base-API mutation method or create a new adoption preview.
 
 Recovery evidence is retained for 24 hours, up to 256 protected records. Capacity pressure refuses a new dispatch rather than deleting unresolved evidence. An expired reference returns `plan-expired`.
 
@@ -91,6 +122,8 @@ The Developer API intentionally provides no audit-reading method. Audit inspecti
 **Can I read the audit from the API?** No, and that is deliberate. There is no audit-reading method; inspecting and clearing the redacted view are user actions in Operon's settings. Clearing leaves a marker that it happened and never removes protected recovery evidence.
 
 **What happens to my writes if the audit cannot be recorded?** They stop. A write needs its durable redacted record before dispatch, so an unavailable audit store is an environment problem to fix rather than something to retry around. If the audit and receipt cannot be finalized together, the result stays uncertain rather than being reported as success.
+
+**Can I recover an adoption after reload?** Yes, only for the same registry-verified consumer and only with that preview's `recoveryRef`, through a newly opened task-workflow Developer API session. It resumes the same plan; it is not permission to preview or apply a new one.
 
 ## Related
 

--- a/docs/operon-docs/manifest.json
+++ b/docs/operon-docs/manifest.json
@@ -39,8 +39,8 @@
     },
     {
       "path": "DOCS-007 Install and enable Operon.md",
-      "sha256": "46312e06b926945d60e933d1acaa95041bb93e0af70c0e4fec77a90e388fc813",
-      "bytes": 4039
+      "sha256": "6819f60c0040f25ce2eea175bdc19fd84e1983570a4235cde3b7ee2c0ae48375",
+      "bytes": 5104
     },
     {
       "path": "DOCS-008 Essential settings to configure first.md",
@@ -64,8 +64,8 @@
     },
     {
       "path": "DOCS-012 Inline task syntax.md",
-      "sha256": "69ee5cf49f282a681c4f149b9ca1b8c8d98aea6a1c2aa78bc9de493b565fe2e1",
-      "bytes": 13976
+      "sha256": "5c8f0142f676a95556b2117b08fa3cc79c1cf41434d3b9975b29a87e176d222c",
+      "bytes": 15147
     },
     {
       "path": "DOCS-013 File tasks.md",
@@ -109,8 +109,8 @@
     },
     {
       "path": "DOCS-021 Task Editor.md",
-      "sha256": "62b38eabad87d42a5b9c5106a436bc48c63230afe9588d0f9065e4e9c543196b",
-      "bytes": 6437
+      "sha256": "19ea6dada318b869fb0b46eca58d229fe987b3ff96a4c30c9ee79b3cfff8803a",
+      "bytes": 7556
     },
     {
       "path": "DOCS-022 Command palette reference.md",
@@ -179,8 +179,8 @@
     },
     {
       "path": "DOCS-035 FlowTime focus sessions.md",
-      "sha256": "f7fb98818126bcd0927790975a6b78318c82dcd27682921c86f3f14597f04eed",
-      "bytes": 4692
+      "sha256": "3f14f86d6b870ce5b6abdd939ac3b45a0a50241d70e2dcfdfcb312e34cb1403b",
+      "bytes": 5818
     },
     {
       "path": "DOCS-036 Agent-friendly workflows.md",
@@ -234,8 +234,8 @@
     },
     {
       "path": "DOCS-046 Plugin data and state files.md",
-      "sha256": "b30ce270fc13d7efef51df60f1e9ca96f08cbbca9b9f2700b51c00be42e353e8",
-      "bytes": 3130
+      "sha256": "6d0a477cfa4964cdfd91b9a5248d9389e2f872c9524b81e8435b946a230e57f3",
+      "bytes": 3436
     },
     {
       "path": "DOCS-047 Sync conflict safety.md",
@@ -319,8 +319,8 @@
     },
     {
       "path": "DOCS-063 Date and time picker.md",
-      "sha256": "7dba4e3c3770aa702f819b2a6f740a9a3111591f11fcd4e1371508d2332f59ac",
-      "bytes": 5156
+      "sha256": "4266a1d7e3e9ef61db523695e5fa509af2e4821b108f85d74a09cfe52dca817c",
+      "bytes": 6127
     },
     {
       "path": "DOCS-064 Recurrence picker.md",
@@ -529,8 +529,8 @@
     },
     {
       "path": "DOCS-105 Table overview.md",
-      "sha256": "4ca740566bc48991d96a5d3e64f1561850dfa24f12b9b2799e020561604d4ed7",
-      "bytes": 10537
+      "sha256": "12649bda5fdc38ecc7856a1c415851e75e5b1d5cbf3d85498a5aca6eee199458",
+      "bytes": 11224
     },
     {
       "path": "DOCS-106 Table columns.md",
@@ -549,13 +549,13 @@
     },
     {
       "path": "DOCS-109 Table presets.md",
-      "sha256": "540c96307c3008bb9b2c0ea5313f16a3a8d74ac062cbe00c9b14097aea715ca3",
-      "bytes": 8123
+      "sha256": "b2e5d53edf2b0c86db97f9c098e6ba49d235c02825d7b2f83e65cca011c0c546",
+      "bytes": 8634
     },
     {
       "path": "DOCS-110 Embed a table in a note.md",
-      "sha256": "85ff3bade81c6ea17feafc0ea25d2e44c739c493087f27fc06c3c159e54503bb",
-      "bytes": 8046
+      "sha256": "6b4d60ed61ccf0490cd7ab4048fbdcd379e0606ad9cb9b0168ff443902e202d9",
+      "bytes": 9309
     },
     {
       "path": "DOCS-111 Export a table.md",
@@ -564,18 +564,18 @@
     },
     {
       "path": "DOCS-112 Table cells display and behavior.md",
-      "sha256": "425252c4b2260b0f23c5a679353e6cc3632665f5b7db646ca1ba4b9079a451c2",
-      "bytes": 12246
+      "sha256": "3399d8a54e931570d727a1fdacb62ec8cd730e99b47134b85b351b7c2fd177b8",
+      "bytes": 12376
     },
     {
       "path": "DOCS-113 Text field editor popover.md",
-      "sha256": "eb30eff37fcab9920a277cb2fbc6b064ef0ba13c23e295a677aa7e2250c61cd5",
-      "bytes": 4118
+      "sha256": "686e318575c486ebb6c03d6d2226b38eefff7cb1a815c5da1b6e41b593ee2348",
+      "bytes": 4516
     },
     {
       "path": "DOCS-114 Table files.md",
-      "sha256": "48db95e3b8322887785418f4287e666366ae7a44e1e8313827d9a6bb0f52fe98",
-      "bytes": 10981
+      "sha256": "b74316e67809b26850f27a8ec36ed907274bc6fd329ee0cdc93065d27942a7f3",
+      "bytes": 11477
     },
     {
       "path": "DOCS-115 File task property columns.md",
@@ -584,8 +584,8 @@
     },
     {
       "path": "DOCS-116 Reminders.md",
-      "sha256": "75c757a4adad5d99fbf3890adabf96ff48ba27d5b8f5a3d53d9be8032acff493",
-      "bytes": 16369
+      "sha256": "458cd42e2dc95fe79e39c45c8cff6bb323458a009ae9ed267ca76db799bf84d4",
+      "bytes": 16972
     },
     {
       "path": "DOCS-117 Reminder rules.md",
@@ -649,23 +649,23 @@
     },
     {
       "path": "DOCS-129 In-process Developer API overview.md",
-      "sha256": "cdf2ea3a8da1173c02b02541155ef758ced2accb9dd8b5bc26eccb2202471872",
-      "bytes": 6681
+      "sha256": "0d5c6e2787e62cfed7cf5d79eb9a05248d378bcf16d5d8f61686b93a8844e1ed",
+      "bytes": 8357
     },
     {
       "path": "DOCS-130 Developer API identity and capability grants.md",
-      "sha256": "82124d4e158c33ca6c5c99f0271d22a499f63b5a79b22c4ff9a6e00eed92b467",
-      "bytes": 6592
+      "sha256": "6377128a276937c3b5655cca2e102c2bd65f93fad59f8552a60763a27774d2e1",
+      "bytes": 8041
     },
     {
       "path": "DOCS-131 Developer API reads and typed mutations.md",
-      "sha256": "86881537c30657c268b0b53c3b79bad02a72c12338c60971698402e9e11a3410",
-      "bytes": 6360
+      "sha256": "4fef69bd51829805cc0b2782806790a29b245b4505e2e63389dfdb5772d821d9",
+      "bytes": 8390
     },
     {
       "path": "DOCS-132 Developer API recovery, errors and audit.md",
-      "sha256": "a9ec89ff2bba962fa84c8a3f48f9447437863fda60fcd28eb161e9f2ee16d214",
-      "bytes": 6427
+      "sha256": "f1200cc488541c13c1ae1e6ed3b1dfcf53f4e7c93d891ad4e9f6265217e51136",
+      "bytes": 8202
     },
     {
       "path": "DOCS-133 JSONL sessions for scripts and agents.md",
@@ -683,5 +683,5 @@
       "bytes": 6058
     }
   ],
-  "generatedAt": "2026-08-15T08:58:44.665Z"
+  "generatedAt": "2026-08-18T16:46:22.632Z"
 }


### PR DESCRIPTION
## Summary

- publish 17 updated canonical Operon documentation pages
- document Table defaults and embedded width behavior, multiline task notes, FlowTime completion sound, Brazilian Portuguese localization and Date-NLP, and Task Adoption Developer API workflows
- refresh the generated docs manifest without changing product code or media

## Impact

This updates only `docs/operon-docs/**`. No plugin code, release metadata, changelog, locale source, or media asset is included.

## Validation

- Operon docs sync runtime tests passed
- generated package/source parity tests passed (3/3)
- docs/media scope guard passed with zero blocked files
- `git diff --check -- docs/operon-docs docs/media` passed
- all 110 existing media files were byte-identical; none were copied or removed