### PR TITLE
Fix Task Workflow settlement with modified-time plugins

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -262,6 +262,7 @@ import {
 	measureRuntimeTimingSpanV1,
 	executeRuntimeGraphTransactionCommitV1,
 	executeRuntimeGraphTransactionRecoveryV1,
+	reconcileRuntimeIdentityGraphSettlementV1,
 	classifyTimerControlRecoveryPrefixV1,
 	withRuntimeVaultMutationLockV1,
 	tryWithRuntimeVaultMutationLockV1,
@@ -12581,6 +12582,8 @@ export default class OperonPlugin extends Plugin {
 			let journal = admission.journal;
 			let journalOwned = false;
 			let appliedThisAttempt = false;
+			let livePostflightReconciliationEligible = false;
+			let liveCommitStartedAtEpochMs: number | null = null;
 			let groupResults: TaskWorkflowMutationResultV1['groupResults'] = [];
 			const affectedFilePaths = [...new Set(plan.affectedResources
 				.filter(resource => resource.resourceKind === 'task-source')
@@ -12651,7 +12654,7 @@ export default class OperonPlugin extends Plugin {
 					return this.agentRuntimeIdentityOutcomeUnknown(request.requestId, [], 'Identity graph recovery could not prove a safe terminal state.', plan.atomicGroups[0]?.groupId);
 				}
 				appliedThisAttempt = true;
-				groupResults = await this.agentRuntimeIdentityGroupResults(journal);
+				groupResults = await this.agentRuntimeIdentityGroupResults(journal.steps);
 			}
 			if (!journal) {
 				const applyStartedAt = new Date().toISOString();
@@ -12865,6 +12868,7 @@ export default class OperonPlugin extends Plugin {
 					);
 				}
 				try {
+					liveCommitStartedAtEpochMs = Date.now();
 					const execution = await executeRuntimeGraphTransactionCommitV1(
 						journal,
 						step => this.applyAgentRuntimeIdentityGraphStep(step, 'forward'),
@@ -12885,7 +12889,8 @@ export default class OperonPlugin extends Plugin {
 					}
 					if (execution.status !== 'committed') return this.agentRuntimeIdentityOutcomeUnknown(request.requestId, [], 'Identity graph commit stopped after a durable prefix.', plan.atomicGroups[0]?.groupId);
 					appliedThisAttempt = true;
-					groupResults = await this.agentRuntimeIdentityGroupResults(journal);
+					livePostflightReconciliationEligible = true;
+					groupResults = await this.agentRuntimeIdentityGroupResults(journal.steps);
 				} catch {
 					return this.agentRuntimeIdentityOutcomeUnknown(
 						request.requestId,
@@ -12907,7 +12912,27 @@ export default class OperonPlugin extends Plugin {
 					requestId: request.requestId,
 					mutationOwnedMaintenance: true,
 				});
-				if (!await this.verifyAgentRuntimeIdentityPlanAfterState(plan, journal?.steps)) throw new Error();
+				if (!journal) throw new Error();
+				if (livePostflightReconciliationEligible) {
+					if (liveCommitStartedAtEpochMs === null) throw new Error();
+					const settledGraph = await reconcileRuntimeIdentityGraphSettlementV1(
+						journal.steps,
+						step => this.readAgentRuntimeIdentityGraphState(step),
+						this.settings.keyMappings,
+						getExternalModifiedTimeFrontmatterPropertyNames(this.app),
+						{
+							applyStartedAtEpochMs: liveCommitStartedAtEpochMs,
+							settlementObservedAtEpochMs: Date.now(),
+						},
+					);
+					if (
+						!settledGraph.ok
+						|| !await this.verifyAgentRuntimeIdentityPlanAfterState(plan, settledGraph.observedSteps)
+					) throw new Error();
+					groupResults = await this.agentRuntimeIdentityGroupResults(settledGraph.observedSteps);
+				} else if (!await this.verifyAgentRuntimeIdentityPlanAfterState(plan, journal.steps)) {
+					throw new Error();
+				}
 				if (plan.capability === 'tasks.create.periodic-note.preview' || plan.capability === 'tasks.update.periodic-note.preview') {
 					const registry = await this.ensureAgentRuntimePeriodicRegistry(plan);
 					if (registry.status === 'uncertain') {
@@ -13277,12 +13302,12 @@ export default class OperonPlugin extends Plugin {
 			&& journal.targetDigest === plan.receiptTargetDigest;
 	}
 
-	private async agentRuntimeIdentityGroupResults(journal: GraphTransactionJournalV1): Promise<TaskWorkflowMutationResultV1['groupResults']> {
+	private async agentRuntimeIdentityGroupResults(steps: readonly GraphTransactionJournalStepV1[]): Promise<TaskWorkflowMutationResultV1['groupResults']> {
 		const repeatRevision = sha256HexV1(String(this.storage.repeatSeries.getRevision()));
-		return [...new Set(journal.steps.map(step => step.groupId))].map(groupId => ({
+		return [...new Set(steps.map(step => step.groupId))].map(groupId => ({
 			groupId,
 			status: 'committed' as const,
-			resourceRevisions: journal.steps.filter(step => step.groupId === groupId).map(step => ({
+			resourceRevisions: steps.filter(step => step.groupId === groupId).map(step => ({
 				resourceKind: step.resourceKind === 'repeat-series' ? 'repeat-series' as const : 'task-source' as const,
 				resourceKey: step.resourceKey,
 				revision: step.resourceKind === 'repeat-series' ? repeatRevision : sourceRevisionForTaskCreationV1(step.resourceKey, step.after.content),

--- a/main.ts
+++ b/main.ts
@@ -13365,15 +13365,33 @@ export default class OperonPlugin extends Plugin {
 			}
 			return true;
 		}
+		const reconciledSourceByPath = new Map(
+			(steps ?? [])
+				.filter(step => step.resourceKind === 'task-source' && step.after.content !== null)
+				.map(step => [step.resourceKey, step.after.content!] as const),
+		);
 		const sourceByPath = new Map<string, string>();
 		for (const effect of plan.createEffects) {
 			const indexed = this.indexer.getTaskSnapshot(effect.operonId);
+			let sourceContent = sourceByPath.get(effect.locator.filePath);
+			if (sourceContent === undefined) {
+				sourceContent = reconciledSourceByPath.get(effect.locator.filePath);
+				if (sourceContent === undefined) {
+					const source = await this.readAgentRuntimeMutationSource(effect.locator.filePath);
+					if (source.content === null) return false;
+					sourceContent = source.content;
+				}
+				sourceByPath.set(effect.locator.filePath, sourceContent);
+			}
+			const sourceWasReconciled = sha256HexV1(sourceContent) !== effect.plannedSourceDigest;
 			if (
 				!indexed
 				|| this.indexer.hasDuplicateOperonIdConflict(effect.operonId)
 				|| indexed.primary.filePath !== effect.locator.filePath
 				|| indexed.primary.format !== (effect.locator.representation === 'file' ? 'yaml' : 'inline')
-				|| (effect.locator.representation === 'inline' && indexed.primary.lineNumber !== effect.locator.lineNumber)
+				|| (effect.locator.representation === 'inline'
+					&& indexed.primary.lineNumber !== effect.locator.lineNumber
+					&& !sourceWasReconciled)
 				|| (effect.resolvedParentOperonId ?? '') !== (indexed.fieldValues['parentTask'] ?? '')
 			) return false;
 			const related = [...new Set(
@@ -13386,18 +13404,15 @@ export default class OperonPlugin extends Plugin {
 				const expected = [...new Set((effect.resolvedDependencies ?? []).filter(item => item.relation === relation).map(item => item.operonId))].sort();
 				if (canonicalJsonV1(toJsonValueV1(actual)) !== canonicalJsonV1(toJsonValueV1(expected))) return false;
 			}
-			let sourceContent = sourceByPath.get(effect.locator.filePath);
-			if (sourceContent === undefined) {
-				const source = await this.readAgentRuntimeMutationSource(effect.locator.filePath);
-				if (source.content === null) return false;
-				sourceContent = source.content;
-				sourceByPath.set(effect.locator.filePath, sourceContent);
-			}
-			if (sha256HexV1(sourceContent) !== effect.plannedSourceDigest) return false;
+			if (sourceWasReconciled && !reconciledSourceByPath.has(effect.locator.filePath)) return false;
 			const rendered = effect.locator.representation === 'file'
 				? sourceContent
-				: sourceContent.split(/\r?\n/u)[effect.locator.lineNumber];
-			if (rendered === undefined || sha256HexV1(rendered) !== effect.renderedTaskDigest) return false;
+				: sourceContent.split(/\r?\n/u)[indexed.primary.lineNumber ?? effect.locator.lineNumber];
+			if (
+				rendered === undefined
+				|| ((!sourceWasReconciled || effect.locator.representation === 'inline')
+					&& sha256HexV1(rendered) !== effect.renderedTaskDigest)
+			) return false;
 			if ('templateIdentityAllocations' in effect && effect.templateIdentityAllocations.some(allocation => !sourceContent.includes(allocation.operonId))) return false;
 			if (effect.repeatSeriesId) {
 				const entry = this.storage.repeatSeries.getEntry(effect.repeatSeriesId);

--- a/scripts/agent-runtime/contracts/run-contract-tests.mjs
+++ b/scripts/agent-runtime/contracts/run-contract-tests.mjs
@@ -58,6 +58,7 @@ const productionContractImporters = new Set([
 	'src/agent-runtime/runtime/context-source.ts',
 	'src/agent-runtime/runtime/facade.ts',
 	'src/agent-runtime/runtime/index.ts',
+	'src/agent-runtime/runtime/identity-graph-settlement.ts',
 	'src/agent-runtime/transport/dispatcher.ts',
 	'src/agent-runtime/transport/invocation-validator.ts',
 	'src/agent-runtime/transport/native-cli.ts',

--- a/scripts/agent-runtime/runtime/runtime-core.test.ts
+++ b/scripts/agent-runtime/runtime/runtime-core.test.ts
@@ -8,6 +8,7 @@ import {
 	toJsonValueV1,
 } from '../../../src/agent-runtime/contracts/v1/canonical';
 import { decodeCapabilityAdvertisementsV1 } from '../../../src/agent-runtime/contracts/v1/decode';
+import { getExternalModifiedTimeFrontmatterPropertyNames } from '../../../src/core/obsidian-app';
 import {
 	computeContextSettingsFingerprintV1,
 	createAgentRuntimeSessionId,
@@ -19,6 +20,7 @@ import {
 	RuntimeSettingsFreshnessCoordinatorV1,
 	buildIdentityPlaceholderCreateEffectsV1,
 	compareRebuiltIdentityPlaceholderPlanV1,
+	reconcileRuntimeIdentityGraphSettlementV1,
 	sealIdentityPlaceholderPreviewResultV1,
 	savedFilterQueryDigestV1,
 	SealedIndexRevisionV1,
@@ -50,6 +52,7 @@ async function run(): Promise<void> {
 	await testFrozenFacadeAndHealth();
 	await testPeriodicFacadeCapabilityRouting();
 	await testIdentityPlaceholderPreviewSealing();
+	await testIdentityGraphModifiedTimeSettlement();
 	await testTaskWorkflowGatewayIsolation();
 	await testHealthRevisionIsolationAndPerformance();
 	testSettingsFingerprintBoundary();
@@ -70,6 +73,111 @@ async function run(): Promise<void> {
 	await testDeadlineAndAbort();
 	await testSettingsFreshnessCoordinator();
 	console.log('Agent Runtime core tests passed');
+}
+
+async function testIdentityGraphModifiedTimeSettlement(): Promise<void> {
+	const beforeTimestamp = '2026-08-24T12:00';
+	const observedTimestamp = '2026-08-24T12:01';
+	const committed = [
+		'---',
+		'creation: 2026-08-20T09:00',
+		'modification: 2026-08-24T12:00',
+		'---',
+		'- [ ] Periodic task {{operonId:: abc1234}}',
+		'',
+	].join('\n');
+	const observed = committed.replace(
+		`modification: ${beforeTimestamp}`,
+		`modification: ${observedTimestamp}`,
+	);
+	const otherCommitted = committed.replace('abc1234', 'def5678');
+	const otherObserved = otherCommitted.replace(
+		`modification: ${beforeTimestamp}`,
+		`modification: ${observedTimestamp}`,
+	);
+	const state = (content: string) => ({
+		state: 'present' as const,
+		digest: sha256HexV1(content),
+		content,
+	});
+	const steps = [
+		{
+			stepId: 'source:Daily.md', groupId: 'periodic-update:abc1234',
+			resourceKind: 'task-source' as const, resourceKey: 'Daily.md', operation: 'modify' as const,
+			before: state(committed), after: state(committed),
+		},
+		{
+			stepId: 'source:Parent.md', groupId: 'periodic-update:abc1234',
+			resourceKind: 'task-source' as const, resourceKey: 'Parent.md', operation: 'modify' as const,
+			before: state(otherCommitted), after: state(otherCommitted),
+		},
+	];
+	const settlementWindow = {
+		applyStartedAtEpochMs: new Date(2026, 7, 24, 12, 0, 30).getTime(),
+		settlementObservedAtEpochMs: new Date(2026, 7, 24, 12, 1, 30).getTime(),
+	};
+	const settledByKey = new Map([['Daily.md', observed], ['Parent.md', otherObserved]]);
+	const accepted = await reconcileRuntimeIdentityGraphSettlementV1(
+		steps,
+		async step => state(settledByKey.get(step.resourceKey) ?? ''),
+		[],
+		['modification'],
+		settlementWindow,
+	);
+	assert.equal(accepted.ok, true, 'Periodic update admits one bounded configured drift per source.');
+	if (!accepted.ok) throw new Error('Expected accepted settlement fixture.');
+	assert.deepEqual(
+		accepted.observedSteps.map(step => step.after.digest),
+		[sha256HexV1(observed), sha256HexV1(otherObserved)],
+		'Observed graph proofs retain the actual settled source revisions.',
+	);
+	assert.deepEqual(
+		accepted.observedSteps.map(step => step.before.content),
+		[committed, otherCommitted],
+		'Sealed before states remain byte-identical.',
+	);
+
+	const updateTimeApp = {
+		plugins: {
+			getPlugin: (pluginId: string) => pluginId === 'update-time'
+				? { settings: { updatedPropertyName: 'viewedAt' } }
+				: null,
+		},
+	} as unknown as Parameters<typeof getExternalModifiedTimeFrontmatterPropertyNames>[0];
+	const dynamicProviderKeys = getExternalModifiedTimeFrontmatterPropertyNames(updateTimeApp);
+	assert.deepEqual(dynamicProviderKeys, ['viewedAt']);
+	const providerCommitted = committed.replace('modification:', 'viewedAt:');
+	const providerObserved = providerCommitted.replace(beforeTimestamp, observedTimestamp);
+	const providerStep = {
+		...steps[0],
+		before: state(providerCommitted),
+		after: state(providerCommitted),
+	};
+	const providerAccepted = await reconcileRuntimeIdentityGraphSettlementV1(
+		[providerStep],
+		async () => state(providerObserved),
+		[],
+		dynamicProviderKeys,
+		settlementWindow,
+	);
+	assert.equal(providerAccepted.ok, true, 'Runtime graph settlement composes with the active Update Time property name.');
+
+	for (const [label, drifted, keys, window] of [
+		['unconfigured property', observed, [], settlementWindow],
+		['body drift', observed.replace('Periodic task', 'Concurrent edit'), ['modification'], settlementWindow],
+		['second frontmatter line', observed.replace('creation: 2026-08-20T09:00', 'creation: 2026-08-24T12:01'), ['modification'], settlementWindow],
+		['drift before first commit attempt', observed, ['modification'], { applyStartedAtEpochMs: new Date(2026, 7, 24, 12, 2, 0).getTime(), settlementObservedAtEpochMs: new Date(2026, 7, 24, 12, 2, 30).getTime() }],
+		['outside settlement window', observed, ['modification'], { ...settlementWindow, settlementObservedAtEpochMs: settlementWindow.applyStartedAtEpochMs + 6 * 60_000 }],
+	] as const) {
+		const rejected = await reconcileRuntimeIdentityGraphSettlementV1(
+			steps.slice(0, 1),
+			async () => state(drifted),
+			[],
+			keys,
+			window,
+		);
+		assert.equal(rejected.ok, false, label);
+	}
 }
 
 async function testPeriodicFacadeCapabilityRouting(): Promise<void> {

--- a/scripts/agent-runtime/runtime/runtime-integration.test.mjs
+++ b/scripts/agent-runtime/runtime/runtime-integration.test.mjs
@@ -262,6 +262,25 @@ test('identity apply seals and verifies a bounded durable journal before its fir
 	assert.match(identityJournalSource, /new TextEncoder\(\)\.encode\(value\)\.byteLength/u);
 });
 
+test('identity graph live postflight reconciles only bounded modified-time source drift', () => {
+	const apply = methodBody(
+		mainSource,
+		'\tprivate async applyAgentRuntimeIdentityCreation(',
+		'\n\n\tprivate async ensureAgentRuntimePeriodicRegistry',
+	);
+	assert.match(apply, /reconcileRuntimeIdentityGraphSettlementV1\(/u);
+	assert.match(apply, /getExternalModifiedTimeFrontmatterPropertyNames\(this\.app\)/u);
+	assert.match(apply, /liveCommitStartedAtEpochMs = Date\.now\(\);[\s\S]*?executeRuntimeGraphTransactionCommitV1\(/u);
+	assert.match(apply, /applyStartedAtEpochMs: liveCommitStartedAtEpochMs/u);
+	assert.doesNotMatch(apply, /applyStartedAtEpochMs: Date\.parse\(journal\.effectiveAt\)/u);
+	assert.match(apply, /groupResults = await this\.agentRuntimeIdentityGroupResults\(settledGraph\.observedSteps\)/u);
+	assert.doesNotMatch(
+		methodBody(mainSource, '\tprivate agentRuntimeIdentityGraphStatesMatch(', '\n\n\tprivate async readAgentRuntimeIdentityGraphState'),
+		/modified|settlement|frontmatter/iu,
+		'CAS and recovery state matching must remain exact.',
+	);
+});
+
 test('task-workflow recovery admission preserves expired same-plan recovery and separates recovery audits', () => {
 	const binding = methodBody(
 		mainSource,

--- a/scripts/agent-runtime/runtime/runtime-integration.test.mjs
+++ b/scripts/agent-runtime/runtime/runtime-integration.test.mjs
@@ -362,3 +362,24 @@ test('identity apply refuses unreceipted after-state convergence before creating
 		/if \(await this\.verifyAgentRuntimeIdentityPlanAfterState\(plan\)\) \{[\s\S]*?'stale-source'/u,
 	);
 });
+
+test('identity creation verification uses the reconciled task-source state', () => {
+	const verify = methodBody(
+		mainSource,
+		'\tprivate async verifyAgentRuntimeIdentityPlanAfterState(',
+		'\n\n\tprivate agentRuntimeTaskWorkflowPreviewFailure',
+	);
+	assert.match(verify, /const reconciledSourceByPath = new Map/u);
+	assert.match(
+		verify,
+		/sourceContent = reconciledSourceByPath\.get\(effect\.locator\.filePath\)/u,
+	);
+	assert.match(
+		verify,
+		/sourceWasReconciled && !reconciledSourceByPath\.has\(effect\.locator\.filePath\)/u,
+	);
+	assert.match(
+		verify,
+		/indexed\.primary\.lineNumber \?\? effect\.locator\.lineNumber/u,
+	);
+});

--- a/src/agent-runtime/runtime/identity-graph-settlement.ts
+++ b/src/agent-runtime/runtime/identity-graph-settlement.ts
@@ -1,0 +1,60 @@
+import { sha256HexV1 } from '../contracts/v1/canonical';
+import type { KeyMapping } from '../../types/settings';
+import type { RuntimeMutationSettlementWindowV1 } from './mutation-gateway';
+import type {
+	GraphTransactionJournalStepV1,
+	GraphTransactionResourceStateV1,
+} from './receipts/graph-transaction-journal';
+import { resolveRuntimeSourceModifiedTimeSettlementRevisionV1 } from './task-mutation-adapter';
+
+export type RuntimeIdentityGraphSettlementResultV1 =
+	| { ok: true; observedSteps: GraphTransactionJournalStepV1[] }
+	| { ok: false };
+
+function statesMatch(
+	left: GraphTransactionResourceStateV1,
+	right: GraphTransactionResourceStateV1,
+): boolean {
+	return left.state === right.state
+		&& left.digest === right.digest
+		&& left.content === right.content;
+}
+
+/**
+ * Reconciles only the live post-commit after-state. Journal before/after
+ * fences, CAS, compensation, and recovery classification remain exact.
+ */
+export async function reconcileRuntimeIdentityGraphSettlementV1(
+	steps: readonly GraphTransactionJournalStepV1[],
+	readState: (step: GraphTransactionJournalStepV1) => Promise<GraphTransactionResourceStateV1>,
+	keyMappings: readonly KeyMapping[],
+	modifiedTimeFrontmatterKeys: readonly string[],
+	settlementWindow: RuntimeMutationSettlementWindowV1,
+): Promise<RuntimeIdentityGraphSettlementResultV1> {
+	const observedSteps: GraphTransactionJournalStepV1[] = [];
+	for (const step of steps) {
+		const observed = await readState(step);
+		if (statesMatch(observed, step.after)) {
+			observedSteps.push({ ...step, before: { ...step.before }, after: { ...observed } });
+			continue;
+		}
+		if (
+			step.resourceKind !== 'task-source'
+			|| step.after.state !== 'present'
+			|| step.after.content === null
+			|| observed.state !== 'present'
+			|| observed.content === null
+			|| sha256HexV1(observed.content) !== observed.digest
+		) return { ok: false };
+		const revision = resolveRuntimeSourceModifiedTimeSettlementRevisionV1(
+			step.after.content,
+			observed.content,
+			keyMappings,
+			modifiedTimeFrontmatterKeys,
+			settlementWindow,
+		);
+		if (revision !== observed.digest) return { ok: false };
+		observedSteps.push({ ...step, before: { ...step.before }, after: { ...observed } });
+	}
+	return { ok: true, observedSteps };
+}

--- a/src/agent-runtime/runtime/index.ts
+++ b/src/agent-runtime/runtime/index.ts
@@ -2,6 +2,7 @@ export * from './catalog-builder';
 export * from './coherent-read';
 export * from './facade';
 export * from './graph-transaction-executor';
+export * from './identity-graph-settlement';
 export * from './lifecycle';
 export * from './mutation-gateway';
 export * from './mutation-request-validator';

--- a/src/agent-runtime/runtime/task-mutation-adapter.ts
+++ b/src/agent-runtime/runtime/task-mutation-adapter.ts
@@ -151,6 +151,48 @@ function resolveBoundedModifiedTimeFrontmatterDriftV1(
 	return false;
 }
 
+/**
+ * Admits only the source-level modified-time drift owned by an active,
+ * supported frontmatter timestamp integration. Replacing the one observed
+ * drift line with its committed counterpart must restore the committed source
+ * byte-for-byte.
+ */
+export function resolveRuntimeSourceModifiedTimeSettlementRevisionV1(
+	committedSourceContent: string,
+	observedSourceContent: string,
+	keyMappings: readonly KeyMapping[],
+	modifiedTimeFrontmatterKeys: readonly string[] = [],
+	settlementWindow?: RuntimeMutationSettlementWindowV1,
+): string | null {
+	if (observedSourceContent === committedSourceContent) {
+		return sha256HexV1(observedSourceContent);
+	}
+	const committedLines = committedSourceContent.split('\n');
+	const observedLines = observedSourceContent.split('\n');
+	if (committedLines.length !== observedLines.length) return null;
+	const driftLineNumbers = committedLines.flatMap((line, index) => (
+		line !== observedLines[index] ? [index] : []
+	));
+	if (driftLineNumbers.length !== 1) return null;
+	const driftLineNumber = driftLineNumbers[0];
+	if (
+		driftLineNumber === undefined
+		|| !resolveBoundedModifiedTimeFrontmatterDriftV1(
+			committedLines,
+			observedLines,
+			driftLineNumber,
+			modifiedTimeFrontmatterKeys,
+			keyMappings,
+			settlementWindow,
+		)
+	) return null;
+	const restoredObservedLines = [...observedLines];
+	restoredObservedLines[driftLineNumber] = committedLines[driftLineNumber] ?? '';
+	return restoredObservedLines.join('\n') === committedSourceContent
+		? sha256HexV1(observedSourceContent)
+		: null;
+}
+
 export interface RuntimeExactTaskMutationSnapshotV1 {
 	readonly operonId: string;
 	readonly locator: TaskSourceLocatorV1;
@@ -287,27 +329,14 @@ export function resolveRuntimeInlineTaskUpdateSettlementEvidenceV1(
 	const observedLines = observedSourceContent.split('\n');
 	if (committedLines.length !== observedLines.length) return null;
 	if (prepared.task.locator.representation === 'file') {
-		const driftLineNumbers = committedLines.flatMap((line, index) => (
-			line !== observedLines[index] ? [index] : []
-		));
-		if (driftLineNumbers.length !== 1) return null;
-		const driftLineNumber = driftLineNumbers[0];
-		if (
-			driftLineNumber === undefined
-			|| !resolveBoundedModifiedTimeFrontmatterDriftV1(
-				committedLines,
-				observedLines,
-				driftLineNumber,
-				modifiedTimeFrontmatterKeys,
-				keyMappings,
-				settlementWindow,
-			)
-		) return null;
-		const restoredObservedLines = [...observedLines];
-		restoredObservedLines[driftLineNumber] = committedLines[driftLineNumber] ?? '';
-		return restoredObservedLines.join('\n') === committedSourceContent
-			? { revision: sha256HexV1(observedSourceContent) }
-			: null;
+		const revision = resolveRuntimeSourceModifiedTimeSettlementRevisionV1(
+			committedSourceContent,
+			observedSourceContent,
+			keyMappings,
+			modifiedTimeFrontmatterKeys,
+			settlementWindow,
+		);
+		return revision ? { revision } : null;
 	}
 	if (lineNumber < 0 || lineNumber >= committedLines.length) return null;
 	const nonTargetDriftLineNumbers = committedLines.flatMap((line, index) => (


### PR DESCRIPTION
## Summary

- reconcile only configured modified-time frontmatter drift during fresh Task Workflow postflight settlement
- keep before-state, CAS, reverse, compensation, and interrupted recovery byte-exact
- project durable resource revisions from the content actually observed after settlement
- resolve configured keys dynamically for Frontmatter Date Manager, Update Time, and Update time on edit

## Safety boundary

The exception is limited to one configured frontmatter timestamp line per task source, a canonical monotonically increasing value inside the live commit-to-settlement window, and a byte-identical document after restoring the sealed line. Any body edit, other property, duplicate key, out-of-window value, or interrupted recovery remains fail-closed.

## Validation

- `npm run agent-runtime:runtime:test` (18/18 integration)
- `npm run agent-runtime:mutation:test` (164/164; receipts 69/69)
- `npx tsc --noEmit --skipLibCheck`
- targeted ESLint strict
- `npm run build`
- `git diff --check`

This generalizes the bounded settlement invariant introduced by #135 to task-source identity graphs, including periodic scheduling, without making graph state comparison globally tolerant.