### PR TITLE
Update Operon docs package

### DIFF
--- a/docs/operon-docs/DOCS-001 Operon Docs MOC.md
+++ b/docs/operon-docs/DOCS-001 Operon Docs MOC.md
@@ -2,7 +2,7 @@
 Notes: Root index and reading path for the Operon documentation
 Icon: book-open
 Color: "#334155"
-Updated: 2026-08-12T17:21:45
+Updated: 2026-08-21T16:12:57
 ---
 
 # Operon Docs
@@ -65,6 +65,7 @@ Follow these in order. They are enough to go from "what is this?" to doing real 
 - [[DOCS-097 Project serials|Project serials]]
 - [[DOCS-017 Plain checkbox lists|Plain checkbox lists]]
 - [[DOCS-018 Task properties|Task properties]]
+- [[DOCS-138 Task images and galleries|Task images and galleries]]
 - [[DOCS-019 Converting inline and file tasks|Converting inline and file tasks]]
 - [[DOCS-058 Operon inheritance rules|Operon inheritance rules]]
 
@@ -138,6 +139,7 @@ Follow these in order. They are enough to go from "what is this?" to doing real 
 - [[DOCS-036 Agent-friendly workflows|Agent-friendly workflows]]
 
 ### Settings and customization
+- [[DOCS-136 Task Router|Task Router]]
 - [[DOCS-037 Pipelines and statuses|Pipelines and statuses]]
 - [[DOCS-038 Task priorities|Task priorities]]
 - [[DOCS-039 Key mappings|Key mappings]]
@@ -163,6 +165,7 @@ Follow these in order. They are enough to go from "what is this?" to doing real 
 - [[DOCS-049 Obsidian Tasks migration|Obsidian Tasks migration]]
 - [[DOCS-082 Bulk convert a folder into file tasks|Bulk convert a folder into file tasks]]
 - [[DOCS-050 Daily Notes workflows|Daily Notes workflows]]
+- [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]]
 - [[DOCS-051 Templater and QuickAdd workflows|Templater and QuickAdd workflows]]
 
 ### Agent Runtime and CLI

--- a/docs/operon-docs/DOCS-008 Essential settings to configure first.md
+++ b/docs/operon-docs/DOCS-008 Essential settings to configure first.md
@@ -2,7 +2,7 @@
 Notes: The few settings to set before real use
 Icon: sliders-horizontal
 Color: "#16a34a"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-21T16:12:57
 ---
 
 # Essential settings to configure first
@@ -15,7 +15,7 @@ You do not need to configure everything before using Operon. But five settings s
 
 ## 1. Where inline tasks are written
 
-Under the **Tasks** settings, decide where a new inline task goes when there is no obvious target. If you use Daily Notes, you can capture into the daily note. If you do not, choose a fixed target file. This is the difference between quick capture landing somewhere sensible and tasks scattering unpredictably.
+Open **Tasks → Task Router** and decide where a new inline task goes when there is no obvious target. Choose Daily Notes, Weekly Notes, a specific file, the active file, or Ask Every Time. This is the difference between quick capture landing somewhere sensible and tasks scattering unpredictably. See [[DOCS-136 Task Router|Task Router]].
 
 > **MEDIA-DOCS-008-2:** The Tasks settings where the inline-task capture target is chosen.
 
@@ -23,7 +23,7 @@ Under the **Tasks** settings, decide where a new inline task goes when there is 
 
 ## 2. Where file tasks are created
 
-Still under **Tasks**, check the file-task location rules. A file task is a real Markdown note, so its folder matters for how your vault stays organized. Decide this before you create file tasks, not after.
+In the same Task Router page, check the File Task default folder, pipeline-specific folders, parent-aware placement, and archive destinations. A File Task is a real Markdown note, so its working and terminal folders matter for how your vault stays organized. Decide the basic rules before you create many File Tasks.
 
 ## 3. Your pipeline and statuses
 
@@ -59,3 +59,5 @@ With the basics in place, make something. See [[DOCS-009 Create your first task|
 
 - [[DOCS-001 Operon Docs MOC|Operon Docs MOC]]
 - [[DOCS-007 Install and enable Operon|Install and enable Operon]]
+- [[DOCS-136 Task Router|Task Router]]
+- [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]]

--- a/docs/operon-docs/DOCS-011 Inline tasks.md
+++ b/docs/operon-docs/DOCS-011 Inline tasks.md
@@ -2,7 +2,7 @@
 Notes: Tasks written on a single Markdown line
 Icon: list-checks
 Color: "#7c3aed"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-21T16:12:57
 ---
 
 # Inline tasks
@@ -56,10 +56,11 @@ And do not treat the metadata as decorative. It is visible because the task live
 
 ## Settings
 
-Operon settings for this live in **Settings → Operon → Tasks → Inline Tasks**, which configures how inline tasks are created, displayed, and auto-parented.
+Choose the default inline destination and parent-aware placement under **Settings → Operon → Tasks → Task Router**. Daily-note field defaults and conversion controls remain under **Tasks → Inline Tasks**. See [[DOCS-136 Task Router|Task Router]].
 
 ## Related
 
 - [[DOCS-001 Operon Docs MOC|Operon Docs MOC]]
 - [[DOCS-005 Operon core concepts|Operon core concepts]]
 - [[DOCS-014 Inline vs file tasks|Inline vs file tasks]]
+- [[DOCS-136 Task Router|Task Router]]

--- a/docs/operon-docs/DOCS-012 Inline task syntax.md
+++ b/docs/operon-docs/DOCS-012 Inline task syntax.md
@@ -2,7 +2,7 @@
 Notes: Complete reference for inline task field syntax and property types, with copy-paste ready examples
 Icon: braces
 Color: "#7c3aed"
-Updated: 2026-08-18T18:18:29
+Updated: 2026-08-21T16:12:57
 ---
 
 # Inline task syntax
@@ -78,8 +78,11 @@ These are the fields you choose and edit, directly or through the Task Creator a
 | `parentTask` | Text | The `operonId` of the parent task. See [[DOCS-016 Parent and sub-tasks\|Parent and sub-tasks]]. | `xyz9876` |
 | `assignees` | List | Who does the work. | `[[Me]]` |
 | `contexts` | List | Environment or condition. | `[[Home]]` |
+| `taskType` | Text | Your own classification for the task. | `Milestone` |
 | `taskIcon` | Text | Icon name (Lucide). | `flag` |
 | `taskColor` | Text | Hex color, without the `#`. | `4987a7` |
+| `taskImage` | Text | One task media reference. See [[DOCS-138 Task images and galleries\|Task images and galleries]]. | `Assets/cover.png` |
+| `taskGallery` | List | Ordered task media references. See [[DOCS-138 Task images and galleries\|Task images and galleries]]. | `Assets/front.png; Assets/back.png` |
 | `note` | Text | An annotation that can contain multiple lines. | `waiting on review` |
 | `location` | Text | Coordinates as latitude, longitude. See [[DOCS-041 Task chips display and behavior\|Task chips]]. | `52.52, 13.40` |
 | `links` | List | External web links. | `https://example.com` |
@@ -198,6 +201,8 @@ The safest way to produce correct syntax is to let Operon do it: create with the
 A quick rule of thumb for what is safe to touch by hand:
 
 - **Safe to edit directly:** the readable text, `#tags`, and simple values such as `status`, `priority`, `dateDue`, `dateScheduled`, and `note`.
+- **Task Gallery:** keep its semicolon order and escape a literal semicolon as `\;`; using the pickers is safer for complex paths.
+- **Not a writable field:** `__taskDataType` is a Table-only inline/file helper and must not be added to task Markdown.
 - **Let the Task Editor handle:** `operonId`, `parentTask`, `blocking` and `blockedBy`, `repeat`, and every field in the *Fields Operon manages for you* table above. These carry identity, task links, recurrence, and bookkeeping that has to stay consistent across the whole vault.
 
 ## Related

--- a/docs/operon-docs/DOCS-013 File tasks.md
+++ b/docs/operon-docs/DOCS-013 File tasks.md
@@ -2,7 +2,7 @@
 Notes: Notes whose frontmatter makes the file itself a task
 Icon: file-text
 Color: "#7c3aed"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-21T16:12:57
 ---
 
 # File tasks
@@ -37,7 +37,7 @@ Use a file task when the task is becoming a small document. A release plan may n
 
 ## Create one
 
-Run **Create file task** from the command palette. Give it a title and the fields that matter, and Operon creates a Markdown note in your configured file-task location.
+Run **Create file task** from the command palette. Give it a title and the fields that matter, and Operon creates a Markdown note in the matching pipeline folder, parent-aware folder, or default File Task location according to [[DOCS-136 Task Router|Task Router]].
 
 If file tasks are your normal way to capture work, you can also make [[DOCS-020 Task Creator|Task Creator]] start there. Turn on **Default to File Task in Task Creator** in **Settings → Operon → Tasks → File Tasks → New File Task Creation Defaults**. Pair it with **Default file task template** if you want your usual template preselected whenever Task Creator opens in File mode.
 
@@ -104,11 +104,14 @@ File tasks shine for recurring work with a stable structure: a weekly review, a 
 
 ## Settings
 
+File Task creation defaults, templates, Daily and Weekly Notes, conversion, and exclusions live under **Settings → Operon → Tasks → File Tasks**. Working folders, parent-aware placement, and archive destinations live under **Tasks → Task Router**.
+
 Operon settings for this live in **Settings → Operon → Tasks → File Tasks**, which configures how file tasks behave. Use **New File Task Creation Defaults** there when you want Task Creator to default to File mode and preselect a file-task template.
 
 ## Related
 
 - [[DOCS-001 Operon Docs MOC|Operon Docs MOC]]
+- [[DOCS-136 Task Router|Task Router]]
 - [[DOCS-005 Operon core concepts|Operon core concepts]]
 - [[DOCS-011 Inline tasks|Inline tasks]]
 - [[DOCS-014 Inline vs file tasks|Inline vs file tasks]]

--- a/docs/operon-docs/DOCS-018 Task properties.md
+++ b/docs/operon-docs/DOCS-018 Task properties.md
@@ -2,7 +2,7 @@
 Notes: What a task property is, the four traits every property has, and the same fields shown both ways
 Icon: table-properties
 Color: "#7c3aed"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-21T16:12:57
 ---
 
 # Task properties
@@ -24,6 +24,10 @@ Properties come from two places:
 
 - **System properties** are built in. They cover the whole task model: identity, status, priority, dates, scheduling, parent and dependency links, recurrence, time tracking, and the automatic rollup counts. You use and rename them, but you do not create or delete them.
 - **Custom properties** are ones you define when the built-in set is not enough. A custom property is a real canonical key with its own type and behavior, not just a loose YAML field. See [[DOCS-040 Custom keys|Custom keys]].
+
+Three built-in user-managed properties describe the task rather than its lifecycle: **Task Type** is a free Text classification, **Task Image** is one Text media reference, and **Task Gallery** is an ordered List of media references. Task Type might hold values such as `Milestone`, `Bug`, or `Meeting`; Operon does not impose an enum. See [[DOCS-138 Task images and galleries|Task images and galleries]] for the visual fields.
+
+Do not confuse user-managed **Task Type** with **Task Data Type**. Task Data Type is a read-only Table helper that reports whether the task is inline or file; it is not a property you write to Markdown.
 
 A third case sits outside this model entirely: a frontmatter property on a file task that is neither of the above, no canonical key, no sync policy. Operon still discovers it and offers it as a typed Table column or filter condition, but only there; it has none of the four traits above, and none of the Task Editor, Task Creator, chip, or swimlane reach a real property gets. See [[DOCS-115 File task property columns|File task property columns]].
 
@@ -68,3 +72,4 @@ Operon settings for this live in two places under **Settings → Operon → Core
 - [[DOCS-001 Operon Docs MOC|Operon Docs MOC]]
 - [[DOCS-115 File task property columns|File task property columns]]
 - [[DOCS-116 Reminders|Reminders]]
+- [[DOCS-138 Task images and galleries|Task images and galleries]]

--- a/docs/operon-docs/DOCS-019 Converting inline and file tasks.md
+++ b/docs/operon-docs/DOCS-019 Converting inline and file tasks.md
@@ -2,7 +2,7 @@
 Notes: Promote an inline task to a file, or collapse a file task back to a line
 Icon: refresh-cw
 Color: "#7c3aed"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-21T16:12:57
 ---
 
 # Converting inline and file tasks
@@ -22,6 +22,8 @@ You can also start a file task straight from a plain line with **Create file tas
 ## Bulk convert many notes at once
 
 Converting one note at a time is not the only path. **Convert notes**, in **Settings → Operon → Tasks → File Tasks**, adopts many existing notes as file tasks in a single pass, matched by a folder, tag, or frontmatter rule. See [[DOCS-082 Bulk convert a folder into file tasks|Bulk convert a folder into file tasks]].
+
+Converted notes normally stay where they are. If **Move converted notes to pipeline location** is enabled in Task Router, an eligible converted note moves after about five seconds to its matching pipeline folder, or to the default File Task folder when no pipeline rule matches. Conversion establishes the task; routing decides its later file location. See [[DOCS-136 Task Router|Task Router]].
 
 ## Collapse a file task back to inline
 
@@ -61,3 +63,4 @@ Use it when you want to keep the Markdown content but stop managing the task in 
 - [[DOCS-022 Command palette reference|Command palette reference]]
 - [[DOCS-087 Edit or convert to file task|Edit or convert to file task]]
 - [[DOCS-082 Bulk convert a folder into file tasks|Bulk convert a folder into file tasks]]
+- [[DOCS-136 Task Router|Task Router]]

--- a/docs/operon-docs/DOCS-020 Task Creator.md
+++ b/docs/operon-docs/DOCS-020 Task Creator.md
@@ -2,7 +2,7 @@
 Notes: The dialog for creating new tasks
 Icon: square-pen
 Color: "#ea580c"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-21T16:12:57
 ---
 
 # Task Creator
@@ -33,6 +33,8 @@ Give the task a clear title, then choose its shape:
 - **File task** if the work needs its own Markdown file and a body. See [[DOCS-013 File tasks|File tasks]].
 
 From there you can set the fields that matter. For a first task, a title, status, priority, and maybe a date are plenty. Contexts, assignees, recurrence, parent links, icons, and colors can wait. The field names follow the canonical set described in [[DOCS-012 Inline task syntax|Inline task syntax]].
+
+Task Type, Task Image, and Task Gallery use the shared task-data picker. Task Type stores one classification, Task Image stores one media reference, and Task Gallery keeps several references in order. See [[DOCS-018 Task properties|Task properties]] and [[DOCS-138 Task images and galleries|Task images and galleries]].
 
 ## Setting reminders while you create
 
@@ -79,3 +81,4 @@ Open the new task in the [[DOCS-021 Task Editor|Task Editor]] to see its structu
 - [[DOCS-009 Create your first task|Create your first task]]
 - [[DOCS-022 Command palette reference|Command palette reference]]
 - [[DOCS-116 Reminders|Reminders]]
+- [[DOCS-138 Task images and galleries|Task images and galleries]]

--- a/docs/operon-docs/DOCS-021 Task Editor.md
+++ b/docs/operon-docs/DOCS-021 Task Editor.md
@@ -2,7 +2,7 @@
 Notes: The dialog for editing every task field
 Icon: square-pen
 Color: "#ea580c"
-Updated: 2026-08-18T18:18:29
+Updated: 2026-08-21T16:12:57
 ---
 
 # Task Editor
@@ -37,6 +37,8 @@ The Task Editor exposes the canonical fields as proper controls:
 - Pinning. See [[DOCS-032 Pinned Task Dock|Pinned Task Dock]].
 - Time tracking, including session history. See [[DOCS-034 Time tracking|Time tracking]].
 - Icon, color, and a Note that can contain multiple lines.
+- Task Type as a user-managed Text classification.
+- Task Image as one media reference and Task Gallery as an ordered list. See [[DOCS-138 Task images and galleries|Task images and galleries]].
 
 For a file task, the editor can also show the Markdown body alongside the fields, so you edit the work and its metadata together. For an inline task, it can reveal the source note when you need the surrounding context. It can also **Show checkboxes** for the task's [[DOCS-017 Plain checkbox lists|plain checklist]].
 
@@ -103,3 +105,4 @@ Operon settings for this live in **Settings → Operon → Interface → Task Ed
 - [[DOCS-116 Reminders|Reminders]]
 - [[DOCS-016 Parent and sub-tasks|Parent and sub-tasks]]
 - [[DOCS-059 Dynamic Subtasks Filter|Dynamic Subtasks Filter]]
+- [[DOCS-138 Task images and galleries|Task images and galleries]]

--- a/docs/operon-docs/DOCS-024 Task templates.md
+++ b/docs/operon-docs/DOCS-024 Task templates.md
@@ -2,7 +2,7 @@
 Notes: Start file tasks from a reusable body and frontmatter
 Icon: file-code
 Color: "#ea580c"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-21T16:12:57
 ---
 
 # Task templates
@@ -36,6 +36,8 @@ This is separate from the alphabetic fallback above. The fallback is for convers
 ## Templater support
 
 Templates can contain Templater syntax. If the [Templater](https://github.com/SilentVoid13/Templater) plugin is installed, Operon processes that syntax when it builds the task, so a template can insert dates, prompts, and other dynamic content. If Templater is not available but a template uses its syntax, Operon tells you rather than writing raw syntax into your note. For the wider pattern of dynamic templates, see [[DOCS-051 Templater and QuickAdd workflows|Templater and QuickAdd workflows]].
+
+Daily and Weekly Note templates are configured separately from this File Task template folder. Their Runtime/CLI route must stay deterministic and write-free during preview, so a periodic template containing Templater `<% ... %>` expressions is refused on that route rather than executed. See [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]].
 
 ## Three variable systems
 
@@ -92,3 +94,4 @@ Operon settings for this live in **Settings → Operon → Tasks → File Tasks*
 - [[DOCS-001 Operon Docs MOC|Operon Docs MOC]]
 - [[DOCS-020 Task Creator|Task Creator]]
 - [[DOCS-037 Pipelines and statuses|Pipelines and statuses]]
+- [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]]

--- a/docs/operon-docs/DOCS-030 Kanban overview.md
+++ b/docs/operon-docs/DOCS-030 Kanban overview.md
@@ -2,7 +2,7 @@
 Notes: Move tasks through status columns on the Kanban
 Icon: columns-3
 Color: "#0284c7"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-21T16:12:57
 ---
 
 # Kanban overview
@@ -38,6 +38,10 @@ If a task has a Project Serial, the serial appears first as a display-only ident
 Kanban also has a **Kanban Task Actions** section at the end of the same settings page. Those controls can add compact action chips at the trailing edge of the card chip row, such as Play, Pin, Note, Add subtask, and Open checkboxes. On desktop, enabled action chips are usable from the card. The Play action changes to Stop when that task's timer is already running. On mobile, the same card chip area stays visible but read-only, so card tap, scroll, and drag gestures stay predictable.
 
 Main cards can grow a little when chips wrap onto multiple lines; descendant preview cards stay compact and do not show chip rows.
+
+## Card images
+
+Each Kanban preset can show no card image, the task's single **Task Image**, the first **Task Gallery** item, or the last gallery item. Choosing a source changes only the card presentation; it does not rewrite or reorder the task's media fields. Empty or unresolved references leave the card without an image from that source. See [[DOCS-138 Task images and galleries|Task images and galleries]].
 
 > **MEDIA-DOCS-030-3:** Kanban cards in action, with task chips, trailing action chips, an active timer shown as Stop, and the active column and swimlane highlighted.
 
@@ -122,3 +126,4 @@ Operon settings for the board live in **Settings → Operon → Views → Kanban
 - [[DOCS-001 Operon Docs MOC|Operon Docs MOC]]
 - [[DOCS-105 Table overview|Table overview]]
 - [[DOCS-025 Filter View|Filter View]]
+- [[DOCS-138 Task images and galleries|Task images and galleries]]

--- a/docs/operon-docs/DOCS-037 Pipelines and statuses.md
+++ b/docs/operon-docs/DOCS-037 Pipelines and statuses.md
@@ -2,7 +2,7 @@
 Notes: Define the workflow stages a task moves through, and the status grid that configures each
 Icon: workflow
 Color: "#ca8a04"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-21T16:12:57
 ---
 
 # Pipelines and statuses
@@ -83,6 +83,10 @@ Both fire only once, on the first transition from empty to set, so they nudge a 
 
 A pipeline can carry an optional **description**: a short note on when this workflow should be used. It is never required, and you already know what your own pipeline is for. Writing it down still pays off twice. It makes the intent explicit for anyone reading the vault later, and it gives an agent working in your vault the shared context to pick the right pipeline and act the way you would, rather than guessing from the name alone. The default Project pipeline ships with such a description, and you can edit it or add one to any pipeline you create.
 
+## Pipeline folders
+
+Task Router can map each pipeline to a working File Task folder and a separate terminal archive folder. A matching pipeline working folder overrides parent-aware placement and the general File Task folder; a matching pipeline archive overrides the fallback archive. These location rules do not change the task's pipeline or identity. See [[DOCS-136 Task Router|Task Router]].
+
 ## FAQ
 
 **Where do Kanban columns come from?** From the statuses of the pipeline the board shows, in their defined order.
@@ -101,3 +105,4 @@ Operon settings for this live in **Settings → Operon → Core → Pipelines**,
 - [[DOCS-008 Essential settings to configure first|Essential settings to configure first]]
 - [[DOCS-034 Time tracking|Time tracking]]
 - [[DOCS-107 Table grouping and sorting|Table grouping and sorting]]
+- [[DOCS-136 Task Router|Task Router]]

--- a/docs/operon-docs/DOCS-041 Task chips display and behavior.md
+++ b/docs/operon-docs/DOCS-041 Task chips display and behavior.md
@@ -2,7 +2,7 @@
 Notes: The compact field badges on tasks, their per-surface order and visibility, and how each behaves on click and hover
 Icon: tags
 Color: "#ca8a04"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-21T16:12:57
 ---
 
 # Task chips: display and behavior
@@ -26,6 +26,8 @@ Chips cover the fields you most often want at a glance:
 - **Reminders**, one chip per reminder, from either reminder field. See [[DOCS-116 Reminders|Reminders]].
 - **Location**, shown as a small map chip.
 - **Tags** and external **Links**.
+- **Task Type**, a user-managed task classification.
+- **Task Image** and **Task Gallery**, as one or several media-reference chips. See [[DOCS-138 Task images and galleries|Task images and galleries]].
 
 Your own [[DOCS-040 Custom keys|custom keys]] can appear as chips too, when you turn on "Show in chips" for them, so the row can carry exactly the fields your workflow cares about.
 
@@ -158,3 +160,4 @@ Chip configuration lives in **Settings → Operon → Interface → Task Chips**
 - [[DOCS-068 Location picker|Location picker]]
 - [[DOCS-040 Custom keys|Custom keys]]
 - [[DOCS-116 Reminders|Reminders]]
+- [[DOCS-138 Task images and galleries|Task images and galleries]]

--- a/docs/operon-docs/DOCS-046 Plugin data and state files.md
+++ b/docs/operon-docs/DOCS-046 Plugin data and state files.md
@@ -2,7 +2,7 @@
 Notes: Where Operon keeps its settings, working state, and rebuildable index
 Icon: folder-cog
 Color: "#0891b2"
-Updated: 2026-08-18T18:18:29
+Updated: 2026-08-21T16:12:57
 ---
 
 # Plugin data and state files
@@ -17,11 +17,13 @@ The plugin's main data file holds your Operon configuration: [[DOCS-039 Key mapp
 
 Alongside it, Operon keeps working state and caches in subfolders:
 
-- **State**: things Operon tracks that are not settings, such as recurring-series records, running timers, pinned tasks, and project serials.
+- **State**: things Operon tracks that are not settings, such as recurring-series records, running timers, pinned tasks, project serials, and verified Daily/Weekly File Task container identities.
 - **Runtime**: the task index, a cache built from your notes for speed.
 - **Cache**: derived data such as fetched external-calendar events.
 
 The split is deliberate: settings are your choices, state is what Operon is currently tracking, and the runtime index is rebuildable from your notes at any time.
+
+The periodic-container registry is Plugin-owned bookkeeping. It lets Operon prove which Daily or Weekly Note is an exact File Task parent before creating or realigning a relationship. Do not edit it manually or reproduce it in CLI scripts; the Plugin updates it together with the related Markdown transaction. See [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]].
 
 Operon saves this index as a set of verified, sharded snapshots rather than one large file, so it loads quickly on startup and writes back only the parts that changed, which keeps routine Sync traffic small. Because the snapshot is never more than a cache, Operon can rebuild it from your Markdown at any time, and it does so automatically if the snapshot is missing or fails one of its own checks.
 
@@ -42,3 +44,4 @@ None of your tasks live in these files. They are in your Markdown notes. If thes
 - [[DOCS-001 Operon Docs MOC|Operon Docs MOC]]
 - [[DOCS-045 Markdown task storage|Markdown task storage]]
 - [[DOCS-114 Table files|Table files]]
+- [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]]

--- a/docs/operon-docs/DOCS-050 Daily Notes workflows.md
+++ b/docs/operon-docs/DOCS-050 Daily Notes workflows.md
@@ -1,64 +1,76 @@
 ---
-Notes: Capture inline tasks into your daily note, dated automatically
+Notes: Capture inline tasks into Daily Notes and inherit dates from their note
 Icon: calendar-check
 Color: "#059669"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-21T16:12:57
 ---
 
 # Daily Notes workflows
 
-If you work out of a daily note, that is often where a task first occurs to you. Operon can send new inline tasks straight to today's daily note, so capture lands where you are already writing. This uses Obsidian's **Daily Notes** core plugin, so it needs that plugin enabled.
+If you work out of a Daily Note, that is often where a task first occurs to you. Operon can route new inline tasks into that note and use its date as a default for task fields. Daily Notes may be managed directly by Operon or resolved through Obsidian's Core Daily Notes configuration.
+
+This page focuses on the daily capture habit and date defaults. For Daily and Weekly formats, templates, folders, container behavior, and Runtime/CLI routing, see [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]].
 
 ## Capture into today's note
 
-Turn on **Save new inline tasks to today's daily note** in settings, and the new-task flow writes inline tasks into the current daily note instead of a fixed file. Quick capture then follows your daily rhythm: open today's note, make a task, and it stays in context. This is one of the two capture targets for inline tasks; the other is a fixed file. See [[DOCS-008 Essential settings to configure first|Essential settings to configure first]].
+Choose **Daily Notes** as the inline destination under **Settings → Operon → Tasks → Task Router**. A normal new inline task then routes to today's Daily Note instead of a fixed file. If Operon manages Daily Notes, it uses Operon's configured format and folder. Otherwise it falls back to the Core Daily Notes configuration when that plugin is available.
+
+The Daily destination is one of five Task Router choices, alongside Weekly Notes, a specific file, the active file, and Ask Every Time. See [[DOCS-136 Task Router|Task Router]].
 
 ## Dates from the note's date
 
-A daily note already stands for a date, and Operon can use it. For inline tasks created in a daily note, it can fill in dates from the note's own date when the task does not already have them:
+A Daily Note already represents a date, and Operon can use it. For inline tasks created there, Daily Note Defaults can fill fields that the task does not already have:
 
-- **Start date** from the daily note's date.
-- **Scheduled date** from the daily note's date.
+- **Start date** from the Daily Note's date.
+- **Scheduled date** from the Daily Note's date.
 
-Each is optional. With them on, a task captured in a given day's note is dated to that day without you typing the date, which is handy for "do this today" capture that should land on the Calendar.
+Each toggle is independent. Existing values win, so the defaults never replace a date you selected deliberately.
 
-## Which date formats work
+## Which filename formats work
 
-Operon does not define its own daily-note naming scheme. It reads the file-name date format straight from the core Daily Notes plugin's own **Date format** setting, so whatever you pick there is what Operon recognizes. That means every option the core plugin offers works, including its ready-made choices such as `YYYY-MM-DD`, `YYYY.MM.DD`, and `YYYY/MM/DD`, as well as **Custom**, where you write your own moment.js pattern. If no format is set, Operon falls back to `YYYY-MM-DD`, the same default the core plugin uses.
+With **Manage Daily Notes with Operon** enabled, Operon's Moment-style Daily format controls the note path and shows a live path preview in settings. The default is `YYYY-MM-DD`; folder-producing formats such as `YYYY/MM/YYYY-MM-DD` are supported when they resolve to a safe vault-relative path.
 
-One thing stays fixed no matter which naming format you choose: the dates Operon writes into a task, such as `dateScheduled`, are always stored as `YYYY-MM-DD`. The file-name format only controls how the note is named and found; it does not change how dates are stored on the task itself. See [[DOCS-012 Inline task syntax|Inline task syntax]] for the stored field formats.
+With Operon management disabled, the Core Daily Notes **Date format** supplies the filename format. If that format is unavailable, Operon uses `YYYY-MM-DD` as the fallback.
 
-## Calendar-created Daily Note templates
+Task date fields stay in `YYYY-MM-DD` form regardless of the note filename. A filename format changes where the note lives, not how `dateScheduled` or `dateStarted` is stored. See [[DOCS-012 Inline task syntax|Inline task syntax]].
 
-When Operon Calendar creates a missing Daily Note, it can resolve the familiar `{{title}}`, `{{date}}`, and `{{time}}` template variables in that new note. `{{title}}` becomes the created note's filename, while `{{date}}` and `{{time}}` use the local creation moment and follow the Core Templates plugin's **Date format** and **Time format** settings. Explicit forms such as `{{date:YYYY-MM-DD}}` and `{{time:HH:mm}}` use the format written in the template.
+## Templates and missing notes
 
-These are different settings from **Daily Notes → Date format**, which only determines the Daily Note filename. A Calendar-created note for a future or past day still gives `{{date}}` the creation date, not the selected Calendar day. Existing Daily Notes are opened as they are; their template is never run again.
+An Operon-managed missing Daily Note can start from its configured Daily template. Compatible `{{title}}`, `{{date}}`, and `{{time}}` variables are resolved when the note is created; an existing note is left as it is and its template is not run again.
 
-This is template creation behavior, not the Daily Note Defaults that fill task start or scheduled dates. For the complete variable reference and File Task differences, see [[DOCS-061 operonId template variables|Template variables]].
+The optional **Create Daily Notes as Operon Tasks** setting makes a newly created Daily Note a minimal File Task container and parents the inline task placed inside it. An existing plain Markdown Daily Note is never adopted automatically: Operon appends the task without assigning the note as its periodic parent. See [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]] for the complete matrix.
 
 ## A simple daily flow
 
-- Open today's daily note.
-- Capture tasks as they come up; they save into the note.
-- Let the note's date fill scheduled or start dates, so today's tasks show on today.
-- Review them in a [[DOCS-025 Filter View|Filter View]] or the [[DOCS-028 Calendar overview|Calendar]] when you plan.
+- Choose Daily Notes in Task Router.
+- Decide whether Operon or Core Daily Notes owns the path configuration.
+- Capture tasks as they come up.
+- Let the Daily Note Defaults fill start or scheduled dates when useful.
+- Review the tasks in a [[DOCS-025 Filter View|Filter View]] or the [[DOCS-028 Calendar overview|Calendar]].
 
 ## FAQ
 
-**Do I need the Daily Notes plugin?** Yes. This workflow uses Obsidian's Daily Notes core plugin, so enable it first.
+**Do I need the Core Daily Notes plugin?** No when Operon manages Daily Notes. When Operon management is off, Core Daily Notes provides the fallback configuration.
 
-**Does every new task go to the daily note?** Only inline tasks, and only when you turn on daily-note saving. Otherwise inline tasks go to your fixed target file.
+**Does every new task go to the Daily Note?** Only inline tasks whose normal Task Router destination is Daily Notes, or tasks explicitly routed there.
 
-**Will it set the date for me?** If you enable the Daily Note Defaults, new inline tasks in a daily note take their start or scheduled date from the note's date.
+**Will Operon set the date for me?** The optional Daily Note Defaults fill a missing start or scheduled date from the note's date.
 
-**Which file-name date formats are supported?** Whatever the core Daily Notes plugin is set to, since Operon reads that same **Date format** setting. The built-in choices and a Custom moment.js pattern all work; the default is `YYYY-MM-DD`.
+**Will an existing Daily Note become a File Task?** No. Plain Markdown is appended to without automatic adoption.
 
-**Why does `{{date}}` differ from the note filename date?** The filename follows the Daily Notes setting and the selected Calendar day. The compatible template variable records when Operon created the note. See [[DOCS-061 operonId template variables|Template variables]].
+**Where are Weekly Notes explained?** In [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]].
 
 ## Settings
 
-Operon settings for this live in **Settings → Operon → Tasks → Inline Tasks**, where you turn on saving new inline tasks to the daily note and set the Daily Note Defaults for start and scheduled dates.
+- Select Daily Notes under **Settings → Operon → Tasks → Task Router**.
+- Configure Operon-managed Daily format, template, folder, and container behavior under **Tasks → File Tasks → Daily Notes**.
+- Configure start and scheduled date defaults under **Tasks → Inline Tasks → Daily Note Defaults**.
 
 ## Related
 
 - [[DOCS-001 Operon Docs MOC|Operon Docs MOC]]
+- [[DOCS-012 Inline task syntax|Inline task syntax]]
+- [[DOCS-028 Calendar overview|Calendar overview]]
+- [[DOCS-061 operonId template variables|Template variables]]
+- [[DOCS-136 Task Router|Task Router]]
+- [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]]

--- a/docs/operon-docs/DOCS-052 Completed task review.md
+++ b/docs/operon-docs/DOCS-052 Completed task review.md
@@ -2,7 +2,7 @@
 Notes: Look back at finished work and keep completed tasks tidy
 Icon: list-checks
 Color: "#4f46e5"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-21T16:12:57
 ---
 
 # Completed task review
@@ -27,7 +27,7 @@ For reviewing the time you spent, rather than the tasks you closed, see [[DOCS-0
 
 Finished tasks do not have to pile up in your active space:
 
-- **Archive file tasks.** Operon can automatically move finished or cancelled [[DOCS-013 File tasks|file tasks]] to an archive folder after a delay, so completed notes leave your working folders without being deleted. The archive folder and delay are yours to set.
+- **Archive file tasks.** Operon can move finished or cancelled [[DOCS-013 File tasks|File Tasks]] after about five seconds to a pipeline-specific archive, or to a fallback archive when no pipeline rule matches. Leaving the fallback empty keeps unmatched terminal tasks in place. See [[DOCS-136 Task Router|Task Router]].
 - **Auto-unpin finished tasks.** The [[DOCS-032 Pinned Task Dock|Pinned Task Dock]] can drop a task automatically when it reaches a finished or cancelled state, so your pinned set stays current.
 
 Nothing is destroyed by these. Completed tasks keep their record and their tracked time; they just move out of the way.
@@ -38,12 +38,13 @@ Nothing is destroyed by these. Completed tasks keep their record and their track
 
 **Do completed tasks get deleted?** No. They are kept, and file tasks can be archived to a folder rather than removed.
 
-**Where do archived file tasks go?** To your configured archive folder, by default an Operon archive folder, after the delay you set.
+**Where do archived File Tasks go?** To their matching pipeline archive first, then to the fallback archive. If neither is configured, they stay where they are.
 
 ## Settings
 
-Operon settings for archiving live in **Settings → Operon → Tasks → File Tasks**, under Archive Finished/Cancelled File Tasks: the archive folder, the delay, and whether to limit archiving to the file-tasks folder. Auto-unpin is in the Pinned Dock settings.
+Operon archive routing lives in **Settings → Operon → Tasks → Task Router → File Task Archive**. Auto-unpin is in the Pinned Dock settings.
 
 ## Related
 
 - [[DOCS-001 Operon Docs MOC|Operon Docs MOC]]
+- [[DOCS-136 Task Router|Task Router]]

--- a/docs/operon-docs/DOCS-094 How to create a task with Task Creator.md
+++ b/docs/operon-docs/DOCS-094 How to create a task with Task Creator.md
@@ -2,7 +2,7 @@
 Notes: Walk through writing a task and triggering field pickers in the Task Creator
 Icon: square-pen
 Color: "#0F766E"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-21T16:12:57
 ---
 
 # How to create a task with Task Creator
@@ -80,7 +80,7 @@ Two things make this safe to use:
 
 So you can set a couple of fields deliberately, attach a parent for the rest, and adjust anything the parent brought in.
 
-A parent can also decide **where** an inline task is saved. With **Parent-Aware Inline Task Placement** turned on (Settings → Operon → Tasks → Inline Tasks), a new inline task that has a parent is written next to that parent: **below the parent** when the parent is an inline task, or **inside the parent file** when the parent is a file task, instead of your default inline save location. Left at the default, the task goes to your usual location and the parent link still holds. See [[DOCS-016 Parent and sub-tasks|Parent and sub-tasks]].
+A parent can also decide **where** an inline task is saved. Configure **Parent-Aware Inline Task Placement** under **Settings → Operon → Tasks → Task Router**. A new inline task can be written **below the parent** when the parent is inline, or **inside the parent file** when the parent is a File Task. Left at the default, the task goes to your normal destination and the parent link still holds. See [[DOCS-016 Parent and sub-tasks|Parent and sub-tasks]] and [[DOCS-136 Task Router|Task Router]].
 
 ## Step 5: Inline or file, and how each is saved
 

--- a/docs/operon-docs/DOCS-103 Task Wikilink Overlay.md
+++ b/docs/operon-docs/DOCS-103 Task Wikilink Overlay.md
@@ -2,7 +2,7 @@
 Notes: Render task chips and actions on a task wikilink, for file and inline tasks
 Icon: link
 Color: "#ca8a04"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-21T16:12:57
 ---
 
 # Task Wikilink Overlay
@@ -83,6 +83,7 @@ On a decorated link, Operon shows, in order:
 - A **progress** indicator for a parent task, summarizing its subtasks.
 - The **Open checkboxes** action, when enabled, for regular Markdown checkboxes associated with the task.
 - The configured **chips**, the same compact metadata chips used elsewhere.
+- Configured **Task Type**, **Task Image**, and **Task Gallery** chips follow the same field and media-reference rules as inline rows and Kanban cards.
 - Optional **actions**: start or stop the timer, pin or unpin, show a note indicator when the task has a `note`, and add a subtask.
 - An **edit** action that opens the task in Task Editor.
 
@@ -119,3 +120,4 @@ An inline task can move inside the same note without changing the link, because 
 - [[DOCS-104 Add Task Wikilink Overlay|Add Task Wikilink Overlay]]
 - [[DOCS-041 Task chips display and behavior|Task chips: display and behavior]]
 - [[DOCS-013 File tasks|File tasks]]
+- [[DOCS-138 Task images and galleries|Task images and galleries]]

--- a/docs/operon-docs/DOCS-105 Table overview.md
+++ b/docs/operon-docs/DOCS-105 Table overview.md
@@ -2,7 +2,7 @@
 Notes: See tasks as rows and columns on the Operon Table
 Icon: table
 Color: "#0284c7"
-Updated: 2026-08-18T18:18:29
+Updated: 2026-08-21T16:12:57
 ---
 
 # Table overview
@@ -25,7 +25,7 @@ A table is shaped by a **Table preset**, which controls the task scope and most 
 - **Summaries** roll each column up into a total at the foot of the table and of each group. See [[DOCS-108 Table summaries|Table summaries]].
 - The **display density** sets how compact or comfortable the rows feel.
 
-So the table is a live picture of a preset: change a task and its row updates, add a task that matches the filter and a new row appears. Saving presets lets you keep several tables for different questions and switch between them. The line number, task icon helper, and task type helper columns are global Table settings, so they appear the same way across presets. See [[DOCS-109 Table presets|Table presets]].
+So the table is a live picture of a preset: change a task and its row updates, add a task that matches the filter and a new row appears. Saving presets lets you keep several tables for different questions and switch between them. The line number, task icon helper, and Task Data Type helper columns are global Table settings, so they appear the same way across presets. Task Data Type shows whether a task is inline or file; it is separate from the editable Task Type property. See [[DOCS-109 Table presets|Table presets]].
 
 > **MEDIA-DOCS-105-2:** The table toolbar, with the preset selector, search box, Group & Sort, filter, export, and related views controls.
 
@@ -101,7 +101,7 @@ If your work is mostly date-driven, the [[DOCS-028 Calendar overview|Calendar]] 
 
 ## Settings
 
-Operon settings for the Table live in **Settings → Operon → Views → Tables**, where you set the default preset; the destination for new Table files; the maximum visible rows; and the default embedded-table width. New files start in `Operon/Tables` unless you choose another vault-relative folder; leave that folder blank to create new files at the vault root. The folder setting never moves existing Table files. Embedded tables default to `175%` width, with `50%`, `75%`, `100%`, `125%`, `150%`, `175%`, `200%`, `225%`, and `250%` choices; a valid local `width:` in an embed takes precedence. You also choose whether rows show the global line number, task icon helper, and task type helper columns. Each preset's own filter, columns, grouping, sorting, and summaries are edited from the table itself. See [[DOCS-109 Table presets|Table presets]].
+Operon settings for the Table live in **Settings → Operon → Views → Tables**, where you set the default preset; the destination for new Table files; the maximum visible rows; and the default embedded-table width. New files start in `Operon/Tables` unless you choose another vault-relative folder; leave that folder blank to create new files at the vault root. The folder setting never moves existing Table files. Embedded tables default to `175%` width, with `50%`, `75%`, `100%`, `125%`, `150%`, `175%`, `200%`, `225%`, and `250%` choices; a valid local `width:` in an embed takes precedence. You also choose whether rows show the global line number, task icon helper, and Task Data Type helper columns. Each preset's own filter, columns, grouping, sorting, and summaries are edited from the table itself. See [[DOCS-109 Table presets|Table presets]].
 
 ## Related
 

--- a/docs/operon-docs/DOCS-106 Table columns.md
+++ b/docs/operon-docs/DOCS-106 Table columns.md
@@ -2,7 +2,7 @@
 Notes: Choose, arrange, size, color, and format the columns on a table
 Icon: table-properties
 Color: "#0284c7"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-21T16:12:57
 ---
 
 # Table columns
@@ -17,7 +17,7 @@ Columns are how a table decides which fields each row shows and how each one loo
 
 Almost any field a task carries can become a column:
 
-- **Task fields**: the description (shown as **Task**), status, priority, the dates (due, scheduled, start, and the completion and cancellation dates), estimate, duration and its rolled-up totals, assignees, contexts, parent, blocking and blocked-by links, location, recurrence, tags, and note.
+- **Task fields**: the description (shown as **Task**), status, priority, Task Type, Task Image, Task Gallery, the dates (due, scheduled, start, and the completion and cancellation dates), estimate, duration and its rolled-up totals, assignees, contexts, parent, blocking and blocked-by links, location, recurrence, tags, and note.
 - **Your custom keys**: any [[DOCS-040 Custom keys|custom key]] appears as a field you can add as a column, so a table can carry exactly the properties your workflow uses.
 - **File task properties**: frontmatter properties Operon does not manage, found automatically on the file tasks in the preset's current scope, typed and offered as columns with no setup at all. See [[DOCS-115 File task property columns|File task property columns]].
 - **Source and file fields**: read-only columns that describe where the task lives, such as **Source**, source path, source line, and the file name, basename, path, and folder.
@@ -98,10 +98,10 @@ Icon-bearing task-field columns can be collapsed with **Show compact cell**, whi
 
 Most columns are editable: click a cell to change that field on the spot, as covered in [[DOCS-105 Table overview|Table overview]]. Some columns are read-only by nature and only display their value:
 
-- **Editable task fields** include status, priority, description, note, due, scheduled, start, completion and cancellation dates, repeat end, estimate, recurrence, parent and dependency links, tags, contexts, assignees, location, the task icon field, task color, and supported custom date, datetime, number, text, and list fields.
+- **Editable task fields** include status, priority, Task Type, Task Image, Task Gallery, description, note, due, scheduled, start, completion and cancellation dates, repeat end, estimate, recurrence, parent and dependency links, tags, contexts, assignees, location, the task icon field, task color, and supported custom date, datetime, number, text, and list fields.
 - **File task property columns** are editable the same way, using the same pickers, but only while their value actually matches the column's type; a value that does not drops to read-only until you fix it in Obsidian's Properties view. See [[DOCS-115 File task property columns|File task property columns]].
 - **Source and file columns**, which describe where the task is stored rather than a property you set.
-- **Identity, checkbox, progress, and helper columns**, such as operonId, Project Serial, checkbox, subtask progress, line number, task icon helper, and task type helper columns, are read-only or have their own dedicated action instead of opening a normal field picker.
+- **Identity, checkbox, progress, and helper columns**, such as operonId, Project Serial, checkbox, subtask progress, line number, task icon helper, and Task Data Type helper columns, are read-only or have their own dedicated action instead of opening a normal field picker.
 
 The source column is still active: clicking it opens the task's source in a new tab.
 
@@ -113,10 +113,10 @@ Beyond your field columns, a table can show three fixed helper columns, turned o
 |---|---|
 | Line numbers | A row-number column at the start of the table |
 | Task icon helper | A status icon you can click to cycle status, with the task's context menu |
-| Task type helper | An inline-or-file icon that opens the [[DOCS-021 Task Editor\|Task Editor]]; Cmd/Ctrl-click opens the task's source |
+| Task Data Type helper | An inline-or-file icon that opens the [[DOCS-021 Task Editor\|Task Editor]]; Cmd/Ctrl-click opens the task's source |
 
-> [!tip] Jump from task type to source
-> On desktop, click the task type icon to open the Task Editor. Cmd-click on macOS, or Ctrl-click on Windows and Linux, opens the task's source instead: the note for a file task, or the exact line for an inline task. The same shortcut also works when the Task Type field is shown as a compact cell.
+> [!tip] Jump from Task Data Type to source
+> On desktop, click the Task Data Type icon to open the Task Editor. Cmd-click on macOS, or Ctrl-click on Windows and Linux, opens the task's source instead: the note for a File Task, or the exact line for an inline task. The editable Task Type field is a separate user classification.
 
 These are global toggles rather than per-preset columns, so they appear the same way on every table. They cannot be reordered or hidden from a header menu.
 
@@ -139,11 +139,11 @@ These are global toggles rather than per-preset columns, so they appear the same
 
 **Why did a frontmatter property show up as a column on its own?** It is an unmanaged file task property, discovered automatically from the tasks in the preset's current scope. See [[DOCS-115 File task property columns|File task property columns]].
 
-**What is the difference between the task icon and task type columns?** The task icon helper cycles status and opens the context menu; the task type helper shows whether the task is inline or file, opens the Task Editor, and Cmd/Ctrl-clicks through to the source. The task icon field can also be added as a normal preset column when you want that value in the table layout.
+**What is the difference between Task Type and Task Data Type?** Task Type is an editable Text property you control. Task Data Type is the read-only inline-or-file helper; it opens the Task Editor and Cmd/Ctrl-clicks through to the source. Its internal key `__taskDataType` is not writable task data.
 
 ## Settings
 
-The three helper columns are toggled in **Settings → Operon → Views → Tables**: show line numbers, show task icon helper, and show task type helper. Every other column choice, its field, width, order, alignment, color, and format, lives in the preset and is edited from the table. See [[DOCS-109 Table presets|Table presets]].
+The three helper columns are toggled in **Settings → Operon → Views → Tables**: show line numbers, show task icon helper, and show Task Data Type helper. Every other column choice, its field, width, order, alignment, color, and format, lives in the preset and is edited from the table. See [[DOCS-109 Table presets|Table presets]].
 
 ## Related
 
@@ -153,6 +153,7 @@ The three helper columns are toggled in **Settings → Operon → Views → Tabl
 - [[DOCS-107 Table grouping and sorting|Table grouping and sorting]]
 - [[DOCS-108 Table summaries|Table summaries]]
 - [[DOCS-109 Table presets|Table presets]]
+- [[DOCS-138 Task images and galleries|Task images and galleries]]
 - [[DOCS-040 Custom keys|Custom keys]]
 - [[DOCS-115 File task property columns|File task property columns]]
 - [[DOCS-097 Project serials|Project serials]]

--- a/docs/operon-docs/DOCS-109 Table presets.md
+++ b/docs/operon-docs/DOCS-109 Table presets.md
@@ -2,7 +2,7 @@
 Notes: Save a table as a preset and switch between several tables
 Icon: table-2
 Color: "#0284c7"
-Updated: 2026-08-18T18:18:29
+Updated: 2026-08-21T16:12:57
 ---
 
 # Table presets
@@ -26,7 +26,7 @@ A preset stores the parts of a table that define the reusable view:
 - The **display** density.
 - The **search scope** choices, such as project scope, Overdue, Happens Today, and whether finished or cancelled tasks are included.
 
-The line number, task icon, and task type helper columns are global Table settings, not normal preset columns. Because the reusable layout lives in the preset, two presets never step on each other: change the columns on one and the others keep their own layout.
+The line number, task icon, and Task Data Type helper columns are global Table settings, not normal preset columns. Task Data Type is the read-only inline-or-file helper, not the editable Task Type property. Because the reusable layout lives in the preset, two presets never step on each other: change the columns on one and the others keep their own layout.
 
 ## Editing a preset
 
@@ -94,7 +94,7 @@ The **default preset** is chosen in **Settings → Operon → Views → Tables**
 
 ## Settings
 
-Table presets and the default preset live in **Settings → Operon → Views → Tables**, alongside the destination for new Table files, the maximum visible rows and default width for embedded tables, and the toggles for the line number, task icon, and task type columns. The Table-file destination is applied only when Operon creates a new `.table` file; leave it blank for the vault root, and changing it never relocates an existing preset. Each preset's own filter, columns, grouping, sorting, summaries, and density are edited from the preset settings, reached with **Edit preset**.
+Table presets and the default preset live in **Settings → Operon → Views → Tables**, alongside the destination for new Table files, the maximum visible rows and default width for embedded tables, and the toggles for the line number, task icon, and Task Data Type columns. The Table-file destination is applied only when Operon creates a new `.table` file; leave it blank for the vault root, and changing it never relocates an existing preset. Each preset's own filter, columns, grouping, sorting, summaries, and density are edited from the preset settings, reached with **Edit preset**.
 
 ## Related
 

--- a/docs/operon-docs/DOCS-111 Export a table.md
+++ b/docs/operon-docs/DOCS-111 Export a table.md
@@ -2,7 +2,7 @@
 Notes: Copy or download a table as Markdown or CSV, or grab its embed code
 Icon: download
 Color: "#0284c7"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-21T16:12:57
 ---
 
 # Export a table
@@ -24,7 +24,7 @@ If the table has no rows, there is nothing to export and Operon tells you so.
 
 Export uses the table's current rows and columns:
 
-- **The visible columns**, in their current order. Hidden columns are left out, and the line number, task icon, and task type helper columns are included when they are shown.
+- **The visible columns**, in their current order. Hidden columns are left out, and the line number, task icon, and Task Data Type helper columns are included when they are shown.
 - **The current row set**, in the current sort order and narrowed by whatever filter, search text, and scopes are active. Export a filtered or searched table and you export just that slice, not every task and not only the rows currently visible in the viewport.
 - **Textual cell values**, using the same display text the table resolves for its cells. Helper columns and compact-rendered cells export their underlying text or icon value, not the visual-only button or compact rendering.
 

--- a/docs/operon-docs/DOCS-112 Table cells display and behavior.md
+++ b/docs/operon-docs/DOCS-112 Table cells display and behavior.md
@@ -2,7 +2,7 @@
 Notes: What each table cell shows and does on click, hover, and keyboard, in detailed and compact cell modes
 Icon: square-mouse-pointer
 Color: "#0284c7"
-Updated: 2026-08-18T18:18:29
+Updated: 2026-08-21T16:12:57
 ---
 
 # Table cells: display and behavior
@@ -41,6 +41,9 @@ In detailed cell mode, each field type renders its own way:
 | Due, Scheduled | The date, turning **red** when overdue and **blue** when due today |
 | Other dates | The date, in neutral text |
 | List, tags | One chip per item in the field |
+| Task Type | The user-managed classification, editable as Text |
+| Task Image | One media-reference value or chip |
+| Task Gallery | One ordered chip per media reference |
 | Task links (parent, blocking, blocked by) | A wikilink chip per linked task |
 | Links (web links) | A chip per link: a named Markdown link shows its label, a bare URL a tidied address |
 | Assignees, contexts | A chip per linked person, place, or context value |
@@ -50,7 +53,7 @@ In detailed cell mode, each field type renders its own way:
 | Description | The task's text, with any wikilinks live |
 | Source | A button that opens the task's source |
 | Project Serial | A chip with the task's serial, where a scope covers it |
-| Line number, task icon helper, task type helper | The row number, a status icon, or an inline-or-file icon |
+| Line number, task icon helper, Task Data Type helper | The row number, a status icon, or an inline-or-file icon |
 
 In detailed cells, an empty field usually shows a plain `--`, so a blank detailed cell is never ambiguous. **Project Serial is the exception**: a task outside any [[DOCS-097 Project serials|Project serial]] scope renders a fully empty cell instead of `--`. Empty compact cells can render blank when there is no value to turn into an icon. Once a task is finished or cancelled, its Due and Scheduled cells drop the red and blue, because the deadline no longer presses, the same rule as [[DOCS-041 Task chips display and behavior|task chips]].
 
@@ -72,7 +75,7 @@ Cells fall into a few roles. Some edit a value in place, some take you somewhere
 | Act on structure | parent task progress | Opens the task's subtasks or checkboxes |
 | Go to source | source column | Opens the task's source in a new Obsidian tab: the note for a file task, the exact line for an inline task |
 | Cycle and menu | task icon column | Cycles the task's status; its hover menu is the [[DOCS-042 Contextual menu actions\|contextual menu]] |
-| Open the editor | task type column | Opens the [[DOCS-021 Task Editor\|Task Editor]]; Cmd/Ctrl-click opens the source instead |
+| Open the editor | Task Data Type helper | Opens the [[DOCS-021 Task Editor\|Task Editor]]; Cmd/Ctrl-click opens the source instead |
 
 Two behaviors apply to every row, whatever the column:
 
@@ -137,5 +140,6 @@ Because a cell both shows and acts, the display mode you pick per column has con
 - [[DOCS-105 Table overview|Table overview]]
 - [[DOCS-113 Text field editor popover|Text field editor popover]]
 - [[DOCS-041 Task chips display and behavior|Task chips: display and behavior]]
+- [[DOCS-138 Task images and galleries|Task images and galleries]]
 - [[DOCS-068 Location picker|Location picker]]
 - [[DOCS-097 Project serials|Project serials]]

--- a/docs/operon-docs/DOCS-118 Operon Agent Runtime overview.md
+++ b/docs/operon-docs/DOCS-118 Operon Agent Runtime overview.md
@@ -2,7 +2,7 @@
 Notes: What the Agent Runtime is, why it exists, and how its two public surfaces differ
 Icon: bot-message-square
 Color: "#059669"
-Updated: 2026-07-30T19:36:17
+Updated: 2026-08-21T16:12:57
 ---
 
 # Operon Agent Runtime overview
@@ -41,6 +41,8 @@ The Runtime does both halves through the CLI and Developer API, and reads are st
 **Reads are live and usable now.** Reading the catalog, resolving and reading tasks, querying, following relationships, building context, and reading timer state are available through the appropriate public surface.
 
 **Writes are live too, behind a sealed preview.** Creating, updating, transitioning, converting, relocating, and deleting tasks all go through the Mutation Gateway's preview-to-apply model. The Runtime computes exactly what a change would do, seals that plan, and applies only that same plan. Nothing is written from a raw request. Eligible routine direct CLI commands may apply an unchanged warning-free plan without a separate manual stop. Typed CLI input, agent stdin, `--preview-only`, and any warning, acknowledgement, confirmation, or destructive gate retain the plan for review or explicit handling. Developer API callers use typed mutation inputs and their own capability and consent rules. The read journey never depends on the write path, so you can rely on reads on their own.
+
+The additive task-workflow extension also supports Daily and Weekly semantic creation and scheduled-date parent realignment. The caller states intent; Operon owns settings, templates, Markdown, container registration, and recovery. Updating a periodic relationship never physically moves the existing task. See [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]].
 
 ## Who this is for
 
@@ -92,3 +94,4 @@ Requirements and platform support in detail live in [[DOCS-119 Install and verif
 - [[DOCS-127 Everyday task commands|Everyday task commands]]
 - [[DOCS-128 Interactive shell and discovery|Interactive shell and discovery]]
 - [[DOCS-129 In-process Developer API overview|In-process Developer API overview]]
+- [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]]

--- a/docs/operon-docs/DOCS-122 Changing tasks safely.md
+++ b/docs/operon-docs/DOCS-122 Changing tasks safely.md
@@ -2,7 +2,7 @@
 Notes: How a change goes from intent to a verified result through one sealed preview-and-apply model
 Icon: square-pen
 Color: "#059669"
-Updated: 2026-07-30T19:36:17
+Updated: 2026-08-21T16:12:57
 ---
 
 # Changing tasks safely
@@ -78,6 +78,10 @@ The write surface covers the same operations you would perform by hand, each thr
 
 The exact commands and their targeting rules are in [[DOCS-127 Everyday task commands|Everyday task commands]]; the compact field syntax they share is in [[DOCS-126 Compact task syntax|Compact task syntax]]. For the authoritative list of mutation kinds and their capability versions, see [[DOCS-125 CLI contract and discovery reference|CLI contract and discovery reference]].
 
+## Periodic relationship changes do not relocate tasks
+
+Daily and Weekly semantic updates use the same sealed preview, apply, receipt, and recovery model. An explicit `dateScheduled` set or clear may keep, detach, or realign a verified periodic parent, but the task's path, representation, and inline locator remain unchanged. Manual parents are never silently replaced. See [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]].
+
 ## FAQ
 
 **Exactly how long does a sealed plan live?** A routine or elevated plan expires five minutes after it is created, and a destructive plan expires after 60 seconds, because a destructive intention should not sit around waiting. Those are deadlines for dispatch, not for how long you may think: once dispatch may have begun the plan stops being re-previewable and becomes recoverable instead, and its recovery evidence is kept for 24 hours.
@@ -104,3 +108,4 @@ The exact commands and their targeting rules are in [[DOCS-127 Everyday task com
 - [[DOCS-127 Everyday task commands|Everyday task commands]]
 - [[DOCS-131 Developer API reads and typed mutations|Developer API reads and typed mutations]]
 - [[DOCS-132 Developer API recovery, errors and audit|Developer API recovery, errors, and audit]]
+- [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]]

--- a/docs/operon-docs/DOCS-124 Troubleshooting and recovery.md
+++ b/docs/operon-docs/DOCS-124 Troubleshooting and recovery.md
@@ -2,7 +2,7 @@
 Notes: Symptom-to-action guide for setup, availability, freshness, and uncertain outcomes
 Icon: wrench
 Color: "#059669"
-Updated: 2026-08-03T10:31:15
+Updated: 2026-08-21T16:12:57
 ---
 
 # Troubleshooting and recovery
@@ -62,7 +62,9 @@ operon capabilities --profile main --json
 
 A degraded capability is available but constrained; an unavailable one cannot run right now. Both are usually tied to Runtime readiness, so the fix is often to wait and retry, exactly as in the availability case. If a capability stays unavailable while health is otherwise good, treat that operation as not offered in this state and defer it.
 
-Some newer write features, such as compact creation with reminders or recurrence, relationship replacement, source transitions, and timer-session edits, are additionally gated behind an advertised capability version that both the CLI and Operon must agree on. If they disagree, the command fails closed before touching anything, rather than acting on a half-supported feature. The fix is to bring both sides up to date so they advertise the same version: update `operon-cli`, and update Operon in the vault.
+Some newer write features, such as compact creation with reminders or recurrence, relationship replacement, source transitions, timer-session edits, and Daily/Weekly periodic routing, are additionally gated behind matching advertised capabilities. If the CLI and Operon disagree, the command fails closed before touching any task, note, setting, template, or registry state rather than acting on a half-supported feature. Bring both sides to a compatible version and confirm the required capability with `operon capabilities --json`.
+
+For periodic creation the required capabilities are `tasks.create.periodic-note.preview` and `tasks.create.periodic-note.apply`; scheduled-date parent realignment uses `tasks.update.periodic-note.preview` and `tasks.update.periodic-note.apply`. A missing capability is compatibility refusal, not permission to fall back to direct Markdown writes. See [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]].
 
 ## Stale or unexpected data
 
@@ -157,3 +159,4 @@ The rules are simple and worth internalizing:
 - [[DOCS-123 Security and trust boundaries|Security and trust boundaries]]
 - [[DOCS-125 CLI contract and discovery reference|CLI contract and discovery reference]]
 - [[DOCS-132 Developer API recovery, errors and audit|Developer API recovery, errors, and audit]]
+- [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]]

--- a/docs/operon-docs/DOCS-125 CLI contract and discovery reference.md
+++ b/docs/operon-docs/DOCS-125 CLI contract and discovery reference.md
@@ -2,7 +2,7 @@
 Notes: Discover and verify the public CLI contract, compatibility ranges, exit codes, and platform support
 Icon: file-json
 Color: "#059669"
-Updated: 2026-08-03T10:31:15
+Updated: 2026-08-21T16:12:57
 ---
 
 # CLI contract and discovery reference
@@ -77,9 +77,13 @@ Scripts should branch on the exit code rather than parsing text. After apply may
 
 ## Capability versions
 
-The newer write features are each gated behind an advertised capability version that both the CLI and the live Runtime must agree on before the feature runs. The manifest advertises these per command under `convenienceContracts`, and every one is currently at version 1: compact and typed creation (`compactGrammarVersion`, `compactBatchVersion`, `typedCreateVersion`, `temporalCreateVersion`, `graphTransactionVersion`), direct updates (`compactUpdateVersion`, `compactUpdateBatchVersion`, `directRelationshipVersion`, `directRecurrenceVersion`), lifecycle and pin state (`directTransitionVersion`, `directPinnedVersion`), source transitions (`sourceTransitionRecoveryVersion`), reminders (`directReminderVersion`), and timer sessions (`directTimerSessionVersion`).
+The newer write features are each gated behind an advertised capability version that both the CLI and the live Runtime must agree on before the feature runs. The manifest advertises these per command under `convenienceContracts`, and every one is currently at version 1: compact and typed creation (`compactGrammarVersion`, `compactBatchVersion`, `typedCreateVersion`, `temporalCreateVersion`, `graphTransactionVersion`), direct updates (`compactUpdateVersion`, `compactUpdateBatchVersion`, `directRelationshipVersion`, `directRecurrenceVersion`), lifecycle and pin state (`directTransitionVersion`, `directPinnedVersion`), source transitions (`sourceTransitionRecoveryVersion`), reminders (`directReminderVersion`), and timer sessions (`directTimerSessionVersion`). Daily/Weekly task workflows additionally require `tasks.create.periodic-note.preview` and `tasks.create.periodic-note.apply`, or `tasks.update.periodic-note.preview` and `tasks.update.periodic-note.apply`.
 
 The compact batch contracts also publish their input format and upper bound. Create accepts `compact-lines` with one to 64 records; update accepts `compact-lines` with two to 64 records. The corresponding manifest fields are `compactBatchInputFormat`, `compactBatchMaxItems`, `compactUpdateBatchInputFormat`, and `compactUpdateBatchMaxItems`. If the CLI and Runtime advertise different versions or limits, the affected command fails closed rather than acting on a half-supported feature. Read the current values with `operon manifest --json`; do not rely on the list here staying exhaustive.
+
+## Canonical task data fields
+
+The Runtime catalog and CLI recognize `taskType` and `taskImage` as Text and `taskGallery` as an ordered List through create, update, and read. Gallery escaping and order are part of the contract. `__taskDataType` is a Table-only helper, is absent from the writable catalog, and must be rejected as mutation input. See [[DOCS-138 Task images and galleries|Task images and galleries]].
 
 ## Platform matrix
 

--- a/docs/operon-docs/DOCS-126 Compact task syntax.md
+++ b/docs/operon-docs/DOCS-126 Compact task syntax.md
@@ -2,7 +2,7 @@
 Notes: The readable key::"VALUE" syntax for single-task and bounded batch creation and update
 Icon: braces
 Color: "#059669"
-Updated: 2026-07-30T19:48:31
+Updated: 2026-08-21T16:12:57
 ---
 
 # Compact task syntax
@@ -49,6 +49,15 @@ operon task create file "Publish notes" note::"Source reviewed"
 
 The optional `inline` or `file` token selects the representation only. Placement stays Runtime-owned: the compiler asks for the configured default target for that representation, so exact paths, file templates, and parent routing are resolved and sealed by the Runtime, not stated here. `parentTask::"<operonId>"` attaches the new task under one existing task by its exact id; it does not resolve a name or create a parent.
 
+Create one inline task through Daily or Weekly semantics with `--periodic-note`:
+
+```bash
+operon task create "Daily review" --periodic-note daily dateScheduled::"2026-08-21"
+operon task create "Weekly review" --periodic-note weekly datetimeStart::"2026-08-21T09:00:00"
+```
+
+The option accepts exactly `daily` or `weekly`, requires one task, rejects an explicit parent, and has no `--route-date` companion flag. The Plugin resolves settings, note path, template, heading, container, parent relationship, registry writes, and recovery. See [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]].
+
 ## Status and priority at creation
 
 At creation, two fields resolve through your live Catalog:
@@ -79,6 +88,12 @@ operon task update --description "Review planning" --clear "dateDue"
 ```
 
 Select the task with exactly one of `--id`, a seven-character Operon id, or `--description`, which matches one task by NFC-normalized, case-sensitive exact text. Set or replace a field with `key::"VALUE"`, and clear one with `--clear "key"`; an empty assigned value is invalid and never means clear, and a key may appear only once across all assignments and clears. Only fields that are mapped, readable, and classified as general updates are admitted, plus `priority`; description can be replaced but not cleared. When every requested change already matches the live task, the CLI returns a no-change result before it ever creates a preview.
+
+An explicit `dateScheduled` set or clear may route one applicable task through `tasks.update.periodic-note.preview`. Operon may keep, detach, or realign a verified periodic parent, but never moves the task's Markdown. A simultaneous explicit `parentTask` is refused for this semantic route; ordinary caller-owned relationship updates remain separate.
+
+## Task Type, Image, and Gallery
+
+`taskType` and `taskImage` take one Text value. `taskGallery` takes an ordered semicolon list and uses `\;` for a literal semicolon and `\\` for a literal backslash. Create and update preserve gallery order. `__taskDataType` is Table-only and produces `FIELD_NOT_WRITABLE` rather than a mutation. See [[DOCS-138 Task images and galleries|Task images and galleries]].
 
 ## Recurrence and scoped temporal updates
 
@@ -180,3 +195,5 @@ Positional compact arguments and `--input-format compact` each describe one task
 - [[DOCS-122 Changing tasks safely|Changing tasks safely]]
 - [[DOCS-125 CLI contract and discovery reference|CLI contract and discovery reference]]
 - [[DOCS-127 Everyday task commands|Everyday task commands]]
+- [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]]
+- [[DOCS-138 Task images and galleries|Task images and galleries]]

--- a/docs/operon-docs/DOCS-127 Everyday task commands.md
+++ b/docs/operon-docs/DOCS-127 Everyday task commands.md
@@ -2,7 +2,7 @@
 Notes: Direct single-task commands, bounded compact batches, exact targeting, and apply behavior
 Icon: list-checks
 Color: "#059669"
-Updated: 2026-07-30T20:01:33
+Updated: 2026-08-21T16:12:57
 ---
 
 # Everyday task commands
@@ -26,10 +26,14 @@ Creating and updating are where the compact field syntax lives:
 
 ```bash
 operon task create inline "Review planning" dateDue::"2026-08-01"
+operon task create "Daily review" --periodic-note daily dateScheduled::"2026-08-21"
+operon task create "Weekly review" --periodic-note weekly datetimeStart::"2026-08-21T09:00:00"
 operon task update --id "abc1234" priority::"High" --clear "dateDue"
 ```
 
 `task create` makes a new task and so takes no selector; `task update` changes fields on an exact task, setting or replacing with `key::"VALUE"` and clearing with `--clear "key"`. Both share the field rules in [[DOCS-126 Compact task syntax|Compact task syntax]].
+
+`--periodic-note daily|weekly` creates one inline task through Plugin-owned periodic routing. Updating `dateScheduled` on an applicable task may realign only its verified periodic parent; it never relocates the task. There is no `--route-date` CLI flag. See [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]].
 
 For a bounded file or stdin batch, use:
 
@@ -155,5 +159,6 @@ Explicit `plan apply`, `plan recover`, and `mutation apply` can dispatch an alre
 - [[DOCS-118 Operon Agent Runtime overview|Operon Agent Runtime overview]]
 - [[DOCS-122 Changing tasks safely|Changing tasks safely]]
 - [[DOCS-124 Troubleshooting and recovery|Troubleshooting and recovery]]
+- [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]]
 - [[DOCS-126 Compact task syntax|Compact task syntax]]
 - [[DOCS-128 Interactive shell and discovery|Interactive shell and discovery]]

--- a/docs/operon-docs/DOCS-129 In-process Developer API overview.md
+++ b/docs/operon-docs/DOCS-129 In-process Developer API overview.md
@@ -2,7 +2,7 @@
 Notes: Connect an Obsidian plugin to Operon's typed in-process API and choose it instead of the CLI when appropriate
 Icon: plug-zap
 Color: "#059669"
-Updated: 2026-08-18T18:18:29
+Updated: 2026-08-21T16:12:57
 ---
 
 # In-process Developer API overview
@@ -49,7 +49,7 @@ The consumer passed to the accessor must be your actual plugin instance. A copie
 
 ## Task workflow extension
 
-The base `getDeveloperApiV1()` accessor remains frozen. It does not accept task-workflow extension capabilities, and its existing read and mutation examples stay on that base surface. For saved-filter reads and inline-task adoption, use the separate, additive `getTaskWorkflowDeveloperApiV1()` accessor on the same verified Operon plugin instance:
+The base `getDeveloperApiV1()` accessor remains frozen. It does not accept task-workflow extension capabilities, and its existing read and mutation examples stay on that base surface. For saved-filter reads, inline-task adoption, and Daily/Weekly periodic creation or update, use the separate, additive `getTaskWorkflowDeveloperApiV1()` accessor on the same verified Operon plugin instance:
 
 ```ts
 interface OperonTaskWorkflowDeveloperApiAccessorV1 {
@@ -72,7 +72,7 @@ if (!workflowOperon || typeof workflowOperon.getTaskWorkflowDeveloperApiV1 !== "
 }
 ```
 
-This extension has its own narrow, capability-projected API. Its exact grants are `tasks.filter-query`, `tasks.adopt.preview`, and `tasks.adopt.apply`; requesting one capability does not expose the others. See [[DOCS-130 Developer API identity and capability grants|Developer API identity and capability grants]] and [[DOCS-131 Developer API reads and typed mutations|Developer API reads and typed mutations]].
+This extension has its own narrow, capability-projected API. Its exact grants cover `tasks.filter-query`, adoption preview/apply, and periodic create/update preview/apply; requesting one capability does not expose the others. The periodic methods are `tasks.createPeriodicNote.preview/apply/recover/pendingRecoveries` and `tasks.updatePeriodicNote.preview/apply/recover/pendingRecoveries`. See [[DOCS-130 Developer API identity and capability grants|Developer API identity and capability grants]] and [[DOCS-131 Developer API reads and typed mutations|Developer API reads and typed mutations]].
 
 ## Open a discovery-only session
 
@@ -124,7 +124,7 @@ The Developer API is desktop-only and local to the current Obsidian process. It 
 
 **Can I use this from mobile, or from outside Obsidian?** No. It is desktop-only and local to the current Obsidian process. It is not a remote API, an HTTP or MCP server, a mobile API, or a sandbox for untrusted plugins. For anything outside the app, use `operon-cli`.
 
-**Why is there a second accessor for task workflows?** It keeps the established Developer API V1 surface unchanged while adding a separately granted extension for saved-filter reads and inline-task adoption. Do not send extension capability names to `getDeveloperApiV1()`; call `getTaskWorkflowDeveloperApiV1()` instead.
+**Why is there a second accessor for task workflows?** It keeps the established Developer API V1 surface unchanged while adding separately granted saved-filter, adoption, and periodic-note workflows. Do not send extension capability names to `getDeveloperApiV1()`; call `getTaskWorkflowDeveloperApiV1()` instead.
 
 ## Related
 
@@ -135,3 +135,4 @@ The Developer API is desktop-only and local to the current Obsidian process. It 
 - [[DOCS-130 Developer API identity and capability grants|Developer API identity and capability grants]]
 - [[DOCS-131 Developer API reads and typed mutations|Developer API reads and typed mutations]]
 - [[DOCS-132 Developer API recovery, errors and audit|Developer API recovery, errors and audit]]
+- [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]]

--- a/docs/operon-docs/DOCS-130 Developer API identity and capability grants.md
+++ b/docs/operon-docs/DOCS-130 Developer API identity and capability grants.md
@@ -2,7 +2,7 @@
 Notes: Understand registry-derived plugin identity, exact capability requests, user approval, suspension, and revocation
 Icon: key-round
 Color: "#059669"
-Updated: 2026-08-18T18:18:29
+Updated: 2026-08-21T16:12:57
 ---
 
 # Developer API identity and capability grants
@@ -33,7 +33,7 @@ The persistent consumer identity is the plugin ID. Operon also creates a new ins
 
 ## Task workflow extension grants
 
-Saved-filter reads and inline-task adoption are on the additive `getTaskWorkflowDeveloperApiV1()` accessor, not the frozen base `getDeveloperApiV1()` accessor. Ask that accessor for exactly the task-workflow capabilities your feature needs:
+Saved-filter reads, inline-task adoption, and periodic-note creation/update are on the additive `getTaskWorkflowDeveloperApiV1()` accessor, not the frozen base `getDeveloperApiV1()` accessor. Ask that accessor for exactly the task-workflow capabilities your feature needs:
 
 ```ts
 const workflowAccess = operon.getTaskWorkflowDeveloperApiV1(this, {
@@ -43,6 +43,10 @@ const workflowAccess = operon.getTaskWorkflowDeveloperApiV1(this, {
     "tasks.filter-query",
     "tasks.adopt.preview",
     "tasks.adopt.apply",
+    "tasks.create.periodic-note.preview",
+    "tasks.create.periodic-note.apply",
+    "tasks.update.periodic-note.preview",
+    "tasks.update.periodic-note.apply",
   ],
 });
 ```
@@ -52,6 +56,10 @@ const workflowAccess = operon.getTaskWorkflowDeveloperApiV1(this, {
 | `tasks.filter-query` | Evaluate one saved FilterSet against the live task index. |
 | `tasks.adopt.preview` | Preview adoption of one exact inline source line. |
 | `tasks.adopt.apply` | Apply or recover the sealed adoption plan from that preview. |
+| `tasks.create.periodic-note.preview` | Preview one typed Daily or Weekly inline-task creation. |
+| `tasks.create.periodic-note.apply` | Apply or recover that sealed periodic creation. |
+| `tasks.update.periodic-note.preview` | Preview one scheduled-date periodic parent update. |
+| `tasks.update.periodic-note.apply` | Apply or recover that sealed periodic update. |
 
 The capability names, order, and uniqueness are exact. A request for any unsupported name, duplicate, or out-of-order subset is refused. The user reviews the same exact requested set in **Settings → Operon → Core → General → Developer API Integrations**. Base Developer API grants do not imply these extension grants, and extension grants do not widen the base API.
 
@@ -103,7 +111,7 @@ Developer API access and mutation preview, apply, and recovery inputs must not a
 
 **Can I supply my own identity, consent, or idempotency values?** No. Those fields belong to Operon, and mutation input containing host-owned fields is rejected as an invalid request rather than being ignored. The one identifier you generate is the `requestId` on Runtime read DTOs, which is a correlation value and not a claim of authority.
 
-**Can I ask `getDeveloperApiV1()` for `tasks.adopt.preview`?** No. The base accessor remains unchanged and rejects task-workflow extension capabilities. Request `tasks.adopt.preview` and `tasks.adopt.apply` through `getTaskWorkflowDeveloperApiV1()` instead.
+**Can I ask `getDeveloperApiV1()` for a task-workflow capability?** No. The base accessor remains unchanged and rejects adoption and periodic-note extension capabilities. Request them through `getTaskWorkflowDeveloperApiV1()` instead.
 
 ## Related
 
@@ -112,3 +120,4 @@ Developer API access and mutation preview, apply, and recovery inputs must not a
 - [[DOCS-129 In-process Developer API overview|In-process Developer API overview]]
 - [[DOCS-131 Developer API reads and typed mutations|Developer API reads and typed mutations]]
 - [[DOCS-132 Developer API recovery, errors and audit|Developer API recovery, errors and audit]]
+- [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]]

--- a/docs/operon-docs/DOCS-131 Developer API reads and typed mutations.md
+++ b/docs/operon-docs/DOCS-131 Developer API reads and typed mutations.md
@@ -2,7 +2,7 @@
 Notes: Use capability-gated reads and the typed preview, apply, receipt, and replay mutation flow
 Icon: code-xml
 Color: "#059669"
-Updated: 2026-08-18T18:18:29
+Updated: 2026-08-21T16:12:57
 ---
 
 # Developer API reads and typed mutations
@@ -95,6 +95,40 @@ if (!preview.ok) {
 const execution = await workflow.tasks.adopt.apply({ plan: preview.plan });
 ```
 
+## Daily and Weekly periodic mutations
+
+Request only the exact periodic capabilities your consumer needs. Creation is exposed as `workflow.tasks.createPeriodicNote`; scheduled-date parent realignment is `workflow.tasks.updatePeriodicNote`. Each projected method group provides `preview`, `apply`, `recover`, and `pendingRecoveries` when the matching grants are active.
+
+```ts
+const access = operon.getTaskWorkflowDeveloperApiV1(this, {
+  contractVersion: 1,
+  runtimeApi: { min: 1, max: 1 },
+  requestedCapabilities: [
+    "tasks.create.periodic-note.preview",
+    "tasks.create.periodic-note.apply",
+  ],
+});
+
+if (!access.ok) throw new Error(access.error.code);
+
+const preview = await access.api.tasks.createPeriodicNote.preview({
+  operation: "create",
+  items: [{
+    itemRef: "weekly-review",
+    description: "Weekly review",
+    target: { representation: "inline", mode: "periodic-note", periodicKind: "weekly" },
+    fields: [{ kind: "date", field: "dateScheduled", value: "2026-08-21" }],
+  }],
+});
+
+if (preview.ok) {
+  const execution = await access.api.tasks.createPeriodicNote.apply({ plan: preview.plan });
+  console.log(execution.status);
+}
+```
+
+The typed caller does not supply settings, note paths, templates, Markdown, parent identity, registry writes, authorization claims, or idempotency values. Operon seals and owns those details. Periodic update accepts one exact task and an explicit `dateScheduled` set or clear; it preserves the task's physical locator and manual relationships. See [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]].
+
 Preview produces a session-bound, opaque plan handle. Apply only that unchanged handle: do not clone it, reconstruct it from fields, pass it to another session or consumer, or make a fresh preview as a retry. If the file, line number, or expected line changes before apply, Operon fails closed before writing. A successful replay returns `already-applied` without another source write.
 
 ## Preview a typed mutation
@@ -171,3 +205,4 @@ If the result is `partial` or `outcome-unknown`, ordinary apply and replacement 
 - [[DOCS-129 In-process Developer API overview|In-process Developer API overview]]
 - [[DOCS-130 Developer API identity and capability grants|Developer API identity and capability grants]]
 - [[DOCS-132 Developer API recovery, errors and audit|Developer API recovery, errors and audit]]
+- [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]]

--- a/docs/operon-docs/DOCS-132 Developer API recovery, errors and audit.md
+++ b/docs/operon-docs/DOCS-132 Developer API recovery, errors and audit.md
@@ -2,7 +2,7 @@
 Notes: Recover only the same dispatched mutation and interpret Developer API errors, receipts, and redacted audit records
 Icon: shield-alert
 Color: "#059669"
-Updated: 2026-08-18T18:18:29
+Updated: 2026-08-21T16:12:57
 ---
 
 # Developer API recovery, errors and audit
@@ -67,6 +67,24 @@ if (reopened.ok) {
 
 `recoveryRef` is only a reference to the original plan's recovery evidence. It is bound to the same registry-verified consumer and cannot authorize a different target, a modified `expectedLine`, or a new adoption. Use `workflow.tasks.adopt.pendingRecoveries()` to list the current consumer's dispatched unresolved adoption operations.
 
+## Periodic-note recovery
+
+Daily/Weekly creation and update follow the same same-plan rule through their own projected method groups:
+
+```ts
+const createRecovered = await workflow.tasks.createPeriodicNote.recover({
+  recoveryRef: createPreview.plan.recoveryRef,
+});
+
+const updateRecovered = await workflow.tasks.updatePeriodicNote.recover({
+  recoveryRef: updatePreview.plan.recoveryRef,
+});
+```
+
+Use `createPeriodicNote.pendingRecoveries()` or `updatePeriodicNote.pendingRecoveries()` to list only the current consumer's dispatched unresolved operations in that family. Recovery requires the corresponding `.apply` grant and continues the same sealed plan. It cannot select another date, task, note, template, parent, or registry entry.
+
+Periodic authority, state, receipt, and uncertain-outcome reasons use the `periodic-note` family. Adoption keeps its established `task-adoption` reasons. Consumers should still branch on structured `code` and `action`, not either human-readable reason.
+
 ## When recovery is required
 
 A result with status `partial` or `outcome-unknown` reports:
@@ -79,7 +97,7 @@ A result with status `partial` or `outcome-unknown` reports:
 
 Do not re-preview, call ordinary apply again, change the target, or mint a new idempotency value. Use `recover({ plan })` or `recover({ recoveryRef })` for that exact operation. If recovery still cannot verify the outcome, keep the operation uncertain.
 
-For inline adoption, those calls are `workflow.tasks.adopt.recover({ plan })` or `workflow.tasks.adopt.recover({ recoveryRef })`. Do not switch to a base-API mutation method or create a new adoption preview.
+For inline adoption, those calls are `workflow.tasks.adopt.recover({ plan })` or `workflow.tasks.adopt.recover({ recoveryRef })`. Periodic workflows use the matching `createPeriodicNote` or `updatePeriodicNote` recovery method. Do not switch to a base-API mutation method or create a replacement preview.
 
 Recovery evidence is retained for 24 hours, up to 256 protected records. Capacity pressure refuses a new dispatch rather than deleting unresolved evidence. An expired reference returns `plan-expired`.
 
@@ -133,3 +151,4 @@ The Developer API intentionally provides no audit-reading method. Audit inspecti
 - [[DOCS-129 In-process Developer API overview|In-process Developer API overview]]
 - [[DOCS-130 Developer API identity and capability grants|Developer API identity and capability grants]]
 - [[DOCS-131 Developer API reads and typed mutations|Developer API reads and typed mutations]]
+- [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]]

--- a/docs/operon-docs/DOCS-136 Task Router.md
+++ b/docs/operon-docs/DOCS-136 Task Router.md
@@ -1,0 +1,119 @@
+---
+Notes: Route new and existing inline and file tasks to the right working and archive locations
+Icon: route
+Color: "#2563eb"
+Updated: 2026-08-21T16:12:57
+---
+
+# Task Router
+
+Task Router is the place where Operon decides where tasks belong. It brings inline capture, File Task folders, parent-aware placement, and File Task archiving into one settings page, so the same routing rules govern creation and later lifecycle changes.
+
+Routing changes location, not identity. An Operon task keeps its `operonId`, fields, relationships, and history when an eligible File Task moves between configured folders.
+
+## What Task Router controls
+
+Task Router has three parts:
+
+- **Inline Tasks** chooses the normal destination for a new inline task and how a parent may override that destination.
+- **File Tasks** chooses the default File Task folder, optional pipeline-specific folders, and parent-aware placement.
+- **File Task Archive** chooses where finished and cancelled File Tasks move.
+
+Daily and Weekly note creation has its own configuration under **Tasks → File Tasks**. Task Router selects those notes as destinations; [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]] explains how Operon resolves and creates them.
+
+## Inline Task destinations
+
+The default inline destination can be:
+
+- **Daily Notes**: the note for the routed day.
+- **Weekly Notes**: the note for the routed week.
+- **Specific File**: one configured Markdown file.
+- **Active File**: the note you are working in.
+- **Ask Every Time**: choose the destination during creation.
+
+Daily Notes is available when Operon manages Daily Notes or Obsidian's Core Daily Notes plugin is available. Weekly Notes requires Operon's Weekly Notes management to be enabled.
+
+For Daily Notes, Active File, and Ask Every Time, **Inline task heading** is a heading keyword rather than a whole Markdown heading. Operon inserts under the first heading containing that phrase; if none exists, it creates a level-two heading. Weekly Notes uses the routed daily-date heading described in [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]]. Specific File mode uses a linked date heading based on the active Core Daily Notes format, with `YYYY-MM-DD` as fallback.
+
+## Parent-aware inline placement
+
+A parent can override the normal inline destination:
+
+- With an **inline parent**, Operon can place the new task directly below that parent.
+- With a **File Task parent**, Operon can place the new task inside the parent note under the configured heading.
+- With either rule left at **Default**, the task goes to the normal inline destination and still keeps its `parentTask` relationship.
+
+This is placement at creation time. It does not make later date or relationship edits physically move an existing inline task. See [[DOCS-016 Parent and sub-tasks|Parent and sub-tasks]].
+
+## File Task destinations
+
+**File Task Default Save Location** is the fallback folder for new File Tasks. Leave it empty to use the vault root.
+
+**Pipeline locations** can map each pipeline to its own folder. A matching pipeline folder takes priority over parent-aware placement and the default File Task folder. This keeps, for example, Project and Personal File Tasks in different working areas without changing how they are created.
+
+When an eligible open File Task changes pipeline, or when you change a pipeline location rule, Operon moves it to the matching folder after about five seconds. The delay lets the task update and index settle before the file move. If the destination is unsafe, occupied, or cannot be resolved, Operon leaves the file in place rather than guessing.
+
+## Converted notes
+
+Converting a plain note into an Operon File Task normally keeps the note where it is. Turn on **Move converted notes to pipeline location** when converted notes should move after about five seconds to their matching pipeline folder, or to the default File Task folder when no pipeline rule matches.
+
+This option is separate from conversion itself. Conversion preserves the note's content and establishes task identity; routing decides whether its file location should then change. See [[DOCS-019 Converting inline and file tasks|Converting inline and file tasks]].
+
+## Parent-aware File Task placement
+
+When no pipeline folder overrides it, a parent can influence where a new File Task is created:
+
+- An inline parent can place the File Task in the parent's folder.
+- A File Task parent can place it in the parent's folder.
+- **Default** uses the configured File Task folder instead.
+
+The relationship is independent of the chosen folder. A task may keep its parent even when routing uses a pipeline or default destination.
+
+## File Task Archive
+
+Finished and cancelled File Tasks can move out of working folders without being deleted.
+
+- A **pipeline archive location** is the first choice for a terminal task in that pipeline.
+- The **fallback archive folder** is used when no pipeline archive rule matches.
+- Leaving the fallback empty keeps unmatched terminal tasks in place.
+
+Terminal moves happen after about five seconds. Operon moves only eligible File Tasks, creates safe missing folders when possible, and refuses an occupied or unsafe destination. A matching pipeline archive always takes priority over the fallback.
+
+## Example setup
+
+Suppose `Project` tasks work in `20 Projects/Tasks`, `Personal` tasks work in `40 Areas/Tasks`, and all unmatched tasks use `File Tasks`:
+
+- Map `Project` to `20 Projects/Tasks`.
+- Map `Personal` to `40 Areas/Tasks`.
+- Set `File Tasks` as the default File Task folder.
+- Map their terminal tasks to matching archive folders.
+- Set one fallback archive for every other pipeline, or leave it empty to keep unmatched tasks where they are.
+
+The rule set remains readable: the matching pipeline wins, then the relevant fallback applies.
+
+## FAQ
+
+**Does changing a pipeline move every task immediately?** Only eligible open File Tasks move, after about five seconds. Inline tasks do not move between notes.
+
+**Does a pipeline folder remove the parent relationship?** No. It overrides physical placement, not the relationship.
+
+**Are converted notes always moved?** No. They move only when **Move converted notes to pipeline location** is enabled.
+
+**Are archived tasks deleted?** No. Their Markdown files move; their task identity and data stay intact.
+
+**What happens when a destination is unsafe or occupied?** Operon leaves the task in place and reports the problem instead of selecting another path silently.
+
+## Settings
+
+These settings live in **Settings → Operon → Tasks → Task Router**, under **Inline Tasks**, **File Tasks**, and **File Task Archive**. Daily and Weekly formats, templates, folders, and container behavior live separately under **Settings → Operon → Tasks → File Tasks**.
+
+## Related
+
+- [[DOCS-001 Operon Docs MOC|Operon Docs MOC]]
+- [[DOCS-011 Inline tasks|Inline tasks]]
+- [[DOCS-013 File tasks|File tasks]]
+- [[DOCS-016 Parent and sub-tasks|Parent and sub-tasks]]
+- [[DOCS-019 Converting inline and file tasks|Converting inline and file tasks]]
+- [[DOCS-037 Pipelines and statuses|Pipelines and statuses]]
+- [[DOCS-052 Completed task review|Completed task review]]
+- [[DOCS-137 Daily and Weekly Notes|Daily and Weekly Notes]]

--- a/docs/operon-docs/DOCS-137 Daily and Weekly Notes.md
+++ b/docs/operon-docs/DOCS-137 Daily and Weekly Notes.md
@@ -1,0 +1,125 @@
+---
+Notes: Configure and use Daily and Weekly Notes as safe task destinations and optional Operon containers
+Icon: calendar-range
+Color: "#059669"
+Updated: 2026-08-21T16:12:57
+---
+
+# Daily and Weekly Notes
+
+Daily and Weekly Notes give dated work a natural home. Operon calls them **periodic notes** as a group: a Daily Note represents one date, while a Weekly Note represents one week. You can use either as the default inline destination, create missing notes from templates, and optionally make each note an Operon File Task that parents the inline tasks inside it.
+
+## When to use each
+
+Use **Daily Notes** for today's actions, meeting follow-ups, and work that belongs to one calendar date. Use **Weekly Notes** for reviews, plans, and work that should stay visible across a week.
+
+Task Router decides whether new inline tasks go to Daily or Weekly Notes. The settings on this page decide how those notes are named, found, and created. See [[DOCS-136 Task Router|Task Router]].
+
+## Daily Notes management
+
+Turn on **Manage Daily Notes with Operon** to use Operon's Daily format, template, and folder. When it is off, Operon continues to use the Core Daily Notes plugin's configuration when that plugin is available.
+
+The default Operon Daily format is `YYYY-MM-DD`. The format controls the note path only; task date fields are still stored as ISO dates such as `2026-08-21`.
+
+Daily Notes therefore have two supported configuration sources:
+
+- **Operon-managed**: Operon's format, template, and folder.
+- **Core fallback**: Obsidian Daily Notes configuration when Operon management is off.
+
+## Weekly Notes management
+
+Turn on **Manage Weekly Notes with Operon** to make Weekly Notes available as a routed destination. Weekly Notes use their own format, template, and folder and do not depend on Core Daily Notes.
+
+The weekly path and optional container identity are anchored to the week's ISO Monday. The actual routed date is still kept for placement inside the note, so a task for Thursday goes under Thursday's linked-date heading rather than Monday's.
+
+## Formats, folders, and templates
+
+Daily and Weekly settings are independent. Each has:
+
+- a Moment-style filename format;
+- an optional Markdown template;
+- a vault-relative destination folder;
+- a **Create as Operon Task** toggle.
+
+For example, a Daily format of `YYYY/MM/YYYY-MM-DD` creates a dated folder path, while a Weekly format such as `GGGG-[W]WW` produces an ISO week name such as `2026-W34`. The preview beneath each format setting shows the path that the current pattern produces. An invalid or unsafe path is rejected.
+
+When a missing note is created, Operon uses the configured template. Existing notes are never rerendered from the template. Periodic templates are separate from the File Task template picker described in [[DOCS-024 Task templates|Task templates]].
+
+## Existing and missing notes
+
+The result depends on what already exists and whether **Create as Operon Task** is enabled:
+
+| Target state | Create as Operon Task | Result |
+|---|---:|---|
+| Existing valid periodic container | Either | Append the inline task and link it to that verified parent. |
+| Existing plain Markdown note | Either | Append the inline task without adopting the note and without a periodic parent. |
+| Missing note | On | Create the note from the template as a minimal Operon File Task, register its exact identity, append the child, and set its parent. |
+| Missing note | Off | Create a normal Markdown note from the template and append a parentless inline task. |
+
+An existing plain note is deliberately not converted into a File Task. Ambiguous, duplicate, unhealthy, stale, occupied, or otherwise unsafe targets fail closed instead of being adopted or overwritten.
+
+## Where the inline task is placed
+
+Daily Notes use the configured inline heading keyword. Operon inserts beneath the first heading containing that phrase and creates a level-two heading when none exists.
+
+Weekly Notes use a linked daily-date heading for the actual routed date, for example `## [[2026-08-20]]`. ISO Monday determines the Weekly Note path and container identity only; it does not replace the task's real date or force every task under Monday.
+
+## Parent and container behavior
+
+With **Create as Operon Task** enabled, a newly created periodic note receives the minimal File Task fields and becomes the parent of the inline task created inside it. Operon tracks that exact container identity in Plugin-owned state so a later update never guesses from a filename alone.
+
+With the toggle off, the periodic note is ordinary Markdown and its inline tasks remain parentless unless you set another relationship yourself.
+
+## Changing the scheduled date
+
+Changing `dateScheduled` may update a verified periodic parent, but it never moves the task's Markdown:
+
+- **Same day or week anchor**: keep the periodic parent.
+- **Different day or week anchor**: bind to the exact valid destination container.
+- **Clear the scheduled date**: detach a verified periodic parent and leave the task where it is.
+- **Manual parent**: keep it; Operon never silently replaces a manual relationship.
+
+The task's path, inline representation, source line, and physical locator stay unchanged. Parent realignment is a relationship update, not a copy or relocation.
+
+## Runtime and CLI routing
+
+The Runtime and CLI expose this as one typed Daily-or-Weekly intent. The CLI sends the requested task data; the Plugin remains responsible for settings, templates, placement, Markdown writes, container identity, registry state, receipts, and recovery.
+
+Compact creation uses:
+
+```sh
+operon task create "Daily review" --periodic-note daily dateScheduled::"2026-08-21"
+operon task create "Weekly review" --periodic-note weekly datetimeStart::"2026-08-21T09:00:00"
+```
+
+There is no `--route-date` command-line flag. Creation routes by explicit typed `routeDate` when a typed Runtime intent supplies one, otherwise by `dateScheduled`, the local date of `datetimeStart`, and finally the local day captured during preview. Periodic update routing is triggered only by an explicit `dateScheduled` set or clear.
+
+The CLI and live Runtime must advertise the matching periodic capability. An older or incompatible side fails closed before any note, task, setting, or registry write. See [[DOCS-125 CLI contract and discovery reference|CLI contract and discovery reference]], [[DOCS-126 Compact task syntax|Compact task syntax]], and [[DOCS-127 Everyday task commands|Everyday task commands]].
+
+Runtime preview must be deterministic and write-free. A configured periodic template containing Templater `<% ... %>` expressions is therefore refused during Runtime preview rather than executed or written raw. Use deterministic Markdown and supported Operon/Core-style template tokens for this route.
+
+## FAQ
+
+**Do I need the Core Daily Notes plugin?** Not when **Manage Daily Notes with Operon** is enabled. When it is disabled, the Core plugin supplies the fallback Daily configuration.
+
+**Do Weekly Notes use the Daily Notes plugin?** No. Operon manages Weekly formats, folders, and templates directly.
+
+**Will Operon adopt an existing plain Daily or Weekly Note?** No. It appends without converting the note or assigning it as a periodic parent.
+
+**Does rescheduling move the task to another note?** No. Only a verified periodic parent may detach or realign; the task remains at its exact source.
+
+**Can the CLI write these notes itself?** No. It sends typed intent to the Plugin, which owns every physical and persistent write.
+
+## Settings
+
+Daily and Weekly formats, templates, folders, and **Create as Operon Task** toggles live in **Settings → Operon → Tasks → File Tasks**. Choose Daily or Weekly as the normal inline destination under **Settings → Operon → Tasks → Task Router**. Daily-note field defaults remain under **Tasks → Inline Tasks**.
+
+## Related
+
+- [[DOCS-001 Operon Docs MOC|Operon Docs MOC]]
+- [[DOCS-012 Inline task syntax|Inline task syntax]]
+- [[DOCS-024 Task templates|Task templates]]
+- [[DOCS-050 Daily Notes workflows|Daily Notes workflows]]
+- [[DOCS-122 Changing tasks safely|Changing tasks safely]]
+- [[DOCS-124 Troubleshooting and recovery|Troubleshooting and recovery]]
+- [[DOCS-136 Task Router|Task Router]]

--- a/docs/operon-docs/DOCS-138 Task images and galleries.md
+++ b/docs/operon-docs/DOCS-138 Task images and galleries.md
@@ -1,0 +1,123 @@
+---
+Notes: Add one image or an ordered gallery to a task and use that media across Operon surfaces
+Icon: images
+Color: "#db2777"
+Updated: 2026-08-21T16:52:15
+---
+
+# Task images and galleries
+
+Task Image and Task Gallery attach visual references to the task itself. A single cover can make a Kanban card recognizable at a glance; an ordered gallery can keep several mockups, receipts, screenshots, or reference images with the work they belong to.
+
+These are canonical task fields, so the same values follow an inline or File Task through the Task Creator, Task Editor, chips, overlays, Tables, filters, Runtime, and CLI.
+
+## Two fields, two shapes
+
+- **Task Image** uses canonical key `taskImage` and stores one scalar **Text** value.
+- **Task Gallery** uses canonical key `taskGallery` and stores an ordered **List** of values.
+
+Task Image is the natural choice for a cover or primary image. Task Gallery is for several references whose order matters.
+
+## Supported references
+
+Each value may be:
+
+- a safe vault-relative path, such as `Assets/cover.png`;
+- a wikilink or embedded wikilink, such as `[[Assets/cover.png]]` or `![[Assets/cover.png]]`;
+- an `http://` or `https://` URL.
+
+Operon resolves the reference without fetching it merely to classify it. An unsafe or unrecognized value remains stored as text but is treated as unresolved rather than opened as a path or URL.
+
+## Gallery order and escaping
+
+An inline `taskGallery` list uses semicolons between items and preserves the first occurrence of each distinct value:
+
+```md
+{{taskGallery:: Assets/front.png; Assets/back.png; https://example.com/detail.png}}
+```
+
+Escape a literal semicolon inside one item with `\;`, and escape a literal backslash with `\\`. Empty items and later duplicates are removed when the value is normalized. Order is otherwise preserved exactly, which is why Kanban can reliably choose the first or last gallery image.
+
+## Inline and File Task storage
+
+Inline tasks use the canonical keys directly:
+
+```md
+- [ ] Prepare launch card {{operonId:: {{operonId}}}} {{taskImage:: Assets/launch-cover.png}} {{taskGallery:: Assets/front.png; Assets/back.png}}
+```
+
+File Tasks use their visible mapped property names in frontmatter. The defaults are `OperonTaskImage` and `OperonTaskGallery`, and you may rename those visible names through [[DOCS-039 Key mappings|Key mappings]] without changing the canonical fields.
+
+```yaml
+---
+OperonTaskImage: Assets/launch-cover.png
+OperonTaskGallery:
+  - Assets/front.png
+  - Assets/back.png
+  - "[[Assets/detail-closeup.png]]"
+---
+```
+
+Quote a wikilink when you place it in YAML so the square brackets are stored as the gallery value rather than interpreted as YAML collection syntax.
+
+## Editing the fields
+
+Task Creator and Task Editor provide the same task-data picker for Task Type, Task Image, and Task Gallery. Task Image accepts one reference. Task Gallery adds and orders multiple references without collapsing them into an unordered set.
+
+On compact task surfaces, Task Image and Task Gallery may appear as configured media chips. A supported reference can open its local file or external URL; an unresolved value remains visible without becoming an unsafe link. Task Wikilink Overlay uses the same configured chip behavior.
+
+## Tables
+
+Add Task Image or Task Gallery as normal editable Table columns. Detailed cells show the media reference values; Task Gallery keeps one ordered chip per item. Supported media fields can also use their compact display where available, while editing still writes back to the same canonical field.
+
+These columns are unrelated to **Task Data Type**, the read-only Table helper that says whether a task is inline or file. See [[DOCS-106 Table columns|Table columns]] and [[DOCS-112 Table cells display and behavior|Table cells: display and behavior]].
+
+## Kanban card images
+
+A Kanban preset can choose one card image source:
+
+- **None**: show no card image.
+- **Task Image**: use `taskImage`.
+- **Task Gallery First**: use the first resolved gallery item.
+- **Task Gallery Last**: use the last resolved gallery item.
+
+The source changes what the card displays; it does not rewrite Task Image or reorder Task Gallery. If the selected value is empty or unresolved, the card has no image from that source.
+
+## Runtime and CLI parity
+
+Runtime V1 and the CLI treat the fields by their canonical shapes:
+
+- `taskType`: Text
+- `taskImage`: Text
+- `taskGallery`: ordered List
+
+Create, update, and read preserve the scalar/list distinction and gallery order. The internal `__taskDataType` helper is Table-only, absent from the writable Runtime catalog, and rejected as CLI input. See [[DOCS-125 CLI contract and discovery reference|CLI contract and discovery reference]] and [[DOCS-126 Compact task syntax|Compact task syntax]].
+
+## FAQ
+
+**Should I put several values in Task Image?** No. Task Image is scalar. Use Task Gallery for multiple references.
+
+**Does Task Gallery sort my images?** No. It preserves your order after removing empty values and duplicate later occurrences.
+
+**Can I use a web image?** Yes, with an HTTP or HTTPS URL.
+
+**Does adding media copy the file?** No. The field stores a reference; it does not duplicate the asset.
+
+**Is Task Data Type another media or Task Type field?** No. It is a read-only Table helper for inline-versus-file identity.
+
+## Settings
+
+Visible property names and icons for Task Image and Task Gallery live under **Settings → Operon → Core → Keymapping**. Chip visibility and order are configured per surface under **Interface → Task Chips**. Kanban card image source belongs to each Kanban preset.
+
+## Related
+
+- [[DOCS-001 Operon Docs MOC|Operon Docs MOC]]
+- [[DOCS-012 Inline task syntax|Inline task syntax]]
+- [[DOCS-018 Task properties|Task properties]]
+- [[DOCS-020 Task Creator|Task Creator]]
+- [[DOCS-021 Task Editor|Task Editor]]
+- [[DOCS-030 Kanban overview|Kanban overview]]
+- [[DOCS-041 Task chips display and behavior|Task chips: display and behavior]]
+- [[DOCS-103 Task Wikilink Overlay|Task Wikilink Overlay]]
+- [[DOCS-106 Table columns|Table columns]]
+- [[DOCS-112 Table cells display and behavior|Table cells: display and behavior]]

--- a/docs/operon-docs/manifest.json
+++ b/docs/operon-docs/manifest.json
@@ -9,8 +9,8 @@
   "files": [
     {
       "path": "DOCS-001 Operon Docs MOC.md",
-      "sha256": "52d83da1a3a3526d99603f7005301097e4c53c426400de6f3f4e48ea004df008",
-      "bytes": 10585
+      "sha256": "b99c02f71c9570db5ad45845ffa45150d645619d261cc33274fddf72728e2299",
+      "bytes": 10752
     },
     {
       "path": "DOCS-002 How to use these docs.md",
@@ -44,8 +44,8 @@
     },
     {
       "path": "DOCS-008 Essential settings to configure first.md",
-      "sha256": "34b471f98c6e793d1ee7dcfce9b4d52380693d2e53202cfbde96c1d06bf8fadf",
-      "bytes": 3412
+      "sha256": "f320de88e93e7ed5ead409fee6d3ccc35133cc0593e712335c9fff3260c54129",
+      "bytes": 3652
     },
     {
       "path": "DOCS-009 Create your first task.md",
@@ -59,18 +59,18 @@
     },
     {
       "path": "DOCS-011 Inline tasks.md",
-      "sha256": "fe104156e38d6d3c641231cdcded07127775c16511a51169d3dc4b8498837d21",
-      "bytes": 3975
+      "sha256": "762ade18d8684ef38ccfa11566a43970e6b476c45328972169213a644b2e6302",
+      "bytes": 4107
     },
     {
       "path": "DOCS-012 Inline task syntax.md",
-      "sha256": "5c8f0142f676a95556b2117b08fa3cc79c1cf41434d3b9975b29a87e176d222c",
-      "bytes": 15147
+      "sha256": "fc26120e9a66a2ddb53bd5dd9a3474cac2de4955e2dbe560742cd0770fd0720a",
+      "bytes": 15784
     },
     {
       "path": "DOCS-013 File tasks.md",
-      "sha256": "83662cf6ed01b9eeef8562e94e5d9b2b34b9150d3e22813982a5eee6ee1bdf1b",
-      "bytes": 5916
+      "sha256": "185dd534db95a44a523917f5cd7566bac991e668d584d99413119ff247fcd5a7",
+      "bytes": 6308
     },
     {
       "path": "DOCS-014 Inline vs file tasks.md",
@@ -94,23 +94,23 @@
     },
     {
       "path": "DOCS-018 Task properties.md",
-      "sha256": "973c01deee7fa2b311fcf95079291b537f6be6203089485f0f5c037ff318905b",
-      "bytes": 5130
+      "sha256": "1c08377f09772c8cbea267bd7c080ece6024438dec19e5545ebb69cafe764d30",
+      "bytes": 5830
     },
     {
       "path": "DOCS-019 Converting inline and file tasks.md",
-      "sha256": "6e1facc61ee37585c8c98dfc02292fb7f66321eba0da0e73fd40ae8b2003b00d",
-      "bytes": 5505
+      "sha256": "6f435cd903a244316eb4ef4c95ffa9ec8802d6c3485940313f43a368d211eb00",
+      "bytes": 5940
     },
     {
       "path": "DOCS-020 Task Creator.md",
-      "sha256": "6d8877ad9b91ad089adc96130422d51d9d7b0384b864efe6c281a3db1ff4c53e",
-      "bytes": 5401
+      "sha256": "337c96dd4dda0084d45c22a36bf06fd5bb93b109750e1aa27443e0735a4f3723",
+      "bytes": 5789
     },
     {
       "path": "DOCS-021 Task Editor.md",
-      "sha256": "19ea6dada318b869fb0b46eca58d229fe987b3ff96a4c30c9ee79b3cfff8803a",
-      "bytes": 7556
+      "sha256": "671ecc5b0e6c64fdcf830c08e50f12ff018132ef4bf1ae9203d23206058bf340",
+      "bytes": 7817
     },
     {
       "path": "DOCS-022 Command palette reference.md",
@@ -124,8 +124,8 @@
     },
     {
       "path": "DOCS-024 Task templates.md",
-      "sha256": "26f29b665bd559f79fd9f69459c66d1a951accf593960657d0e06d9672c888df",
-      "bytes": 6618
+      "sha256": "bdbbafb9a02da18a00bb55bb020c6283b68848cc04323e97ba779709f1ceaea0",
+      "bytes": 7033
     },
     {
       "path": "DOCS-025 Filter View.md",
@@ -154,8 +154,8 @@
     },
     {
       "path": "DOCS-030 Kanban overview.md",
-      "sha256": "340d01c3e7470e38d4afb5d45465b2c075c6e984bff675af1583e1d32ba2f2a1",
-      "bytes": 10172
+      "sha256": "bb355817799859dcd993763d7ff324b3462a18ba2005142745b2376d4a5ce73c",
+      "bytes": 10653
     },
     {
       "path": "DOCS-031 Kanban manual order.md",
@@ -189,8 +189,8 @@
     },
     {
       "path": "DOCS-037 Pipelines and statuses.md",
-      "sha256": "d9b91c0486f4199d5cc4f1e95a671847cc4dfc5d50d4d3b45f02a7a493a441cd",
-      "bytes": 6764
+      "sha256": "98aae7ee9188da8b9b08ac3b1ce0c181ba06d9fe47e0881f7d9b228a081bed10",
+      "bytes": 7201
     },
     {
       "path": "DOCS-038 Task priorities.md",
@@ -209,8 +209,8 @@
     },
     {
       "path": "DOCS-041 Task chips display and behavior.md",
-      "sha256": "93b7e3b53c3fb84131cf245850fa92342b2c22088ae0cf61c805cf577a57b7ea",
-      "bytes": 11735
+      "sha256": "a7bf4fca96ac00d1ecad8366b7754bd7eac73fbf35c4feba52696a0dcb68a96f",
+      "bytes": 12005
     },
     {
       "path": "DOCS-042 Contextual menu actions.md",
@@ -234,8 +234,8 @@
     },
     {
       "path": "DOCS-046 Plugin data and state files.md",
-      "sha256": "6d0a477cfa4964cdfd91b9a5248d9389e2f872c9524b81e8435b946a230e57f3",
-      "bytes": 3436
+      "sha256": "a343974e642e9f46bf250c37d620e2d988f661a1eaddb469d3dcea28bee87b33",
+      "bytes": 3926
     },
     {
       "path": "DOCS-047 Sync conflict safety.md",
@@ -254,8 +254,8 @@
     },
     {
       "path": "DOCS-050 Daily Notes workflows.md",
-      "sha256": "2ea8c36f45f2f0a96ccc20f56834eb2424d848f74568e705d159b16a1970781e",
-      "bytes": 4984
+      "sha256": "808e06464bc5f176c032529c1048b054e470baebc9c194b621cd8af2792c03d2",
+      "bytes": 4770
     },
     {
       "path": "DOCS-051 Templater and QuickAdd workflows.md",
@@ -264,8 +264,8 @@
     },
     {
       "path": "DOCS-052 Completed task review.md",
-      "sha256": "c2fa49c224fcf90a69ed1bb82adf04bd0c573d34fd9a1c167ff02a07ab9ead1b",
-      "bytes": 3099
+      "sha256": "44a16f3efe16bb5902697d194e3ecf36024c9901f84bdb43ee119168a0111a2b",
+      "bytes": 3106
     },
     {
       "path": "DOCS-053 Time session history.md",
@@ -474,8 +474,8 @@
     },
     {
       "path": "DOCS-094 How to create a task with Task Creator.md",
-      "sha256": "74f909ae467a8832d23b0acce39412ccb207dd553f9de2640714fcbb9f234564",
-      "bytes": 8994
+      "sha256": "8deb68579479b516bee2ec49d70a67f6febc9a693a53e90d8ffe8918cdd01f98",
+      "bytes": 8952
     },
     {
       "path": "DOCS-095 Calendar Task Pool.md",
@@ -519,8 +519,8 @@
     },
     {
       "path": "DOCS-103 Task Wikilink Overlay.md",
-      "sha256": "e2a30a4fbcbeda2560efaf0ce75c5234b197033f5313bd2005ee8b299514b3be",
-      "bytes": 7139
+      "sha256": "99564b57a612e3b9b9dc7a5f4187531f008d1bcb81ea02e232044cf9f088df70",
+      "bytes": 7358
     },
     {
       "path": "DOCS-104 Add Task Wikilink Overlay.md",
@@ -529,13 +529,13 @@
     },
     {
       "path": "DOCS-105 Table overview.md",
-      "sha256": "12649bda5fdc38ecc7856a1c415851e75e5b1d5cbf3d85498a5aca6eee199458",
-      "bytes": 11224
+      "sha256": "198b44c654fe6bb4fe9034c5962bfc69b464481e02251cef01314c04ac77723d",
+      "bytes": 11342
     },
     {
       "path": "DOCS-106 Table columns.md",
-      "sha256": "d09985cb3629efc06aa4243fbd04814759a73522a951dfe42a8b0487f8f2c5de",
-      "bytes": 13077
+      "sha256": "1703b92ccf60cab68fa3b371f61e65d8e25d74aae046b241f77a2bd32521f503",
+      "bytes": 13152
     },
     {
       "path": "DOCS-107 Table grouping and sorting.md",
@@ -549,8 +549,8 @@
     },
     {
       "path": "DOCS-109 Table presets.md",
-      "sha256": "b2e5d53edf2b0c86db97f9c098e6ba49d235c02825d7b2f83e65cca011c0c546",
-      "bytes": 8634
+      "sha256": "efc8a04f0e240edabf5caea4c569608ef96aed2aeda10a9cd8b69aa94e009390",
+      "bytes": 8736
     },
     {
       "path": "DOCS-110 Embed a table in a note.md",
@@ -559,13 +559,13 @@
     },
     {
       "path": "DOCS-111 Export a table.md",
-      "sha256": "a8c93c3509107bcff403e737d1a507131b7d02d253ed130b864a683390847d68",
-      "bytes": 4440
+      "sha256": "513bec6215e1522d9d1b54f969dfdc432ba970f2650b82d88dbd854166fb6cd7",
+      "bytes": 4445
     },
     {
       "path": "DOCS-112 Table cells display and behavior.md",
-      "sha256": "3399d8a54e931570d727a1fdacb62ec8cd730e99b47134b85b351b7c2fd177b8",
-      "bytes": 12376
+      "sha256": "ada75743bc43706d7c1c9042aca9396be8253778b5429a6ab5cc1ccdc3da29a0",
+      "bytes": 12626
     },
     {
       "path": "DOCS-113 Text field editor popover.md",
@@ -594,8 +594,8 @@
     },
     {
       "path": "DOCS-118 Operon Agent Runtime overview.md",
-      "sha256": "dc9d8beb8eb1556a8f8bf4b65aca884ff6bab6f490e1dbd292b2875eb6eb5bc2",
-      "bytes": 9747
+      "sha256": "cbb5b7b8986f0f2d241e7dd1a4cf916501b2f72bca4c241a6d8af8e0eb8b32c4",
+      "bytes": 10180
     },
     {
       "path": "DOCS-119 Install and verify Operon CLI.md",
@@ -614,8 +614,8 @@
     },
     {
       "path": "DOCS-122 Changing tasks safely.md",
-      "sha256": "c9c43f16ce1a7b7cb730ef88649cb4620d0f53d2583102f0398f7c5ff267c13a",
-      "bytes": 10438
+      "sha256": "7df190cb5f9d62a47f51ae62d4d1d25411d7231484501d04c141529bf716177d",
+      "bytes": 10935
     },
     {
       "path": "DOCS-123 Security and trust boundaries.md",
@@ -624,23 +624,23 @@
     },
     {
       "path": "DOCS-124 Troubleshooting and recovery.md",
-      "sha256": "7112ff31ec58b623b8e99de266f754b4022fd4a8df4c33e5b29657c834aa000e",
-      "bytes": 12603
+      "sha256": "5cc9912c67b923961360ee47da85916620f5dcd7e78fe98ffcd2705cf31b332a",
+      "bytes": 13102
     },
     {
       "path": "DOCS-125 CLI contract and discovery reference.md",
-      "sha256": "18a824fb8e3c5f4fca107ebeda043ec2c48cc63d5f16a27b8cc831fd8674f7df",
-      "bytes": 9932
+      "sha256": "1134345920963fc90ac3331a3c5450ed6da57cc2d852248da0fd17cb73e82049",
+      "bytes": 10555
     },
     {
       "path": "DOCS-126 Compact task syntax.md",
-      "sha256": "e58746e5cb408021e7b710bcdf8311a3cce907d6ca8bc4d60be3213a0a247235",
-      "bytes": 12798
+      "sha256": "3153c414fa2bc27d9f08f2da8cdbfcd0660bc6b36e3c6b47208b940a6f40ad53",
+      "bytes": 14279
     },
     {
       "path": "DOCS-127 Everyday task commands.md",
-      "sha256": "2374e4c34b745086b3d626c6d6d1c98d17114175b2dbd4bc528386653ff18ea0",
-      "bytes": 10987
+      "sha256": "42750e521f3b3386cce2e4a3fa66e617dce44920d35846b73a998e76e50a7462",
+      "bytes": 11546
     },
     {
       "path": "DOCS-128 Interactive shell and discovery.md",
@@ -649,23 +649,23 @@
     },
     {
       "path": "DOCS-129 In-process Developer API overview.md",
-      "sha256": "0d5c6e2787e62cfed7cf5d79eb9a05248d378bcf16d5d8f61686b93a8844e1ed",
-      "bytes": 8357
+      "sha256": "3e4a2e7aa13e8c3e6082e1262be83b785495d6d5b96e07440e1e4a7ab7e4d1a8",
+      "bytes": 8637
     },
     {
       "path": "DOCS-130 Developer API identity and capability grants.md",
-      "sha256": "6377128a276937c3b5655cca2e102c2bd65f93fad59f8552a60763a27774d2e1",
-      "bytes": 8041
+      "sha256": "5d3a9e9d29c838d19c969a1f4626513de6d80a88a2147d14ddc59da3be9f9cf5",
+      "bytes": 8644
     },
     {
       "path": "DOCS-131 Developer API reads and typed mutations.md",
-      "sha256": "4fef69bd51829805cc0b2782806790a29b245b4505e2e63389dfdb5772d821d9",
-      "bytes": 8390
+      "sha256": "1116752a4ba206a995fae54358ca51a34efc2687cd105fc96399a9266ac1ac64",
+      "bytes": 10019
     },
     {
       "path": "DOCS-132 Developer API recovery, errors and audit.md",
-      "sha256": "f1200cc488541c13c1ae1e6ed3b1dfcf53f4e7c93d891ad4e9f6265217e51136",
-      "bytes": 8202
+      "sha256": "b47788f3ecb6746124b6c37a5bb20acca5de89f9756abb2cb58392e6188dcf08",
+      "bytes": 9353
     },
     {
       "path": "DOCS-133 JSONL sessions for scripts and agents.md",
@@ -681,7 +681,22 @@
       "path": "DOCS-135 Convert task to plain.md",
       "sha256": "17c473d6d10557a41cb3c0c7378bb49085c59278b14d329e2e5c0ebf09555db2",
       "bytes": 6058
+    },
+    {
+      "path": "DOCS-136 Task Router.md",
+      "sha256": "eea341eceba14b4457d29dc0429418f1083539e95e526638d4a8b3b400e80f55",
+      "bytes": 7250
+    },
+    {
+      "path": "DOCS-137 Daily and Weekly Notes.md",
+      "sha256": "7c1693b7b14d0197655e788a7f2f01c257b2630722d784475afb4df82fdeb536",
+      "bytes": 8260
+    },
+    {
+      "path": "DOCS-138 Task images and galleries.md",
+      "sha256": "897a383708e1cedd61c267794a07b3177b60a9f7600e4ac81f0046d51172cc61",
+      "bytes": 6161
     }
   ],
-  "generatedAt": "2026-08-18T16:46:22.632Z"
+  "generatedAt": "2026-08-21T14:57:42.743Z"
 }


### PR DESCRIPTION
## Summary
- update 33 generated Operon documentation pages
- add Task Router, Daily and Weekly Notes, and Task images and galleries documentation
- regenerate the exact 138-document manifest
- preserve the existing media package without additions, changes, or deletions

## Validation
- Operon docs sync runtime tests passed
- generated docs package tests passed 3/3
- generated package is byte-identical to the approved source documents
- docs/media scope guard passed with no blocked files
- git diff --check passed