### PR TITLE
Update W008 Operon documentation

### DIFF
--- a/docs/operon-docs/DOCS-030 Kanban overview.md
+++ b/docs/operon-docs/DOCS-030 Kanban overview.md
@@ -2,7 +2,7 @@
 Notes: Move tasks through status columns on the Kanban
 Icon: columns-3
 Color: "#0284c7"
-Updated: 2026-08-21T16:12:57
+Updated: 2026-08-23T10:58:57
 ---
 
 # Kanban overview
@@ -21,7 +21,7 @@ The columns come from your pipeline: each status in the pipeline is a column, an
 
 You can also split the board into **swimlanes**, horizontal rows that group cards by another field such as priority, assignee, context, or a date. With swimlanes on, each card sits where its status column meets its lane, which is how you see, say, what is in progress *per person* or *per priority* at a glance. See [[DOCS-074 Kanban swimlanes|Kanban swimlanes]].
 
-A board is shaped by a **Kanban preset**, which chooses the pipeline, the swimlane field, the sort order, the card color source, and an optional filter that limits which tasks appear. Saving presets lets you keep several boards for different pipelines or slices of work, and switch between them. See [[DOCS-037 Pipelines and statuses|Pipelines and statuses]].
+A board is shaped by a **Kanban preset**, which chooses the pipeline, the swimlane field, the sort order, the card color source, and an optional filter that limits which tasks appear. **Board sorting** is the fallback order for every column. **Pipeline column sorting** can override that fallback for selected status columns, so Automatic and Manual columns can coexist on the same board. Saving presets lets you keep several boards for different pipelines or slices of work, and switch between them. See [[DOCS-031 Kanban manual order|Kanban manual order]] and [[DOCS-037 Pipelines and statuses|Pipelines and statuses]].
 
 The toolbar's center holds one button per **favorite** preset, favorite any preset from its **Edit preset** settings or its row in **Settings → Operon → Views → Kanban**, so your most-used boards are one click away. A picker button beside them opens a searchable list of every preset, favorite or not, and picks up a calm accent when the active preset is not itself a favorite. On a narrow pane the favorite buttons wrap to a second row; on mobile a plain preset dropdown takes over instead.
 
@@ -78,7 +78,7 @@ If your work is mostly date-driven rather than stage-driven, the [[DOCS-028 Cale
 
 ## Card order
 
-Within a column you can arrange cards in a deliberate order rather than an automatic one, which is useful for expressing priority or sequence by hand. See [[DOCS-031 Kanban manual order|Kanban manual order]].
+Within a column, Operon uses that column's effective sorting: its own Pipeline column override when one exists, otherwise Board sorting. Automatic rules can sort by fields such as priority, dates, or **Project Serial**; Manual mode keeps the deliberate order you set by dragging. With swimlanes, the same effective column rule is applied independently inside each status-and-lane cell. See [[DOCS-031 Kanban manual order|Kanban manual order]].
 
 ## Searching the board
 
@@ -92,7 +92,7 @@ The important part: **these scopes filter the board on their own, with or withou
 
 ### It narrows the board, it does not flatten it
 
-However you filter, by text, by scope, or both, the Kanban stays a board. Matching cards remain in their status columns and swimlanes, in their normal order; the non-matching ones simply drop away. You never get a flat list of results: you get the same board showing fewer cards. That keeps the structure you are planning against intact while you focus on a slice of it.
+However you filter, by text, by scope, or both, the Kanban stays a board. Matching cards remain in their status columns and swimlanes, in their normal Kanban order; the non-matching ones simply drop away. A saved filter decides which cards qualify, but any presentation sorting attached to that filter does not replace Board sorting or Pipeline column sorting. You never get a flat list of results: you get the same board showing fewer cards. That keeps the structure you are planning against intact while you focus on a slice of it.
 
 For exactly which fields are matched and how Task Finder ranks its own results, see [[DOCS-027 Task Finder|Task Finder]].
 

--- a/docs/operon-docs/DOCS-031 Kanban manual order.md
+++ b/docs/operon-docs/DOCS-031 Kanban manual order.md
@@ -1,33 +1,37 @@
 ---
-Notes: Arrange cards by hand within a Kanban column
+Notes: Set board-wide fallback sorting and per-column Kanban order
 Icon: list-ordered
 Color: "#0284c7"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-23T10:58:57
 ---
 
 # Kanban manual order
 
-Inside a [[DOCS-030 Kanban overview|Kanban]] column, cards can sit in an order you set by hand rather than one Operon computes. Manual order lets you express priority or sequence that no single field captures: the next three things to do, in the order you will do them. It is a per-board choice, so some boards can sort automatically while others stay hand-arranged.
+Inside a [[DOCS-030 Kanban overview|Kanban]] column, cards can follow automatic rules or an order you set by hand. Every preset has a permanent **Board sorting** fallback, and selected status columns can have their own **Pipeline column sorting** override. This lets one board mix automatic columns with hand-arranged columns.
 
-## Two order modes
+## Board sorting and column overrides
 
-A board orders the cards in each column one of two ways:
+**Board sorting** supplies the mode and rules for every column that has no override. Under **Pipeline column sorting**, choose a pipeline status and add an override for that column. A new override starts as an independent copy of the current Board sorting; changing it does not change the fallback or another column. A status can be added only once, and removing its override immediately returns that column to Board sorting.
+
+At either level, the order mode is:
 
 - **Automatic**: Operon sorts the cards by rules you define, such as priority then due date. The order updates itself as tasks change.
 - **Manual**: cards keep the exact order you set by dragging them inside a column. Operon does not re-sort them.
 
-You pick the mode per board, as part of its Kanban preset. See [[DOCS-030 Kanban overview|Kanban overview]].
+Automatic rules can use task fields such as priority, dates, text, or **Project Serial**. Each column resolves its own effective mode and rules, so an Automatic source column and a Manual target column behave independently during a drag.
 
 ## Setting a manual order
 
-With manual order on, drag a card up or down within its column to place it. The position you give it sticks, so the column reads top to bottom as the sequence you intend. Moving a card to another column still changes its `status`, as always; manual order is about position within a column, not which column it is in. See [[DOCS-037 Pipelines and statuses|Pipelines and statuses]].
+With Manual mode effective for a column, drag a card up or down to place it. The position you give it sticks, so the column reads top to bottom as the sequence you intend. When a column first becomes Manual, Operon uses its current visible order as the starting order.
+
+Moving a card to another column still changes its `status`, as always. A Manual target keeps the insertion position you chose; an Automatic target re-sorts the card by that column's rules. When swimlanes are active, manual order is kept separately for each preset, status column, and swimlane cell. See [[DOCS-037 Pipelines and statuses|Pipelines and statuses]] and [[DOCS-074 Kanban swimlanes|Kanban swimlanes]].
 
 ## When to use which
 
 - **Automatic** suits boards where a rule already captures what matters, like priority or deadline. See [[DOCS-038 Task priorities|Task priorities]].
 - **Manual** suits boards where the order is a judgment call: a plan of attack, a publishing sequence, a triage line.
 
-Many people mix both across different boards, automatic where a field decides and manual where they do.
+You can mix both across different boards and across columns of the same board: automatic where a field decides and manual where you do.
 
 ## FAQ
 
@@ -35,11 +39,11 @@ Many people mix both across different boards, automatic where a field decides an
 
 **Does dragging a card change its status?** Only when you move it to another column. Reordering within the same column keeps the status and just changes position.
 
-**Can one board be manual and another automatic?** Yes. Order mode is set per board through its Kanban preset.
+**Can one column be Manual while another is Automatic?** Yes. Add a Pipeline column sorting override for the column that should differ. Columns without an override continue to use Board sorting.
 
 ## Settings
 
-Operon settings for this live in **Settings → Operon → Views → Kanban**, where each board's preset sets the order mode (Automatic or Manual) and, for automatic boards, the sort rules.
+Operon settings for this live in **Settings → Operon → Views → Kanban** and in the Kanban preset's quick settings. **Board sorting** defines the fallback. **Pipeline column sorting** adds, edits, or removes overrides for individual pipeline statuses.
 
 ## Related
 

--- a/docs/operon-docs/DOCS-041 Task chips display and behavior.md
+++ b/docs/operon-docs/DOCS-041 Task chips display and behavior.md
@@ -2,7 +2,7 @@
 Notes: The compact field badges on tasks, their per-surface order and visibility, and how each behaves on click and hover
 Icon: tags
 Color: "#ca8a04"
-Updated: 2026-08-21T16:12:57
+Updated: 2026-08-23T10:58:57
 ---
 
 # Task chips: display and behavior
@@ -75,8 +75,15 @@ On interactive surfaces, clicking a chip does something specific to its field. S
 | Tags | Opens Obsidian's tag search for that tag |
 | Links | Opens the external link |
 | Location | Opens the map popover (see below) |
+| Task Image, Task Gallery | Opens a supported local file or external URL; hovering previews the image |
 
 So status, priority, dates, estimate, and repeat let you change the value on the spot, while the link, tag, and location chips take you somewhere.
+
+## Task media preview and lightbox
+
+Plain-hover a **Task Image** or **Task Gallery** chip to see the image without leaving the task. Local vault images and HTTP or HTTPS images use the same compact Operon preview, rather than switching local files into Obsidian's Page Preview frame.
+
+The preview's top-left zoom button, or a double-click on the image, opens a centered Operon lightbox. Its header shows the local image label or file name, or the HTTP address, and provides a close button. You can also close it with **Escape** or by clicking the backdrop. Use a trackpad pinch or **Cmd/Ctrl + wheel** to zoom, double-click to toggle zoom, and drag or scroll to pan while zoomed. The lightbox is for viewing only; it does not edit the field or gallery order. See [[DOCS-138 Task images and galleries|Task images and galleries]].
 
 ## Wikilink chips: open and preview
 

--- a/docs/operon-docs/DOCS-044 Where Operon stores data.md
+++ b/docs/operon-docs/DOCS-044 Where Operon stores data.md
@@ -2,7 +2,7 @@
 Notes: The two places Operon keeps data, all inside your vault
 Icon: database
 Color: "#0891b2"
-Updated: 2026-08-12T17:21:45
+Updated: 2026-08-23T10:58:57
 ---
 
 # Where Operon stores data
@@ -21,7 +21,7 @@ This is the data you most care about, and it stays plain text you own.
 
 Operon's own configuration and working state (key mappings, pipelines, priorities, saved filters, Calendar and Kanban presets, and similar) live in the plugin's data files under `.obsidian/plugins/operon/`, not mixed into your notes. This is settings and bookkeeping, not your tasks. If it were lost, you would lose preferences and have to reconfigure, but your tasks would be untouched in your notes. See [[DOCS-046 Plugin data and state files|Plugin data and state files]].
 
-**Table presets are the one exception.** Each saved table is also its own `.table` file inside your vault, not only an entry in the plugin's data, so it moves, renames, and backs up as a vault file in its own right. Calendar, Kanban, and saved Filter presets are unaffected; they still live in the plugin's data as described above. See [[DOCS-114 Table files|Table files]].
+**Table presets are the one exception.** A Table preset is its `.table` file inside your vault; the file is the preset's single source of truth. Operon keeps only small derived bookkeeping in plugin data so it can preserve order, favorites, and the current default, and rebuilds that bookkeeping from the valid `.table` files it finds. Calendar, Kanban, and saved Filter presets are unaffected; they still live in the plugin's data as described above. See [[DOCS-114 Table files|Table files]].
 
 ## Why the split matters
 

--- a/docs/operon-docs/DOCS-046 Plugin data and state files.md
+++ b/docs/operon-docs/DOCS-046 Plugin data and state files.md
@@ -2,7 +2,7 @@
 Notes: Where Operon keeps its settings, working state, and rebuildable index
 Icon: folder-cog
 Color: "#0891b2"
-Updated: 2026-08-21T16:12:57
+Updated: 2026-08-23T10:58:57
 ---
 
 # Plugin data and state files
@@ -13,7 +13,7 @@ Apart from your tasks, which live in your Markdown, Operon keeps its own configu
 
 The plugin's main data file holds your Operon configuration: [[DOCS-039 Key mappings|key mappings]], [[DOCS-037 Pipelines and statuses|pipelines]], [[DOCS-038 Task priorities|priorities]], saved [[DOCS-025 Filter View|filters]], Calendar and Kanban presets, contextual menu setup, and the rest of your settings.
 
-**Table presets are the exception.** Each one lives as its own `.table` file in your vault rather than inside the plugin's data. **Settings → Operon → Views → Tables → Table default folder** chooses where *new* Table files are created. The historical default is `Operon/Tables`; choose another vault-relative folder to organize new files elsewhere, or leave the setting blank to create them at the vault root. Changing it never moves existing `.table` files. The plugin's data still records small bookkeeping about presets, such as their order and which one is the default, but the preset itself is the vault file. See [[DOCS-114 Table files|Table files]].
+**Table presets are the exception.** Each preset is a `.table` file in your vault rather than a preset stored in the plugin's settings. **Settings → Operon → Views → Tables → Table default folder** chooses where *new* Table files are created. The historical default is `Operon/Tables`; choose another vault-relative folder to organize new files elsewhere, or leave the setting blank to create them at the vault root. Changing it never moves existing `.table` files. The plugin's data records only derived bookkeeping such as valid file bindings, order, favorites, and the default. Operon reconciles that bookkeeping from the valid, uniquely identified `.table` files at startup, drops stale Settings-only references, and creates a fresh default Table file when no valid preset remains. See [[DOCS-114 Table files|Table files]].
 
 Alongside it, Operon keeps working state and caches in subfolders:
 

--- a/docs/operon-docs/DOCS-074 Kanban swimlanes.md
+++ b/docs/operon-docs/DOCS-074 Kanban swimlanes.md
@@ -2,7 +2,7 @@
 Notes: Split the Kanban into horizontal lanes by a second field
 Icon: rows-3
 Color: "#0284c7"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-23T10:58:57
 ---
 
 # Kanban swimlanes
@@ -21,6 +21,8 @@ Keep the two axes separate in your head:
 - **Swimlanes** come from a field you choose, one lane per value of that field.
 
 A card lands in the column for its status and the lane for its swimlane value, so "high priority, in progress" is one cell of the grid. Moving a card between columns changes its status as usual; the lane reflects the swimlane field.
+
+Sorting is resolved per status column and then applied independently inside each swimlane cell. A Pipeline column sorting override wins for that column; otherwise the cell uses Board sorting. Manual order is therefore kept separately for each status-and-lane intersection rather than as one list for the whole board. See [[DOCS-031 Kanban manual order|Kanban manual order]].
 
 ## Choosing the swimlane field
 
@@ -58,7 +60,7 @@ When you only care about status, leave the swimlane field empty and the board st
 
 ## FAQ
 
-**Do swimlanes change a task's data?** No. Lanes are a grouping of the same cards by a field. Moving a card between columns still changes status; the lane just reflects the swimlane field's value.
+**Do swimlanes change a task's data?** Merely showing or grouping lanes does not. Dragging a card into a different lane does change the grouped field, just as moving it to another column changes status. One drag can change both.
 
 **Can two boards group differently?** Yes. The swimlane field is saved per preset, so each board can group by its own field.
 

--- a/docs/operon-docs/DOCS-097 Project serials.md
+++ b/docs/operon-docs/DOCS-097 Project serials.md
@@ -2,7 +2,7 @@
 Notes: Read-only sequential serial IDs assigned to the tasks in a project tree
 Icon: hash
 Color: "#7c3aed"
-Updated: 2026-07-23T16:45:34
+Updated: 2026-08-23T10:58:57
 ---
 
 # Project serials
@@ -82,6 +82,8 @@ When you add or rename a scope that **overlaps** another tree or **reuses a pref
 A serial appears as a display-only **chip** on supported task surfaces: in [[DOCS-041 Task chips display and behavior|reading view and Live Preview]], on rows in the [[DOCS-025 Filter View|Filter View]], on main cards in the [[DOCS-030 Kanban overview|Kanban]], in the [[DOCS-021 Task Editor|Task Editor]], and in the calendar task picker. There is nothing to click to edit, and nothing is written into the task text.
 
 It can also be its own read-only column on the [[DOCS-105 Table overview|Table]], where it searches, groups, sorts, and exports like any other column. See [[DOCS-106 Table columns|Table columns]].
+
+On the [[DOCS-030 Kanban overview|Kanban]], **Project Serial** is also available as an Automatic sort field in both Board sorting and Pipeline column sorting. Operon compares the two-part identity naturally: the prefix alphabetically without case sensitivity, then the numeric serial as a number. Tasks without a serial follow the rule's **First** or **Last** empty-value choice.
 
 ## Grouping and filtering by serial group
 

--- a/docs/operon-docs/DOCS-109 Table presets.md
+++ b/docs/operon-docs/DOCS-109 Table presets.md
@@ -2,14 +2,14 @@
 Notes: Save a table as a preset and switch between several tables
 Icon: table-2
 Color: "#0284c7"
-Updated: 2026-08-21T16:12:57
+Updated: 2026-08-23T10:58:57
 ---
 
 # Table presets
 
 A preset saves a table layout and scope. It bundles which tasks appear, which task-field columns show and in what order, how the rows are grouped and sorted, which summaries roll up, how dense the rows are, and which search scopes are saved with the preset, all under a name. Presets are what let you keep several tables for different questions and switch between them from the toolbar, and the **default preset** is the one a new table opens with or the **Insert Operon Table embed** command uses.
 
-Each preset is also a real file in your vault, with a `.table` extension. Editing a preset here writes straight to that file. New files use the configurable **Table default folder** in **Settings → Operon → Views → Tables**: `Operon/Tables` is the historical default, and a blank setting means the vault root. Changing that destination affects only files created afterward; it does not move any existing preset. See [[DOCS-114 Table files|Table files]] for the file itself: where it lives, what happens when you rename or move it, and what a broken or duplicate file looks like.
+Each preset is a real file in your vault, with a `.table` extension. That file is the preset's single source of truth, and editing a preset here writes straight to it. Settings lists only files that parse successfully and carry a unique preset id; stale Settings-only entries and bindings whose files no longer exist are removed from the list. New files use the configurable **Table default folder** in **Settings → Operon → Views → Tables**: `Operon/Tables` is the historical default, and a blank setting means the vault root. Changing that destination affects only files created afterward; it does not move any existing preset. See [[DOCS-114 Table files|Table files]] for the file itself: where it lives, what happens when you rename or move it, and how invalid or duplicate files are reported.
 
 > **MEDIA-DOCS-109-1:** The table preset settings, with the Filtering, Grouping, Sort, Summaries, Display, and Columns sections.
 
@@ -66,6 +66,8 @@ The footer of the preset settings carries the management actions:
 | Delete | Sends the preset's file to Obsidian's Trash, disabled when only one preset remains |
 
 The footer has no "set as default" action: the **default preset** is chosen from the dropdown in **Settings → Operon → Views → Tables**, where the **Table Presets** list also has an **Add Table Preset** button, each row opens the same settings, and the current default carries a **Default** label.
+
+**Add Table Preset**, **New**, and **Duplicate** create a new `.table` file and register it as one serialized operation, so a preset that appears successfully remains available after restart. If no valid Table preset exists at startup, Operon creates a fresh `Default table.table` from the current defaults instead of converting an old Settings entry.
 
 ## The default preset and saved state
 

--- a/docs/operon-docs/DOCS-112 Table cells display and behavior.md
+++ b/docs/operon-docs/DOCS-112 Table cells display and behavior.md
@@ -2,7 +2,7 @@
 Notes: What each table cell shows and does on click, hover, and keyboard, in detailed and compact cell modes
 Icon: square-mouse-pointer
 Color: "#0284c7"
-Updated: 2026-08-21T16:12:57
+Updated: 2026-08-23T10:58:57
 ---
 
 # Table cells: display and behavior
@@ -105,6 +105,7 @@ Hovering a cell can reveal more without a click:
 - **Compact cells** show a tooltip with the field's name and its full value, so a collapsed column stays readable.
 - **Wikilinks** inside text cells and wikilink-style task link chips support **Page Preview**: hold **Cmd** or **Ctrl** and hover to get Obsidian's hover preview of the linked note. This needs Obsidian's core **Page Preview** plugin enabled, and the modifier key; a plain hover does not trigger it.
 - **Web link chips** in the Links column show their **full URL** on hover, along with a hint that a Cmd or Ctrl-click opens the link in a new Web Viewer tab.
+- **Task Image and Task Gallery chips** show the same compact image preview for local vault files and HTTP or HTTPS references. Use the preview's top-left zoom button or double-click the image to open the centered lightbox; its title, zoom, pan, and close behavior are described in [[DOCS-138 Task images and galleries|Task images and galleries]].
 
 ## How this guides configuration
 

--- a/docs/operon-docs/DOCS-114 Table files.md
+++ b/docs/operon-docs/DOCS-114 Table files.md
@@ -2,12 +2,12 @@
 Notes: How a saved table lives as its own portable .table file in your vault
 Icon: file-cog
 Color: "#0284c7"
-Updated: 2026-08-18T18:18:29
+Updated: 2026-08-23T10:58:57
 ---
 
 # Table files
 
-A [[DOCS-109 Table presets|Table preset]] is not only a setting tucked away in Operon's data. Each one is also a real file in your vault, with a `.table` extension. That file is the preset: open it, and Operon shows the same table you would get from the toolbar's preset picker. Move it, rename it, back it up, or put it under version control, and you are doing exactly what you would do with any other note. This page covers the file itself, its lifecycle, and what happens when something about it goes wrong. For what a preset holds and how you edit it day to day, see [[DOCS-109 Table presets|Table presets]].
+A [[DOCS-109 Table presets|Table preset]] is a real file in your vault, with a `.table` extension. The file is the preset's single source of truth: open it, and Operon shows the same table you would get from the toolbar's preset picker. Move it, rename it, back it up, or put it under version control, and you are doing exactly what you would do with any other note. Old Settings-only preset records and retired sidecar files are not converted back into presets. This page covers the file itself, its lifecycle, and what happens when something about it goes wrong. For what a preset holds and how you edit it day to day, see [[DOCS-109 Table presets|Table presets]].
 
 > **MEDIA-DOCS-114-1:** A `.table` file in Obsidian's file explorer, opened as a standard Operon Table view with its normal header.
 
@@ -55,7 +55,7 @@ Moving the file to another folder is just a move. Operon notices and keeps track
 
 ## Deleting a Table file
 
-Deleting a Table file, whether with **Delete** from **Edit preset** or by deleting the file itself from the file explorer, sends it to **Obsidian's Trash**, not a permanent delete. It is recoverable the same way any trashed vault file is.
+Deleting a Table file with **Delete** from **Edit preset** sends it to **Obsidian's Trash**, not a permanent delete. Deleting it yourself from the file explorer follows Obsidian's own deletion behavior. Either way, once the file is gone Operon removes its stale preset reference rather than leaving a **Missing file** card in Settings.
 
 Deleting also cleans up automatically:
 
@@ -64,22 +64,22 @@ Deleting also cleans up automatically:
 - Any open tab that was showing the deleted preset falls back to another available preset.
 - Any `operon-table` **embed** still pointed at the deleted preset shows **Table preset not found** until you point it at a different one. See [[DOCS-110 Embed a table in a note|Embed a table in a note]].
 
-As with presets generally, you cannot delete the last remaining Table preset; a table always has at least one to fall back to. See [[DOCS-109 Table presets|Table presets]].
+The in-app Delete action does not let you remove the last preset. If files are removed outside Operon and no valid Table preset remains, Operon creates a fresh `Default table.table` from the current defaults. It does not revive or convert an old Settings preset. See [[DOCS-109 Table presets|Table presets]].
 
 ## When a file cannot be read
 
 Opening a Table file directly can land on one of two states instead of the table itself:
 
 - **Loading**: a brief moment while Operon reads and parses the file. You should rarely notice this.
-- **Invalid**: the file could not be turned into a working preset. Operon shows the file's name, a plain-language reason for each problem found, and the file's raw text underneath, so you can see exactly what is there. It never rewrites, discards, or silently repairs an invalid file; you fix it (by hand, or by restoring an earlier version) and Operon picks it back up automatically once it parses.
+- **Invalid**: the file could not be turned into a working preset. Operon shows the file's name, a plain-language reason for each problem found, and the file's raw text underneath, so you can see exactly what is there. It never rewrites, discards, or silently repairs an invalid file. Invalid files remain on disk and appear only in file diagnostics, not in the editable Table Presets list. Fix the file by hand, or restore an earlier version, and Operon adopts it again once it parses successfully and has a unique id.
 
 A file can be invalid for any of these reasons: the text is not valid JSON; the JSON root is not an object; the `format` value is wrong; the `version` value is one Operon does not support; a required field is missing; a field has the wrong type or an invalid value; the file has a field that is not part of the current version; the file could not be read at all; or its id duplicates another Table file's id (see "Duplicate IDs" below).
 
 ## Duplicate IDs
 
-Two Table files can end up sharing the same internal id, most often from copying a `.table` file directly in your file manager instead of using **Duplicate** from the preset settings (**Duplicate** always assigns a fresh id; a raw file copy does not). When that happens, Operon does not guess which file is authoritative. Both files show as invalid until you resolve the conflict.
+Two Table files can end up sharing the same internal id, most often from copying a `.table` file directly in your file manager instead of using **Duplicate** from the preset settings (**Duplicate** always assigns a fresh id; a raw file copy does not). When that happens, Operon does not guess which file is authoritative and does not rewrite either file. The conflicting files remain on disk, appear in file diagnostics, and stay out of the editable preset list until every usable preset has a unique id.
 
-Resolve it from **Settings → Operon → Views → Tables**: the conflicted entry in the **Table Presets** list is flagged with an **ID conflict** label and offers to keep one file as the original. Choose which file keeps the existing id, and Operon assigns fresh ids to the others and renames them so they load as normal, independent Table presets, no data is lost, they simply become separate tables from that point on.
+To keep both files, edit one copy's internal id to a new unique value or recreate the copy with **Duplicate** from a healthy preset. Once the conflict is gone, Operon adopts the valid files automatically. Other healthy Table presets and General Table Settings remain available while the conflict exists.
 
 ## Wikilinks and Page Preview
 
@@ -103,11 +103,11 @@ A `.table` file is an ordinary vault file as far as Obsidian's linking is concer
 
 **What happens if I delete a Table file that is still embedded somewhere?** The file goes to Obsidian's Trash. Restore it from there to bring the preset back; otherwise, any note still embedding it shows **Table preset not found** until you point that embed at a different preset.
 
-**Two Table files ended up with the same id. What do I do?** In **Settings → Operon → Views → Tables**, the conflicted entry in the Table Presets list is flagged and lets you keep one file as the original. Choose the file that should keep the existing id; the others get new ids and are renamed automatically.
+**Two Table files ended up with the same id. What do I do?** Give one copy a new unique internal id, restore a known-good version, or recreate the copy with **Duplicate** from a healthy preset. Operon leaves both conflicting files unchanged and adopts them when their ids are unique.
 
 ## Settings
 
-Open this page from the help action beside **General Table Settings** in **Settings → Operon → Views → Tables**. Duplicate-ID conflict resolution remains in the **Table Presets** list, where each conflicted entry lets you choose which file keeps the existing id. Day-to-day renaming, duplicating, and deleting a Table file are done from **Edit preset** or the file's own context menu. See [[DOCS-109 Table presets|Table presets]].
+Open this page from the help action beside **General Table Settings** in **Settings → Operon → Views → Tables**. The Table Presets list contains only healthy file-backed presets; invalid and duplicate-id files remain available through file diagnostics without disabling healthy presets or general controls. Day-to-day renaming, duplicating, and deleting a healthy Table file are done from **Edit preset** or the file's own context menu. See [[DOCS-109 Table presets|Table presets]].
 
 ## Related
 

--- a/docs/operon-docs/DOCS-138 Task images and galleries.md
+++ b/docs/operon-docs/DOCS-138 Task images and galleries.md
@@ -2,7 +2,7 @@
 Notes: Add one image or an ordered gallery to a task and use that media across Operon surfaces
 Icon: images
 Color: "#db2777"
-Updated: 2026-08-21T16:52:15
+Updated: 2026-08-23T10:58:57
 ---
 
 # Task images and galleries
@@ -71,6 +71,14 @@ On compact task surfaces, Task Image and Task Gallery may appear as configured m
 Add Task Image or Task Gallery as normal editable Table columns. Detailed cells show the media reference values; Task Gallery keeps one ordered chip per item. Supported media fields can also use their compact display where available, while editing still writes back to the same canonical field.
 
 These columns are unrelated to **Task Data Type**, the read-only Table helper that says whether a task is inline or file. See [[DOCS-106 Table columns|Table columns]] and [[DOCS-112 Table cells display and behavior|Table cells: display and behavior]].
+
+## Preview and lightbox
+
+Hovering a Task Image or Task Gallery chip in a supported task or Table surface opens a compact image preview. Local vault files and HTTP or HTTPS images use the same Operon-owned frame, dimensions, and controls, so a local reference does not switch to a differently sized Obsidian Page Preview.
+
+Use the preview's top-left zoom button, or double-click the preview image, to open a centered lightbox. The header shows the local image label or file name, or the HTTP address, centered beside the close control. Close the lightbox with its **X**, **Escape**, or a click on the backdrop.
+
+The lightbox supports a trackpad pinch and **Cmd/Ctrl + wheel** for zooming. Double-click toggles zoom, and you can drag or scroll to pan when the image is enlarged. These actions only inspect the image: they do not edit Task Image, reorder Task Gallery, or change the underlying file.
 
 ## Kanban card images
 

--- a/docs/operon-docs/manifest.json
+++ b/docs/operon-docs/manifest.json
@@ -154,13 +154,13 @@
     },
     {
       "path": "DOCS-030 Kanban overview.md",
-      "sha256": "bb355817799859dcd993763d7ff324b3462a18ba2005142745b2376d4a5ce73c",
-      "bytes": 10653
+      "sha256": "ea4028bfc274c985088ce6d901ccb1e5ae63a3d5291bb9340abec71235eca058",
+      "bytes": 11313
     },
     {
       "path": "DOCS-031 Kanban manual order.md",
-      "sha256": "9d6a80ecba3c960394dbaec1a7800cc9cd6fb5c95424097cab2170358b41ca0c",
-      "bytes": 2444
+      "sha256": "c00d4a92c760ac0a5ee1fe2b593b7a43b610710851d4b675b6031ceb73d8b672",
+      "bytes": 3459
     },
     {
       "path": "DOCS-032 Pinned Task Dock.md",
@@ -209,8 +209,8 @@
     },
     {
       "path": "DOCS-041 Task chips display and behavior.md",
-      "sha256": "a7bf4fca96ac00d1ecad8366b7754bd7eac73fbf35c4feba52696a0dcb68a96f",
-      "bytes": 12005
+      "sha256": "9c2178668177a27295ea08eb719b6e9342514b76e6cc1163834641f8c684f728",
+      "bytes": 12940
     },
     {
       "path": "DOCS-042 Contextual menu actions.md",
@@ -224,8 +224,8 @@
     },
     {
       "path": "DOCS-044 Where Operon stores data.md",
-      "sha256": "b11298c7d7f38bce3982bb60376f80a92a7d9f75af860422f87ebcbdb85cbcf3",
-      "bytes": 2928
+      "sha256": "f6ab48f7c7f8bc49148b1838fae140a36fa185f078233f48c221edff9f638d11",
+      "bytes": 3048
     },
     {
       "path": "DOCS-045 Markdown task storage.md",
@@ -234,8 +234,8 @@
     },
     {
       "path": "DOCS-046 Plugin data and state files.md",
-      "sha256": "a343974e642e9f46bf250c37d620e2d988f661a1eaddb469d3dcea28bee87b33",
-      "bytes": 3926
+      "sha256": "4a26f385de0f63cc8cde6b41e36a03dc2a2709b328ccd8d53ace6c6b7dbabe8c",
+      "bytes": 4097
     },
     {
       "path": "DOCS-047 Sync conflict safety.md",
@@ -374,8 +374,8 @@
     },
     {
       "path": "DOCS-074 Kanban swimlanes.md",
-      "sha256": "21c9c8309a36ccfa49176d325edb34abbb9cafa4ea391939d184984bc3c1a6ce",
-      "bytes": 3770
+      "sha256": "2225edd76ab2efbd30962ccb84bd40397dad86649991456ce0ac939d9390201c",
+      "bytes": 4178
     },
     {
       "path": "DOCS-075 Welcome - choose your starting point.md",
@@ -489,8 +489,8 @@
     },
     {
       "path": "DOCS-097 Project serials.md",
-      "sha256": "633ba712bd72f3d69b08a89e949c3feb184fecce6296c93f8db7b81af3f80e4b",
-      "bytes": 9634
+      "sha256": "bf7c3fbd24e88b509bcb42ebf281699d1689d993403a56db8f739aa6332511d9",
+      "bytes": 10015
     },
     {
       "path": "DOCS-098 Workspace Tweaks.md",
@@ -549,8 +549,8 @@
     },
     {
       "path": "DOCS-109 Table presets.md",
-      "sha256": "efc8a04f0e240edabf5caea4c569608ef96aed2aeda10a9cd8b69aa94e009390",
-      "bytes": 8736
+      "sha256": "a34357473aa0f41c9a71111817cee29ead965b1a248e0c50da192ff2d1df1b91",
+      "bytes": 9308
     },
     {
       "path": "DOCS-110 Embed a table in a note.md",
@@ -564,8 +564,8 @@
     },
     {
       "path": "DOCS-112 Table cells display and behavior.md",
-      "sha256": "ada75743bc43706d7c1c9042aca9396be8253778b5429a6ab5cc1ccdc3da29a0",
-      "bytes": 12626
+      "sha256": "8cc21cc66324cd16e25da482d37b323653a9ab77eca396d886427e249dd72e9b",
+      "bytes": 12974
     },
     {
       "path": "DOCS-113 Text field editor popover.md",
@@ -574,8 +574,8 @@
     },
     {
       "path": "DOCS-114 Table files.md",
-      "sha256": "b74316e67809b26850f27a8ec36ed907274bc6fd329ee0cdc93065d27942a7f3",
-      "bytes": 11477
+      "sha256": "4d46b79b3882c2ea39209a3828467a16a7d78cfa11e3aa4c70e83ae7a3c7c4be",
+      "bytes": 11909
     },
     {
       "path": "DOCS-115 File task property columns.md",
@@ -694,9 +694,9 @@
     },
     {
       "path": "DOCS-138 Task images and galleries.md",
-      "sha256": "897a383708e1cedd61c267794a07b3177b60a9f7600e4ac81f0046d51172cc61",
-      "bytes": 6161
+      "sha256": "1a0116167fefa1f456428709d39c8a4e5e9defddefafda0c5a7f0ce0085b864b",
+      "bytes": 7059
     }
   ],
-  "generatedAt": "2026-08-21T14:57:42.743Z"
+  "generatedAt": "2026-08-23T09:11:11.350Z"
 }


### PR DESCRIPTION
## Summary
- sync the 11 approved W008 source documents into the GitHub docs package
- update the package manifest for the changed document hashes and byte sizes
- leave media, plugin code, changelog, website, and release files unchanged

## Validation
- npm run docs:sync-runtime:test
- OPERON_DOCS_SOURCE_ROOT=<vault source> npm run docs:package:test
- git diff --check
- exact 12-file scope: 11 documents plus docs/operon-docs/manifest.json