### PR TITLE
Fix Developer API task adoption authorization

### DIFF
--- a/scripts/agent-runtime/developer-api/security/security-policy.test.ts
+++ b/scripts/agent-runtime/developer-api/security/security-policy.test.ts
@@ -9,6 +9,8 @@ import {
 	DeveloperMutationSecurityPolicyV1,
 	type DeveloperCapabilityGrantV1,
 	type DeveloperConsentDecisionV1,
+	type DeveloperMutationCapabilityV1,
+	type DeveloperMutationSealedPlanV1,
 	type DeveloperSecuritySessionV1,
 } from '../../../../src/agent-runtime/developer-api/security';
 import { requestBoundedDeveloperConsentV1 } from '../../../../src/agent-runtime/developer-api/security/bounded-consent';
@@ -112,7 +114,7 @@ const confirmationTargets: SealedMutationPlanV1['targets'] = [{
 }];
 
 function grant(
-	capabilities: CapabilityIdV1[],
+	capabilities: DeveloperMutationCapabilityV1[],
 	overrides: Partial<DeveloperCapabilityGrantV1> = {},
 ): DeveloperCapabilityGrantV1 {
 	return {
@@ -283,6 +285,79 @@ test('admits routine plans from a standing grant without consent', async () => {
 	assert.equal(admitted.ok ? admitted.consent : undefined, 'standing-grant');
 	assert.equal(admitted.ok ? admitted.authorization.basis : undefined, 'user-standing-instruction');
 	assert.deepEqual(prompts, []);
+});
+
+test('maps routine Developer API plans to the authorization basis required by each Runtime mutation', async () => {
+	const cases: ReadonlyArray<{
+		name: string;
+		capability: DeveloperMutationCapabilityV1;
+		applyCapability: DeveloperMutationCapabilityV1;
+		mutationKind: DeveloperMutationSealedPlanV1['mutationKind'];
+		expectedBasis: 'user-explicit-request' | 'user-standing-instruction';
+	}> = [
+		{
+			name: 'ordinary update',
+			capability: 'tasks.update.preview',
+			applyCapability: 'tasks.update.apply',
+			mutationKind: 'task.update',
+			expectedBasis: 'user-standing-instruction',
+		},
+		{
+			name: 'task creation',
+			capability: 'tasks.create.preview',
+			applyCapability: 'tasks.create.apply',
+			mutationKind: 'task.create',
+			expectedBasis: 'user-explicit-request',
+		},
+		{
+			name: 'task adoption',
+			capability: 'tasks.adopt.preview',
+			applyCapability: 'tasks.adopt.apply',
+			mutationKind: 'task.adopt',
+			expectedBasis: 'user-explicit-request',
+		},
+		{
+			name: 'periodic-note creation',
+			capability: 'tasks.create.periodic-note.preview',
+			applyCapability: 'tasks.create.periodic-note.apply',
+			mutationKind: 'task.create',
+			expectedBasis: 'user-explicit-request',
+		},
+		{
+			name: 'periodic-note update',
+			capability: 'tasks.update.periodic-note.preview',
+			applyCapability: 'tasks.update.periodic-note.apply',
+			mutationKind: 'task.update',
+			expectedBasis: 'user-explicit-request',
+		},
+	];
+
+	for (const testCase of cases) {
+		const { policy, prompts } = harness();
+		const sealed = {
+			...plan(),
+			capability: testCase.capability,
+			mutationKind: testCase.mutationKind,
+		} as unknown as DeveloperMutationSealedPlanV1;
+		const activeGrant = grant([testCase.capability, testCase.applyCapability]);
+		const binding = policy.bindPlan({ session, grant: activeGrant, plan: sealed });
+		assert.equal(binding.ok, true, testCase.name);
+		if (!binding.ok) continue;
+
+		const admitted = await policy.admitApply({
+			session,
+			grant: activeGrant,
+			binding: binding.binding,
+			plan: sealed,
+		});
+		assert.equal(admitted.ok, true, testCase.name);
+		assert.equal(
+			admitted.ok ? admitted.authorization.basis : undefined,
+			testCase.expectedBasis,
+			testCase.name,
+		);
+		assert.deepEqual(prompts, [], testCase.name);
+	}
 });
 
 test('mints host-owned destructive confirmation and target-bound acknowledgements', async () => {

--- a/src/agent-runtime/developer-api/security/policy.ts
+++ b/src/agent-runtime/developer-api/security/policy.ts
@@ -313,9 +313,12 @@ export class DeveloperMutationSecurityPolicyV1 {
 }
 
 function routineAuthorization(plan: DeveloperMutationSealedPlanV1): MutationAuthorizationV1 {
-	// The existing Runtime V1 create gate specifically requires this basis.
+	// Runtime V1 create and adoption gates require an explicit-request basis.
+	// Periodic-note updates retain the same explicit-request contract.
 	return hostAuthorization(
-		plan.mutationKind === 'task.create' || plan.capability === 'tasks.update.periodic-note.preview'
+		plan.mutationKind === 'task.create'
+			|| plan.mutationKind === 'task.adopt'
+			|| plan.capability === 'tasks.update.periodic-note.preview'
 			? 'user-explicit-request'
 			: 'user-standing-instruction',
 	);


### PR DESCRIPTION
## Summary

- map routine `task.adopt` Developer API plans to `user-explicit-request`
- keep ordinary updates on standing instructions
- cover create, adopt, periodic create/update and ordinary update in one authorization matrix

## Why

Operon 3.5.2 currently seals an adoption plan with `user-standing-instruction`, while `applyAgentRuntimeTaskAdoption` requires the original explicit user request. The official Developer API path therefore rejects every routine adoption before mutation.

## Verification

- reproduced the regression before the policy change
- `npm run agent-runtime:developer-api`
- `npx tsc -noEmit -skipLibCheck`
- strict ESLint on the changed production file
- `git diff --check`

The broad local `npm run check` reached the unrelated Task Finder performance gate and stopped because the cold median exceeded the machine-local 150 ms threshold. All Developer API and security suites, including the new regression matrix, are green.