### PR TITLE
Fix task-source creation graph invariants

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -6406,8 +6406,8 @@ export default class OperonPlugin extends Plugin {
 								if (recoveryStep.resourceKind === 'task-source') {
 									continued = await applyGraphStep(recoveryStep, 'forward');
 									if (continued) {
-										await this.indexer.reindexAffectedSources(
-											[recoveryStep.resourceKey],
+										await this.indexer.forceReindexFilePathAfterMutation(
+											recoveryStep.resourceKey,
 											{ notify: false },
 										);
 									}
@@ -12874,8 +12874,8 @@ export default class OperonPlugin extends Plugin {
 							// A later sealed source may reference a task created by this
 							// committed step. Publish that exact source to the index before
 							// TaskWriter validates the next cross-source relationship.
-							await this.indexer.reindexAffectedSources(
-								[step.resourceKey],
+							await this.indexer.forceReindexFilePathAfterMutation(
+								step.resourceKey,
 								{ notify: false },
 							);
 						},

--- a/main.ts
+++ b/main.ts
@@ -12605,6 +12605,10 @@ export default class OperonPlugin extends Plugin {
 							plan.atomicGroups[0]?.groupId,
 						);
 					}
+					// A durable checkpoint can outlive the in-memory index. Rebuild its
+					// committed source prefix before recovery advances to a child that
+					// validates a relationship against that parent.
+					await this.reindexAgentRuntimeIdentityGraphPrefix(journal.steps);
 					recovered = await executeRuntimeGraphTransactionRecoveryV1(journal, {
 						readState: step => this.readAgentRuntimeIdentityGraphState(step),
 						statesMatch: (left, right) => this.agentRuntimeIdentityGraphStatesMatch(left, right),
@@ -12869,16 +12873,6 @@ export default class OperonPlugin extends Plugin {
 						journal,
 						step => this.applyAgentRuntimeIdentityGraphStep(step, 'forward'),
 						checkpoint,
-						async step => {
-							if (step.resourceKind !== 'task-source') return;
-							// A later sealed source may reference a task created by this
-							// committed step. Publish that exact source to the index before
-							// TaskWriter validates the next cross-source relationship.
-							await this.indexer.forceReindexFilePathAfterMutation(
-								step.resourceKey,
-								{ notify: false },
-							);
-						},
 					);
 					if (execution.status === 'failed') {
 						try {
@@ -13271,7 +13265,43 @@ export default class OperonPlugin extends Plugin {
 			: after.state === 'absent'
 				? await this.writer.applyTaskSourceMutation({ kind: 'trash', filePath: step.resourceKey, expectedContent: before.content ?? '' })
 				: await this.writer.applyTaskSourceMutation({ kind: 'modify', filePath: step.resourceKey, expectedContent: before.content ?? '', nextContent: after.content ?? '' });
-		return write.outcome === 'committed';
+		if (write.outcome !== 'committed') return false;
+		// TaskWriter returns the exact TFile and committed content for creations
+		// and updates. Index through that handle before a later graph step may
+		// validate a relationship against this source: a newly created path can
+		// briefly be absent from Vault's path lookup even though the write won.
+		if (write.file && write.committedContent !== undefined) {
+			await this.indexer.forceReindexKnownFileAfterMutation(
+				write.file,
+				{ notify: false },
+				write.committedContent,
+			);
+			return true;
+		}
+		await this.indexer.forceReindexFilePathAfterMutation(
+			step.resourceKey,
+			{ notify: false },
+		);
+		return true;
+	}
+
+	private async reindexAgentRuntimeIdentityGraphPrefix(
+		steps: readonly GraphTransactionJournalStepV1[],
+	): Promise<void> {
+		for (const step of steps) {
+			// Match the executor's actual-state prefix, not only its last durable
+			// checkpoint: a process can stop after a source write but before that
+			// checkpoint is persisted.
+			if (!this.agentRuntimeIdentityGraphStatesMatch(
+				await this.readAgentRuntimeIdentityGraphState(step),
+				step.after,
+			)) break;
+			if (step.resourceKind !== 'task-source') continue;
+			await this.indexer.forceReindexFilePathAfterMutation(
+				step.resourceKey,
+				{ notify: false },
+			);
+		}
 	}
 
 	private async verifyAgentRuntimeIdentityGraphSteps(

--- a/main.ts
+++ b/main.ts
@@ -13103,7 +13103,16 @@ export default class OperonPlugin extends Plugin {
 		for (const filePath of prepared.sourceGroupGraph.sourceOrder) {
 			const group = prepared.plan.sourceGroups.find(candidate => candidate.filePath === filePath);
 			const parents = prepared.parentResources.filter(parent => parent.filePath === filePath);
-			const expected = group?.expectedContent ?? parents[0]?.sourceContent ?? null;
+			let expected: string | null;
+			if (!group) {
+				expected = parents[0]?.sourceContent ?? null;
+			} else if (group.expectedState === 'absent') {
+				expected = null;
+			} else if (group.expectedContent === null) {
+				return { ok: false, reason: `Present source group has no expected content: ${filePath}` };
+			} else {
+				expected = group.expectedContent;
+			}
 			let resulting = group?.resultingContent ?? expected ?? '';
 			if (parents.length > 0) {
 				const rendered = this.writer.renderGuardedTaskSourceContent(

--- a/main.ts
+++ b/main.ts
@@ -12869,6 +12869,16 @@ export default class OperonPlugin extends Plugin {
 						journal,
 						step => this.applyAgentRuntimeIdentityGraphStep(step, 'forward'),
 						checkpoint,
+						async step => {
+							if (step.resourceKind !== 'task-source') return;
+							// A later sealed source may reference a task created by this
+							// committed step. Publish that exact source to the index before
+							// TaskWriter validates the next cross-source relationship.
+							await this.indexer.reindexAffectedSources(
+								[step.resourceKey],
+								{ notify: false },
+							);
+						},
 					);
 					if (execution.status === 'failed') {
 						try {

--- a/scripts/agent-runtime/runtime/runtime-integration.test.mjs
+++ b/scripts/agent-runtime/runtime/runtime-integration.test.mjs
@@ -337,13 +337,31 @@ test('identity apply seals and verifies a bounded durable journal before its fir
 	assert.ok(alteredFenceCleanupIndex > readbackIndex);
 	assert.ok(writerIndex > readbackIndex);
 	assert.ok(writerIndex > alteredFenceCleanupIndex);
-	assert.match(
-		apply,
-		/executeRuntimeGraphTransactionCommitV1\([\s\S]*?async step => \{[\s\S]*?step\.resourceKind !== 'task-source'[\s\S]*?forceReindexFilePathAfterMutation\([\s\S]*?step\.resourceKey[\s\S]*?notify: false/u,
+	const graphStepApply = methodBody(
+		mainSource,
+		'\tprivate async applyAgentRuntimeIdentityGraphStep(',
+		'\n\n\tprivate async reindexAgentRuntimeIdentityGraphPrefix',
 	);
 	assert.match(
+		graphStepApply,
+		/forceReindexKnownFileAfterMutation\([\s\S]*?write\.file[\s\S]*?write\.committedContent/u,
+	);
+	assert.match(
+		graphStepApply,
+		/forceReindexFilePathAfterMutation\([\s\S]*?step\.resourceKey[\s\S]*?notify: false/u,
+	);
+	assert.match(
+		apply,
+		/reindexAgentRuntimeIdentityGraphPrefix\(journal\.steps\)/u,
+	);
+	const graphPrefix = methodBody(
 		mainSource,
-		/recoveryStep\.resourceKind === 'task-source'[\s\S]*?forceReindexFilePathAfterMutation\([\s\S]*?recoveryStep\.resourceKey[\s\S]*?notify: false/u,
+		'\tprivate async reindexAgentRuntimeIdentityGraphPrefix(',
+		'\n\n\tprivate async verifyAgentRuntimeIdentityGraphSteps',
+	);
+	assert.match(
+		graphPrefix,
+		/await this\.readAgentRuntimeIdentityGraphState\(step\)[\s\S]*?step\.after[\s\S]*?break/u,
 	);
 	assert.match(apply, /const applyStartedAt = new Date\(\)\.toISOString\(\);/u);
 	assert.match(apply, /effectiveAt: receiptEffectiveAt/u);

--- a/scripts/agent-runtime/runtime/runtime-integration.test.mjs
+++ b/scripts/agent-runtime/runtime/runtime-integration.test.mjs
@@ -339,7 +339,11 @@ test('identity apply seals and verifies a bounded durable journal before its fir
 	assert.ok(writerIndex > alteredFenceCleanupIndex);
 	assert.match(
 		apply,
-		/executeRuntimeGraphTransactionCommitV1\([\s\S]*?async step => \{[\s\S]*?step\.resourceKind !== 'task-source'[\s\S]*?reindexAffectedSources\([\s\S]*?\[step\.resourceKey\][\s\S]*?notify: false/u,
+		/executeRuntimeGraphTransactionCommitV1\([\s\S]*?async step => \{[\s\S]*?step\.resourceKind !== 'task-source'[\s\S]*?forceReindexFilePathAfterMutation\([\s\S]*?step\.resourceKey[\s\S]*?notify: false/u,
+	);
+	assert.match(
+		mainSource,
+		/recoveryStep\.resourceKind === 'task-source'[\s\S]*?forceReindexFilePathAfterMutation\([\s\S]*?recoveryStep\.resourceKey[\s\S]*?notify: false/u,
 	);
 	assert.match(apply, /const applyStartedAt = new Date\(\)\.toISOString\(\);/u);
 	assert.match(apply, /effectiveAt: receiptEffectiveAt/u);

--- a/scripts/agent-runtime/runtime/runtime-integration.test.mjs
+++ b/scripts/agent-runtime/runtime/runtime-integration.test.mjs
@@ -63,9 +63,14 @@ test('identity graph honors source expectedState before seeded content or parent
 	const absent = await harness.prepareAgentRuntimeIdentityGraphSteps(graphPreparation({
 		filePath: 'Periodic.md',
 		expectedState: 'absent',
-		expectedContent: 'seeded periodic note',
+		expectedContent: null,
 		resultingContent: 'seeded periodic note with task',
-	}), '2026-08-24T10:00:00.000Z');
+	}, [{
+		filePath: 'Periodic.md',
+		sourceContent: 'seeded periodic note',
+		operonId: 'par0001',
+		format: 'yaml',
+	}]), '2026-08-24T10:00:00.000Z');
 	assert.equal(absent.ok, true);
 	assert.equal(absent.steps[0].operation, 'create');
 	assert.deepEqual(absent.steps[0].before, { state: 'absent', digest: 'test-digest', content: null });

--- a/scripts/agent-runtime/runtime/runtime-integration.test.mjs
+++ b/scripts/agent-runtime/runtime/runtime-integration.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import test from 'node:test';
+import ts from 'typescript';
 
 const mainSource = await readFile(new URL('../../../main.ts', import.meta.url), 'utf8');
 const indexerSource = await readFile(new URL('../../../src/indexer/indexer.ts', import.meta.url), 'utf8');
@@ -20,6 +21,86 @@ function methodBody(source, signature, nextSignature) {
 	assert.notEqual(end, -1, `Missing boundary ${nextSignature}`);
 	return source.slice(start, end);
 }
+
+function identityGraphHarness() {
+	const method = methodBody(
+		mainSource,
+		'\tprivate async prepareAgentRuntimeIdentityGraphSteps(',
+		'\n\n\tprivate agentRuntimeIdentityGraphState',
+	);
+	const source = `
+		class IdentityGraphHarness {
+			constructor() {
+				this.writer = {
+					renderGuardedTaskSourceContent: (_filePath, content) => ({ ok: true, content, reason: 'none' }),
+				};
+				this.aggregateCoordinator = { planCreationAggregatePatches: () => [] };
+			}
+			${method}
+			agentRuntimeIdentityGraphState(content) {
+				return { state: content === null ? 'absent' : 'present', digest: 'test-digest', content };
+			}
+		}
+	`;
+	const transpiled = ts.transpileModule(source, {
+		compilerOptions: { module: ts.ModuleKind.None, target: ts.ScriptTarget.ES2022 },
+	}).outputText;
+	const Harness = new Function('toLocalDatetime', `${transpiled}\nreturn IdentityGraphHarness;`)(value => value);
+	return new Harness();
+}
+
+function graphPreparation(sourceGroup, parentResources = []) {
+	return {
+		plan: { sourceGroups: sourceGroup ? [sourceGroup] : [], tasks: [] },
+		sourceGroupGraph: { sourceOrder: ['Periodic.md'] },
+		parentResources,
+		recurrenceResources: [],
+	};
+}
+
+test('identity graph honors source expectedState before seeded content or parent fallbacks', async () => {
+	const harness = identityGraphHarness();
+	const absent = await harness.prepareAgentRuntimeIdentityGraphSteps(graphPreparation({
+		filePath: 'Periodic.md',
+		expectedState: 'absent',
+		expectedContent: 'seeded periodic note',
+		resultingContent: 'seeded periodic note with task',
+	}), '2026-08-24T10:00:00.000Z');
+	assert.equal(absent.ok, true);
+	assert.equal(absent.steps[0].operation, 'create');
+	assert.deepEqual(absent.steps[0].before, { state: 'absent', digest: 'test-digest', content: null });
+
+	const present = await harness.prepareAgentRuntimeIdentityGraphSteps(graphPreparation({
+		filePath: 'Periodic.md',
+		expectedState: 'present',
+		expectedContent: 'existing periodic note',
+		resultingContent: 'existing periodic note with task',
+	}), '2026-08-24T10:00:00.000Z');
+	assert.equal(present.ok, true);
+	assert.equal(present.steps[0].operation, 'modify');
+	assert.deepEqual(present.steps[0].before, { state: 'present', digest: 'test-digest', content: 'existing periodic note' });
+
+	const invalidPresent = await harness.prepareAgentRuntimeIdentityGraphSteps(graphPreparation({
+		filePath: 'Periodic.md',
+		expectedState: 'present',
+		expectedContent: null,
+		resultingContent: 'replacement content',
+	}), '2026-08-24T10:00:00.000Z');
+	assert.deepEqual(invalidPresent, {
+		ok: false,
+		reason: 'Present source group has no expected content: Periodic.md',
+	});
+
+	const parentFallback = await harness.prepareAgentRuntimeIdentityGraphSteps(graphPreparation(undefined, [{
+		filePath: 'Periodic.md',
+		sourceContent: 'parent resource content',
+		operonId: 'par0001',
+		format: 'yaml',
+	}]), '2026-08-24T10:00:00.000Z');
+	assert.equal(parentFallback.ok, true);
+	assert.equal(parentFallback.steps[0].operation, 'modify');
+	assert.deepEqual(parentFallback.steps[0].before, { state: 'present', digest: 'test-digest', content: 'parent resource content' });
+});
 
 test('publishes the Runtime facade synchronously before asynchronous plugin loading', () => {
 	const onload = methodBody(mainSource, '\tonload(): void {', '\n\tprivate async initializeTablePresetRegistry');

--- a/scripts/agent-runtime/runtime/runtime-integration.test.mjs
+++ b/scripts/agent-runtime/runtime/runtime-integration.test.mjs
@@ -337,6 +337,10 @@ test('identity apply seals and verifies a bounded durable journal before its fir
 	assert.ok(alteredFenceCleanupIndex > readbackIndex);
 	assert.ok(writerIndex > readbackIndex);
 	assert.ok(writerIndex > alteredFenceCleanupIndex);
+	assert.match(
+		apply,
+		/executeRuntimeGraphTransactionCommitV1\([\s\S]*?async step => \{[\s\S]*?step\.resourceKind !== 'task-source'[\s\S]*?reindexAffectedSources\([\s\S]*?\[step\.resourceKey\][\s\S]*?notify: false/u,
+	);
 	assert.match(apply, /const applyStartedAt = new Date\(\)\.toISOString\(\);/u);
 	assert.match(apply, /effectiveAt: receiptEffectiveAt/u);
 	assert.match(apply, /Identity graph journal readback did not match the sealed pre-write fence/u);

--- a/scripts/task-writer-deoperon-cleanup.test.ts
+++ b/scripts/task-writer-deoperon-cleanup.test.ts
@@ -443,6 +443,44 @@ async function run(): Promise<void> {
 		'a fenced relationship example does not create a phantom recovery fence',
 	);
 
+	const paddedYamlIdentityApp = new FakeApp('');
+	const paddedYamlIdentityWriter = new TaskWriter(paddedYamlIdentityApp as any, {
+		getTask: () => undefined,
+		hasDuplicateOperonIdConflict: () => false,
+	} as any, keyMappings);
+	const paddedYamlIdentityResult = await paddedYamlIdentityWriter.applyTaskSourceMutation({
+		kind: 'create',
+		filePath: 'Padded identity.md',
+		nextContent: [
+			'---',
+			'operonId: " par0003 "',
+			'---',
+			'- [ ] Child {{operonId:: chd0009}} {{parentTask:: par0003}}',
+			'',
+		].join('\n'),
+	});
+	equal(paddedYamlIdentityResult.outcome, 'conflict', 'a padded YAML identity rejected by the indexer cannot satisfy a local relationship');
+	equal(paddedYamlIdentityApp.createdContents.size, 0, 'a padded YAML identity cannot commit a dangling relationship');
+
+	const blankAliasApp = new FakeApp('');
+	const blankAliasWriter = new TaskWriter(blankAliasApp as any, {
+		getTask: () => undefined,
+		hasDuplicateOperonIdConflict: () => false,
+	} as any, keyMappings);
+	const blankAliasResult = await blankAliasWriter.applyTaskSourceMutation({
+		kind: 'create',
+		filePath: 'Blank alias.md',
+		nextContent: [
+			'---',
+			'operonId: par0004',
+			'Task ID: " "',
+			'---',
+			'- [ ] Child {{operonId:: chd0010}} {{parentTask:: par0004}}',
+			'',
+		].join('\n'),
+	});
+	equal(blankAliasResult.outcome, 'committed', 'a blank mapped alias does not make a canonical YAML identity ambiguous');
+
 	const conflictingYamlAliases = [
 		'---',
 		'operonId: aaa0001',

--- a/scripts/task-writer-deoperon-cleanup.test.ts
+++ b/scripts/task-writer-deoperon-cleanup.test.ts
@@ -400,6 +400,70 @@ async function run(): Promise<void> {
 	equal(sameSourceCreated.outcome, 'committed', 'a child may target the unique parent created in the same source');
 	equal(sameSourceApp.createdContents.get('Same source.md'), sameSourceParent, 'same-source relationship content is committed unchanged');
 
+	const fencedExample = [
+		'```markdown',
+		'- [ ] Example {{operonId:: par0002}}',
+		'```',
+		'- [ ] Child {{operonId:: chd0007}} {{parentTask:: par0002}}',
+		'',
+	].join('\n');
+	const fencedExampleApp = new FakeApp('');
+	const fencedExampleWriter = new TaskWriter(fencedExampleApp as any, {
+		getTask: () => undefined,
+		hasDuplicateOperonIdConflict: () => false,
+	} as any, keyMappings);
+	const fencedExampleResult = await fencedExampleWriter.applyTaskSourceMutation({
+		kind: 'create',
+		filePath: 'Fenced example.md',
+		nextContent: fencedExample,
+	});
+	equal(fencedExampleResult.outcome, 'conflict', 'fenced task examples must not satisfy same-source relationships');
+	equal(fencedExampleApp.createdContents.size, 0, 'fenced examples must not make a dangling relationship writable');
+
+	const conflictingYamlAliases = [
+		'---',
+		'operonId: aaa0001',
+		'Task ID: bbb0002',
+		'---',
+		'- [ ] Child {{operonId:: chd0008}} {{parentTask:: bbb0002}}',
+		'',
+	].join('\n');
+	const conflictingYamlApp = new FakeApp('');
+	const conflictingYamlWriter = new TaskWriter(conflictingYamlApp as any, {
+		getTask: () => undefined,
+		hasDuplicateOperonIdConflict: () => false,
+	} as any, [
+		...keyMappings,
+		{ canonicalKey: 'operonId', visiblePropertyName: 'Task ID', type: 'text', sync: 'yes', enabled: true, isSystem: true },
+	]);
+	const conflictingYamlResult = await conflictingYamlWriter.applyTaskSourceMutation({
+		kind: 'create',
+		filePath: 'Conflicting aliases.md',
+		nextContent: conflictingYamlAliases,
+	});
+	equal(conflictingYamlResult.outcome, 'conflict', 'conflicting identity aliases must follow the canonical indexer identity');
+	equal(conflictingYamlApp.createdContents.size, 0, 'an alias not selected by the indexer must not satisfy a relationship');
+
+	const conflictingCanonicalAliases = conflictingYamlAliases.replace(
+		'{{parentTask:: bbb0002}}',
+		'{{parentTask:: aaa0001}}',
+	);
+	const conflictingCanonicalApp = new FakeApp('');
+	const conflictingCanonicalWriter = new TaskWriter(conflictingCanonicalApp as any, {
+		getTask: () => undefined,
+		hasDuplicateOperonIdConflict: () => false,
+	} as any, [
+		...keyMappings,
+		{ canonicalKey: 'operonId', visiblePropertyName: 'Task ID', type: 'text', sync: 'yes', enabled: true, isSystem: true },
+	]);
+	const conflictingCanonicalResult = await conflictingCanonicalWriter.applyTaskSourceMutation({
+		kind: 'create',
+		filePath: 'Conflicting canonical alias.md',
+		nextContent: conflictingCanonicalAliases,
+	});
+	equal(conflictingCanonicalResult.outcome, 'conflict', 'multiple populated identity aliases make the canonical value ambiguous too');
+	equal(conflictingCanonicalApp.createdContents.size, 0, 'neither conflicting identity alias may authorize a relationship');
+
 	const missingTargetApp = new FakeApp('');
 	const missingTargetWriter = new TaskWriter(missingTargetApp as any, {
 		getTask: () => undefined,
@@ -438,7 +502,7 @@ async function run(): Promise<void> {
 
 	const invalidLocalApp = new FakeApp('');
 	const invalidLocalWriter = new TaskWriter(invalidLocalApp as any, {
-		getTask: (operonId: string) => operonId === 'INVALID' ? { operonId } : undefined,
+		getTask: () => undefined,
 		hasDuplicateOperonIdConflict: () => false,
 	} as any, keyMappings);
 	const invalidLocal = await invalidLocalWriter.applyTaskSourceMutation({
@@ -454,6 +518,25 @@ async function run(): Promise<void> {
 	});
 	equal(invalidLocal.outcome, 'conflict', 'an invalid same-source identity cannot satisfy a relationship');
 	equal(invalidLocalApp.createdContents.size, 0, 'invalid local identity cannot create a source');
+
+	const indexedLegacyApp = new FakeApp('');
+	const indexedLegacyWriter = new TaskWriter(indexedLegacyApp as any, {
+		getTask: (operonId: string) => operonId === 'INVALID' ? { operonId } : undefined,
+		hasDuplicateOperonIdConflict: () => false,
+	} as any, keyMappings);
+	const indexedLegacy = await indexedLegacyWriter.applyTaskSourceMutation({
+		kind: 'create',
+		filePath: 'Indexed legacy target.md',
+		nextContent: [
+			'---',
+			'operonId: INVALID',
+			'---',
+			'- [ ] Child {{operonId:: chd0009}} {{parentTask:: INVALID}}',
+			'',
+		].join('\n'),
+	});
+	equal(indexedLegacy.outcome, 'committed', 'an already indexed legacy target remains available before canonical ID validation');
+	equal(indexedLegacyApp.createdContents.size, 1, 'indexed legacy target can be used by a same-source relationship');
 
 	const externalTargetApp = new FakeApp('');
 	const externalTargetWriter = new TaskWriter(externalTargetApp as any, {

--- a/scripts/task-writer-deoperon-cleanup.test.ts
+++ b/scripts/task-writer-deoperon-cleanup.test.ts
@@ -481,6 +481,24 @@ async function run(): Promise<void> {
 	});
 	equal(blankAliasResult.outcome, 'committed', 'a blank mapped alias does not make a canonical YAML identity ambiguous');
 
+	const excludedSourceApp = new FakeApp('');
+	const excludedSourceWriter = new TaskWriter(excludedSourceApp as any, {
+		getTask: () => undefined,
+		hasDuplicateOperonIdConflict: () => false,
+		isPathIndexable: () => false,
+	} as any, keyMappings);
+	const excludedSourceResult = await excludedSourceWriter.applyTaskSourceMutation({
+		kind: 'create',
+		filePath: 'Templates/Excluded relationship.md',
+		nextContent: [
+			'- [ ] Parent {{operonId:: par0005}}',
+			'- [ ] Child {{operonId:: chd0011}} {{parentTask:: par0005}}',
+			'',
+		].join('\n'),
+	});
+	equal(excludedSourceResult.outcome, 'conflict', 'same-source identities cannot authorize relationships in an excluded source');
+	equal(excludedSourceApp.createdContents.size, 0, 'an excluded source cannot commit a relationship that the indexer will never see');
+
 	const conflictingYamlAliases = [
 		'---',
 		'operonId: aaa0001',

--- a/scripts/task-writer-deoperon-cleanup.test.ts
+++ b/scripts/task-writer-deoperon-cleanup.test.ts
@@ -420,6 +420,29 @@ async function run(): Promise<void> {
 	equal(fencedExampleResult.outcome, 'conflict', 'fenced task examples must not satisfy same-source relationships');
 	equal(fencedExampleApp.createdContents.size, 0, 'fenced examples must not make a dangling relationship writable');
 
+	const fencedRelationshipApp = new FakeApp('');
+	const fencedRelationshipWriter = new TaskWriter(fencedRelationshipApp as any, {
+		getTask: (operonId: string) => operonId === 'ext0002' ? { operonId } : undefined,
+		hasDuplicateOperonIdConflict: () => false,
+	} as any, keyMappings);
+	const fencedRelationshipResult = await fencedRelationshipWriter.applyTaskSourceMutation({
+		kind: 'create',
+		filePath: 'Fenced relationship.md',
+		nextContent: [
+			'```markdown',
+			'- [ ] Example {{operonId:: exm0001}} {{parentTask:: ext0002}}',
+			'```',
+			'- [ ] Real task {{operonId:: rel0001}}',
+			'',
+		].join('\n'),
+	});
+	equal(fencedRelationshipResult.outcome, 'committed', 'a fenced relationship example does not affect source validation');
+	equal(
+		fencedRelationshipWriter.hasUnsettledRelationshipReference('ext0002'),
+		false,
+		'a fenced relationship example does not create a phantom recovery fence',
+	);
+
 	const conflictingYamlAliases = [
 		'---',
 		'operonId: aaa0001',

--- a/scripts/task-writer-deoperon-cleanup.test.ts
+++ b/scripts/task-writer-deoperon-cleanup.test.ts
@@ -29,6 +29,7 @@ class FakeFile extends TFile {
 
 class FakeApp {
 	readonly file = new FakeFile('Tasks/Plain file.md');
+	readonly createdContents = new Map<string, string>();
 	content: string;
 	processFrontMatterCalls = 0;
 	processCalls = 0;
@@ -46,10 +47,17 @@ class FakeApp {
 	}
 
 	readonly vault = {
-		getAbstractFileByPath: (path: string): TFile | null => path === this.file.path ? this.file : null,
+		getAbstractFileByPath: (path: string): TFile | null => {
+			if (path === this.file.path) return this.file;
+			return this.createdContents.has(path) ? new FakeFile(path) : null;
+		},
 		read: async (_file: TFile): Promise<string> => {
 			if (this.throwRead) throw new Error('read failed');
 			return this.content;
+		},
+		create: async (path: string, content: string): Promise<TFile> => {
+			this.createdContents.set(path, content);
+			return new FakeFile(path);
 		},
 		process: async (_file: TFile, mutate: (content: string) => string): Promise<string> => {
 			this.processCalls += 1;
@@ -369,6 +377,107 @@ async function run(): Promise<void> {
 	const sourceMutation = await queuedSourceMutation;
 	equal(sourceMutation.outcome, 'conflict', 'queued source plan rechecks relationship targets after conversion');
 	ok(!relationshipApp.content.includes('parentTask:'), 'stale source plan never commits a removed parent');
+
+	const sameSourceParent = [
+		'---',
+		'operonId: par0001',
+		'Status: Todo',
+		'---',
+		'# Parent',
+		'- [ ] Child {{operonId:: chd0001}} {{parentTask:: par0001}}',
+		'',
+	].join('\n');
+	const sameSourceApp = new FakeApp('');
+	const sameSourceWriter = new TaskWriter(sameSourceApp as any, {
+		getTask: () => undefined,
+		hasDuplicateOperonIdConflict: () => false,
+	} as any, keyMappings);
+	const sameSourceCreated = await sameSourceWriter.applyTaskSourceMutation({
+		kind: 'create',
+		filePath: 'Same source.md',
+		nextContent: sameSourceParent,
+	});
+	equal(sameSourceCreated.outcome, 'committed', 'a child may target the unique parent created in the same source');
+	equal(sameSourceApp.createdContents.get('Same source.md'), sameSourceParent, 'same-source relationship content is committed unchanged');
+
+	const missingTargetApp = new FakeApp('');
+	const missingTargetWriter = new TaskWriter(missingTargetApp as any, {
+		getTask: () => undefined,
+		hasDuplicateOperonIdConflict: () => false,
+	} as any, keyMappings);
+	const missingTarget = await missingTargetWriter.applyTaskSourceMutation({
+		kind: 'create',
+		filePath: 'Missing target.md',
+		nextContent: '- [ ] Child {{operonId:: chd0002}} {{parentTask:: par9999}}\n',
+	});
+	equal(missingTarget.outcome, 'conflict', 'a relationship to an absent local and indexed target remains rejected');
+	equal(missingTargetApp.createdContents.size, 0, 'missing relationship target cannot create a source');
+
+	const duplicateLocalId = [
+		'---',
+		'operonId: dup0001',
+		'Status: Todo',
+		'---',
+		'# Parent',
+		'- [ ] Duplicate identity {{operonId:: dup0001}}',
+		'- [ ] Child {{operonId:: chd0003}} {{parentTask:: dup0001}}',
+		'',
+	].join('\n');
+	const duplicateLocalApp = new FakeApp('');
+	const duplicateLocalWriter = new TaskWriter(duplicateLocalApp as any, {
+		getTask: (operonId: string) => operonId === 'dup0001' ? { operonId } : undefined,
+		hasDuplicateOperonIdConflict: () => false,
+	} as any, keyMappings);
+	const duplicateLocal = await duplicateLocalWriter.applyTaskSourceMutation({
+		kind: 'create',
+		filePath: 'Duplicate local.md',
+		nextContent: duplicateLocalId,
+	});
+	equal(duplicateLocal.outcome, 'conflict', 'a duplicated same-source identity cannot satisfy a relationship');
+	equal(duplicateLocalApp.createdContents.size, 0, 'duplicate local identity cannot create a source');
+
+	const invalidLocalApp = new FakeApp('');
+	const invalidLocalWriter = new TaskWriter(invalidLocalApp as any, {
+		getTask: (operonId: string) => operonId === 'INVALID' ? { operonId } : undefined,
+		hasDuplicateOperonIdConflict: () => false,
+	} as any, keyMappings);
+	const invalidLocal = await invalidLocalWriter.applyTaskSourceMutation({
+		kind: 'create',
+		filePath: 'Invalid local.md',
+		nextContent: [
+			'---',
+			'operonId: INVALID',
+			'---',
+			'- [ ] Child {{operonId:: chd0005}} {{parentTask:: INVALID}}',
+			'',
+		].join('\n'),
+	});
+	equal(invalidLocal.outcome, 'conflict', 'an invalid same-source identity cannot satisfy a relationship');
+	equal(invalidLocalApp.createdContents.size, 0, 'invalid local identity cannot create a source');
+
+	const externalTargetApp = new FakeApp('');
+	const externalTargetWriter = new TaskWriter(externalTargetApp as any, {
+		getTask: (operonId: string) => operonId === 'ext0001' ? { operonId } : undefined,
+		hasDuplicateOperonIdConflict: () => false,
+	} as any, keyMappings);
+	const externalTarget = await externalTargetWriter.applyTaskSourceMutation({
+		kind: 'create',
+		filePath: 'External target.md',
+		nextContent: '- [ ] Child {{operonId:: chd0004}} {{parentTask:: ext0001}}\n',
+	});
+	equal(externalTarget.outcome, 'committed', 'a relationship to a live indexed target remains supported');
+
+	const legacyExternalApp = new FakeApp('');
+	const legacyExternalWriter = new TaskWriter(legacyExternalApp as any, {
+		getTask: (operonId: string) => operonId === 'LEGACY1' ? { operonId } : undefined,
+		hasDuplicateOperonIdConflict: () => false,
+	} as any, keyMappings);
+	const legacyExternalTarget = await legacyExternalWriter.applyTaskSourceMutation({
+		kind: 'create',
+		filePath: 'Legacy external target.md',
+		nextContent: '- [ ] Child {{operonId:: chd0006}} {{parentTask:: LEGACY1}}\n',
+	});
+	equal(legacyExternalTarget.outcome, 'committed', 'a legacy-shaped target already admitted by the live index remains supported');
 
 	relationshipApp.content = relationshipSource;
 	relationshipTasks.set('ABC1234', {

--- a/scripts/task-writer-deoperon-cleanup.test.ts
+++ b/scripts/task-writer-deoperon-cleanup.test.ts
@@ -481,6 +481,30 @@ async function run(): Promise<void> {
 	});
 	equal(blankAliasResult.outcome, 'committed', 'a blank mapped alias does not make a canonical YAML identity ambiguous');
 
+	const mirroredYamlAliases = [
+		'---',
+		'operonId: par0006',
+		'Task ID: par0006',
+		'---',
+		'- [ ] Child {{operonId:: chd0012}} {{parentTask:: par0006}}',
+		'',
+	].join('\n');
+	const mirroredYamlApp = new FakeApp('');
+	const mirroredYamlWriter = new TaskWriter(mirroredYamlApp as any, {
+		getTask: () => undefined,
+		hasDuplicateOperonIdConflict: () => false,
+	} as any, [
+		...keyMappings,
+		{ canonicalKey: 'operonId', visiblePropertyName: 'Task ID', type: 'text', sync: 'yes', enabled: true, isSystem: true },
+	]);
+	const mirroredYamlResult = await mirroredYamlWriter.applyTaskSourceMutation({
+		kind: 'create',
+		filePath: 'Mirrored aliases.md',
+		nextContent: mirroredYamlAliases,
+	});
+	equal(mirroredYamlResult.outcome, 'committed', 'equivalent YAML identity aliases count as one local target');
+	equal(mirroredYamlApp.createdContents.get('Mirrored aliases.md'), mirroredYamlAliases);
+
 	const excludedSourceApp = new FakeApp('');
 	const excludedSourceWriter = new TaskWriter(excludedSourceApp as any, {
 		getTask: () => undefined,

--- a/scripts/task-writer-deoperon-cleanup.test.ts
+++ b/scripts/task-writer-deoperon-cleanup.test.ts
@@ -443,6 +443,36 @@ async function run(): Promise<void> {
 		'a fenced relationship example does not create a phantom recovery fence',
 	);
 
+	const fencedSameSourceExample = [
+		'- [ ] Real target {{operonId:: par0007}}',
+		'```markdown',
+		'- [ ] Example {{operonId:: exm0002}} {{parentTask:: par0007}}',
+		'```',
+		'- [ ] Real sibling {{operonId:: sib0001}}',
+		'',
+	].join('\n');
+	const fencedSameSourceApp = new FakeApp('');
+	const fencedSameSourceWriter = new TaskWriter(fencedSameSourceApp as any, {
+		getTask: () => undefined,
+		hasDuplicateOperonIdConflict: () => false,
+	} as any, keyMappings);
+	const fencedSameSourceResult = await fencedSameSourceWriter.applyTaskSourceMutation({
+		kind: 'create',
+		filePath: 'Fenced same source example.md',
+		nextContent: fencedSameSourceExample,
+	});
+	equal(fencedSameSourceResult.outcome, 'committed', 'a fenced relationship example does not invalidate real same-source tasks');
+	equal(
+		fencedSameSourceWriter.hasUnsettledRelationshipReference('par0007'),
+		false,
+		'a fenced task never creates a phantom relationship fence that blocks target removal',
+	);
+	equal(
+		fencedSameSourceWriter.hasUnsettledRelationshipReference('par0007'),
+		false,
+		'a fenced task never creates a phantom relationship fence that blocks target conversion',
+	);
+
 	const paddedYamlIdentityApp = new FakeApp('');
 	const paddedYamlIdentityWriter = new TaskWriter(paddedYamlIdentityApp as any, {
 		getTask: () => undefined,

--- a/src/core/task-writer.ts
+++ b/src/core/task-writer.ts
@@ -1197,10 +1197,13 @@ export class TaskWriter {
         const localOperonIdCounts = this.sourceOperonIdCounts(content, filePath);
         const targetExists = (targetId: string): boolean => {
             const localCount = localOperonIdCounts.get(targetId) ?? 0;
-            if (localCount > 0) return localCount === 1 && isValidOperonId(targetId);
+            if (localCount > 1) return false;
+            if (localCount === 1 && isValidOperonId(targetId)) return true;
+            // Preserve the indexer's legacy/external fallback before requiring
+            // a canonical ID for a local identity that is not indexable.
             return !!this.indexer.getTask(targetId);
         };
-        for (const [lineNumber, line] of content.split('\n').entries()) {
+        for (const [lineNumber, line] of this.sourceBodyLines(content)) {
             const task = parseTaskLine(line, lineNumber, filePath, this.keyMappings);
             if (!task) continue;
             const fieldValues = Object.fromEntries(task.fields.map(field => [field.key, field.value]));
@@ -1235,7 +1238,7 @@ export class TaskWriter {
             if (!operonId) return;
             counts.set(operonId, (counts.get(operonId) ?? 0) + 1);
         };
-        for (const [lineNumber, line] of content.split('\n').entries()) {
+        for (const [lineNumber, line] of this.sourceBodyLines(content)) {
             const task = parseTaskLine(line, lineNumber, filePath, this.keyMappings);
             if (task?.operonId) count(task.operonId);
         }
@@ -1249,15 +1252,38 @@ export class TaskWriter {
         }
         if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return counts;
         const frontmatter = parsed as Record<string, unknown>;
-        for (const yamlKey of getManagedYamlAliases('operonId', this.keyMappings)) {
-            const raw = frontmatter[yamlKey];
-            if (typeof raw === 'string') {
-                count(raw);
-            } else if (typeof raw === 'number' && Number.isSafeInteger(raw) && raw >= 0) {
-                count(String(raw));
+        const yamlScalar = (value: unknown): string | null => {
+            if (typeof value === 'string') return value;
+            if (typeof value === 'number' && Number.isSafeInteger(value) && value >= 0) return String(value);
+            return null;
+        };
+        const identityEntries = getManagedYamlAliases('operonId', this.keyMappings)
+            .filter(yamlKey => Object.prototype.hasOwnProperty.call(frontmatter, yamlKey))
+            .map(yamlKey => yamlScalar(frontmatter[yamlKey]))
+            .filter((value): value is string => value !== null && value.length > 0);
+        if (identityEntries.length === 1) {
+            count(identityEntries[0]);
+        } else if (identityEntries.length > 1) {
+            // The indexer selects one alias by priority, but a proposed source
+            // with multiple populated identities is not a safe local
+            // relationship authority. Mark every candidate ambiguous.
+            for (const operonId of new Set(identityEntries)) {
+                count(operonId);
+                count(operonId);
             }
         }
         return counts;
+    }
+
+    private *sourceBodyLines(content: string): Iterable<[number, string]> {
+        let inFencedCodeBlock = false;
+        for (const [lineNumber, line] of content.split('\n').entries()) {
+            if (/^\s*```/.test(line) || /^\s*~~~/.test(line)) {
+                inFencedCodeBlock = !inFencedCodeBlock;
+                continue;
+            }
+            if (!inFencedCodeBlock) yield [lineNumber, line];
+        }
     }
 
     private recordSourceRelationshipTargets(content: string, filePath: string): void {

--- a/src/core/task-writer.ts
+++ b/src/core/task-writer.ts
@@ -1287,7 +1287,7 @@ export class TaskWriter {
     }
 
     private recordSourceRelationshipTargets(content: string, filePath: string): void {
-        for (const [lineNumber, line] of content.split('\n').entries()) {
+        for (const [lineNumber, line] of this.sourceBodyLines(content)) {
             const task = parseTaskLine(line, lineNumber, filePath, this.keyMappings);
             if (!task) continue;
             const fieldValues = Object.fromEntries(task.fields.map(field => [field.key, field.value]));

--- a/src/core/task-writer.ts
+++ b/src/core/task-writer.ts
@@ -1231,12 +1231,11 @@ export class TaskWriter {
         return this.getRelationshipTargetIds(fieldValues).every(targetExists);
     }
 
-    private sourceOperonIdCounts(content: string, filePath: string): Map<string, number> {
-        const counts = new Map<string, number>();
-        const count = (rawOperonId: string): void => {
-            const operonId = rawOperonId.trim();
-            if (!operonId) return;
-            counts.set(operonId, (counts.get(operonId) ?? 0) + 1);
+	private sourceOperonIdCounts(content: string, filePath: string): Map<string, number> {
+		const counts = new Map<string, number>();
+		const count = (rawOperonId: string): void => {
+			if (!isValidOperonId(rawOperonId)) return;
+			counts.set(rawOperonId, (counts.get(rawOperonId) ?? 0) + 1);
         };
         for (const [lineNumber, line] of this.sourceBodyLines(content)) {
             const task = parseTaskLine(line, lineNumber, filePath, this.keyMappings);
@@ -1260,7 +1259,7 @@ export class TaskWriter {
         const identityEntries = getManagedYamlAliases('operonId', this.keyMappings)
             .filter(yamlKey => Object.prototype.hasOwnProperty.call(frontmatter, yamlKey))
             .map(yamlKey => yamlScalar(frontmatter[yamlKey]))
-            .filter((value): value is string => value !== null && value.length > 0);
+			.filter((value): value is string => value !== null && value.trim().length > 0);
         if (identityEntries.length === 1) {
             count(identityEntries[0]);
         } else if (identityEntries.length > 1) {

--- a/src/core/task-writer.ts
+++ b/src/core/task-writer.ts
@@ -27,6 +27,7 @@ import { enginePerfLog, enginePerfNow } from './engine-perf';
 import { getManagedTaskFieldType, isManagedTaskFieldCanonicalKey } from './managed-task-fields';
 import { normalizeTaskMediaReferenceList } from './task-media-reference';
 import { parseDependencyIdList } from './dependency-graph';
+import { isValidOperonId } from './id-generator';
 import { CANONICAL_KEY_MAP, CANONICAL_KEYS, isInternalCanonicalKey } from '../types/keys';
 import {
     isWritableRawYamlPropertyName,
@@ -1193,11 +1194,17 @@ export class TaskWriter {
     }
 
     private sourceRelationshipTargetsExist(content: string, filePath: string): boolean {
+        const localOperonIdCounts = this.sourceOperonIdCounts(content, filePath);
+        const targetExists = (targetId: string): boolean => {
+            const localCount = localOperonIdCounts.get(targetId) ?? 0;
+            if (localCount > 0) return localCount === 1 && isValidOperonId(targetId);
+            return !!this.indexer.getTask(targetId);
+        };
         for (const [lineNumber, line] of content.split('\n').entries()) {
             const task = parseTaskLine(line, lineNumber, filePath, this.keyMappings);
             if (!task) continue;
             const fieldValues = Object.fromEntries(task.fields.map(field => [field.key, field.value]));
-            if (!this.taskRelationshipTargetsExist(fieldValues)) return false;
+            if (!this.getRelationshipTargetIds(fieldValues).every(targetExists)) return false;
         }
         const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/u);
         if (!match) return true;
@@ -1218,7 +1225,39 @@ export class TaskWriter {
                 break;
             }
         }
-        return this.taskRelationshipTargetsExist(fieldValues);
+        return this.getRelationshipTargetIds(fieldValues).every(targetExists);
+    }
+
+    private sourceOperonIdCounts(content: string, filePath: string): Map<string, number> {
+        const counts = new Map<string, number>();
+        const count = (rawOperonId: string): void => {
+            const operonId = rawOperonId.trim();
+            if (!operonId) return;
+            counts.set(operonId, (counts.get(operonId) ?? 0) + 1);
+        };
+        for (const [lineNumber, line] of content.split('\n').entries()) {
+            const task = parseTaskLine(line, lineNumber, filePath, this.keyMappings);
+            if (task?.operonId) count(task.operonId);
+        }
+        const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/u);
+        if (!match) return counts;
+        let parsed: unknown;
+        try {
+            parsed = parseYaml(match[1]);
+        } catch {
+            return counts;
+        }
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return counts;
+        const frontmatter = parsed as Record<string, unknown>;
+        for (const yamlKey of getManagedYamlAliases('operonId', this.keyMappings)) {
+            const raw = frontmatter[yamlKey];
+            if (typeof raw === 'string') {
+                count(raw);
+            } else if (typeof raw === 'number' && Number.isSafeInteger(raw) && raw >= 0) {
+                count(String(raw));
+            }
+        }
+        return counts;
     }
 
     private recordSourceRelationshipTargets(content: string, filePath: string): void {

--- a/src/core/task-writer.ts
+++ b/src/core/task-writer.ts
@@ -1193,12 +1193,13 @@ export class TaskWriter {
         return false;
     }
 
-    private sourceRelationshipTargetsExist(content: string, filePath: string): boolean {
-        const localOperonIdCounts = this.sourceOperonIdCounts(content, filePath);
-        const targetExists = (targetId: string): boolean => {
-            const localCount = localOperonIdCounts.get(targetId) ?? 0;
-            if (localCount > 1) return false;
-            if (localCount === 1 && isValidOperonId(targetId)) return true;
+	private sourceRelationshipTargetsExist(content: string, filePath: string): boolean {
+		const localOperonIdCounts = this.sourceOperonIdCounts(content, filePath);
+		const localTargetsAreIndexable = this.indexer.isPathIndexable?.(filePath) ?? true;
+		const targetExists = (targetId: string): boolean => {
+			const localCount = localOperonIdCounts.get(targetId) ?? 0;
+			if (localCount > 1) return false;
+			if (localTargetsAreIndexable && localCount === 1 && isValidOperonId(targetId)) return true;
             // Preserve the indexer's legacy/external fallback before requiring
             // a canonical ID for a local identity that is not indexable.
             return !!this.indexer.getTask(targetId);

--- a/src/core/task-writer.ts
+++ b/src/core/task-writer.ts
@@ -1261,13 +1261,17 @@ export class TaskWriter {
             .filter(yamlKey => Object.prototype.hasOwnProperty.call(frontmatter, yamlKey))
             .map(yamlKey => yamlScalar(frontmatter[yamlKey]))
 			.filter((value): value is string => value !== null && value.trim().length > 0);
-        if (identityEntries.length === 1) {
-            count(identityEntries[0]);
-        } else if (identityEntries.length > 1) {
+        const distinctIdentityEntries = [...new Set(identityEntries)];
+        if (distinctIdentityEntries.length === 1) {
+            // Multiple mapped YAML properties may intentionally mirror the
+            // same identity. The indexer resolves that as one task, so it is
+            // one local relationship target as well.
+            count(distinctIdentityEntries[0]);
+        } else if (distinctIdentityEntries.length > 1) {
             // The indexer selects one alias by priority, but a proposed source
-            // with multiple populated identities is not a safe local
+            // with distinct populated identities is not a safe local
             // relationship authority. Mark every candidate ambiguous.
-            for (const operonId of new Set(identityEntries)) {
+            for (const operonId of distinctIdentityEntries) {
                 count(operonId);
                 count(operonId);
             }

--- a/src/core/task-writer.ts
+++ b/src/core/task-writer.ts
@@ -1204,7 +1204,7 @@ export class TaskWriter {
             // a canonical ID for a local identity that is not indexable.
             return !!this.indexer.getTask(targetId);
         };
-        for (const [lineNumber, line] of this.sourceBodyLines(content)) {
+        for (const [lineNumber, line] of this.sourceIndexableTaskLines(content)) {
             const task = parseTaskLine(line, lineNumber, filePath, this.keyMappings);
             if (!task) continue;
             const fieldValues = Object.fromEntries(task.fields.map(field => [field.key, field.value]));
@@ -1238,7 +1238,7 @@ export class TaskWriter {
 			if (!isValidOperonId(rawOperonId)) return;
 			counts.set(rawOperonId, (counts.get(rawOperonId) ?? 0) + 1);
         };
-        for (const [lineNumber, line] of this.sourceBodyLines(content)) {
+        for (const [lineNumber, line] of this.sourceIndexableTaskLines(content)) {
             const task = parseTaskLine(line, lineNumber, filePath, this.keyMappings);
             if (task?.operonId) count(task.operonId);
         }
@@ -1279,10 +1279,16 @@ export class TaskWriter {
         return counts;
     }
 
-    private *sourceBodyLines(content: string): Iterable<[number, string]> {
+    /**
+     * Keep TaskWriter's local relationship authority on the same Markdown
+     * surface as the indexer: task-shaped examples inside fenced blocks are
+     * documentation, never executable task sources or recovery fences.
+     */
+    private *sourceIndexableTaskLines(content: string): Iterable<[number, string]> {
         let inFencedCodeBlock = false;
         for (const [lineNumber, line] of content.split('\n').entries()) {
-            if (/^\s*```/.test(line) || /^\s*~~~/.test(line)) {
+            const isFence = /^\s*(?:`{3,}|~{3,})/.test(line);
+            if (isFence) {
                 inFencedCodeBlock = !inFencedCodeBlock;
                 continue;
             }
@@ -1291,7 +1297,7 @@ export class TaskWriter {
     }
 
     private recordSourceRelationshipTargets(content: string, filePath: string): void {
-        for (const [lineNumber, line] of this.sourceBodyLines(content)) {
+        for (const [lineNumber, line] of this.sourceIndexableTaskLines(content)) {
             const task = parseTaskLine(line, lineNumber, filePath, this.keyMappings);
             if (!task) continue;
             const fieldValues = Object.fromEntries(task.fields.map(field => [field.key, field.value]));

--- a/src/indexer/indexer.ts
+++ b/src/indexer/indexer.ts
@@ -2409,6 +2409,11 @@ export class OperonIndexer {
 
 	// --- Query API ---
 
+	/** Whether a source path can contribute tasks to this index. */
+	isPathIndexable(filePath: string): boolean {
+		return !isOperonExcludedPath(filePath, this.storage.getSettings());
+	}
+
 	/** Get task by operonId. O(1) lookup. */
 	getTask(operonId: string): IndexedTask | undefined {
 		return this.tasks.get(operonId);


### PR DESCRIPTION
## Summary

- make a sealed source group's `expectedState` authoritative for its graph before-state:
  - `absent` always produces an absent before-state and a source `create`, even when deterministic seed content is available
  - `present` requires exact expected content
  - parent-source fallback applies only when no source group exists
- allow a task relationship to target a canonical Operon ID defined exactly once in the same proposed source
- keep missing, invalid, and duplicate same-source identities fail-closed
- preserve live-index fallback, including legacy-shaped identities already admitted by the index

## Why

Periodic-note creation with **Create as Operon Task** seals one new Markdown source containing:

1. a File Task container in YAML;
2. an inline child whose `parentTask` points to that container;
3. deterministic periodic seed content used to render the new note.

Two pre-write invariants previously rejected this valid graph.

First, graph preparation inferred source existence through `expectedContent ?? parentSourceContent`. For an absent periodic note, seed content could therefore turn the sealed before-state into `present`, making the first graph step attempt a `modify` instead of a `create`.

Second, once the source was treated as a creation, TaskWriter validated relationship targets only against the pre-write index. The new File Task container was present exactly once in the sealed after-state but was not indexed yet, so the child relationship was rejected before `vault.create`.

Both failures surfaced as `Identity graph source changed before the first commit.` No mutation had actually occurred.

## Invariants

- source existence is determined by the sealed `expectedState`, never by render seed content
- a relationship target is valid when it either already exists in the live index or is a valid canonical Operon ID defined exactly once in the same proposed source
- missing, invalid, or ambiguous identities remain rejected before mutation
- ordinary indexed relationship validation remains unchanged

## Validation

- exact regression fixture: `expectedState=absent`, `expectedContent=null`, parent seed present
- runtime integration: 18/18
- agent runtime and creation suites: green
- same-source YAML parent plus inline child: committed in the task-writer suite
- missing, invalid, and duplicate same-source targets: rejected
- live indexed and legacy-shaped indexed targets: preserved
- task-writer suite: 81/81
- TypeScript: green
- production build: green
- `git diff --check`: green

The repository-wide `npm run check` additionally reaches an unrelated Task Finder cold-start benchmark that exceeds its 150 ms machine threshold in both this branch and a clean sibling worktree (~190-204 ms); the deterministic behavioral suites above are green.

This remains intentionally separate from #182, which fixes Developer API adoption authorization.
