### PR TITLE
feat: add read-projection Developer API extension

### DIFF
--- a/docs/operon-docs/DOCS-129 In-process Developer API overview.md
+++ b/docs/operon-docs/DOCS-129 In-process Developer API overview.md
@@ -74,6 +74,46 @@ if (!workflowOperon || typeof workflowOperon.getTaskWorkflowDeveloperApiV1 !== "
 
 This extension has its own narrow, capability-projected API. Its exact grants cover `tasks.filter-query`, adoption preview/apply, and periodic create/update preview/apply; requesting one capability does not expose the others. The periodic methods are `tasks.createPeriodicNote.preview/apply/recover/pendingRecoveries` and `tasks.updatePeriodicNote.preview/apply/recover/pendingRecoveries`. See [[DOCS-130 Developer API identity and capability grants|Developer API identity and capability grants]] and [[DOCS-131 Developer API reads and typed mutations|Developer API reads and typed mutations]].
 
+## Read-projection extension
+
+Some integrations need the same bounded read DTOs that Operon uses to make a project decision, but must not receive the broad base API object. Use the separate additive `getReadProjectionDeveloperApiV1()` accessor. It leaves the frozen `getDeveloperApiV1()` surface untouched and exposes only the methods matching the exact capability set you request:
+
+| Capability | Projected method |
+| --- | --- |
+| `read-projection.system.diagnostics` | `api.system.diagnostics()` |
+| `read-projection.tasks.finder` | `api.tasks.find(request)` |
+| `read-projection.entities.resolve` | `api.entities.resolve(request)` |
+| `read-projection.relationships.read` | `api.relationships.get(request)` |
+| `read-projection.context.build` | `api.context.build(request)` |
+| `read-projection.timers.read` | `api.timers.read(request)` |
+
+```ts
+interface OperonReadProjectionDeveloperApiAccessorV1 {
+  getReadProjectionDeveloperApiV1(
+    consumerPlugin: object,
+    request: {
+      contractVersion: 1;
+      runtimeApi: { min: 1; max: 1 };
+      requestedCapabilities: readonly string[];
+    },
+  ): unknown;
+}
+
+const readProjectionOperon = hostApp.plugins.getPlugin("operon") as
+  | OperonReadProjectionDeveloperApiAccessorV1
+  | undefined;
+
+const access = readProjectionOperon?.getReadProjectionDeveloperApiV1(this, {
+  contractVersion: 1,
+  runtimeApi: { min: 1, max: 1 },
+  requestedCapabilities: ["read-projection.context.build"],
+});
+```
+
+The accessor validates both the caller request and each native result with the existing Runtime V1 decoders. It then returns a new, immutable allowlisted DTO: native objects, unexpected additive fields, and prototype-shaped data do not cross the extension boundary. Each call re-checks the consumer instance, lifecycle, exact extension grant, and live Runtime capability before dispatch and again after the awaited native read. An in-flight result is therefore fenced if either plugin reloads, the grant changes, the Runtime core is replaced, or its lifecycle leaves `ready` while the read is pending.
+
+Operon maintains the extension's explicit structural contract in `src/agent-runtime/extensions/read-projection-v1/public-contract.ts`, separately from its Runtime-backed implementation. The first matching type-only declaration must still be released by the standalone `operon-cli` contract package. Until a coordinated package release adds that declaration, integrations may use the small structural accessor interface above; they must not import private Operon source types.
+
 ## Open a discovery-only session
 
 Start without domain capabilities when you only need baseline health and capability status:
@@ -125,6 +165,8 @@ The Developer API is desktop-only and local to the current Obsidian process. It 
 **Can I use this from mobile, or from outside Obsidian?** No. It is desktop-only and local to the current Obsidian process. It is not a remote API, an HTTP or MCP server, a mobile API, or a sandbox for untrusted plugins. For anything outside the app, use `operon-cli`.
 
 **Why is there a second accessor for task workflows?** It keeps the established Developer API V1 surface unchanged while adding separately granted saved-filter, adoption, and periodic-note workflows. Do not send extension capability names to `getDeveloperApiV1()`; call `getTaskWorkflowDeveloperApiV1()` instead.
+
+**Why is there a separate read-projection accessor?** It gives a project-analysis integration exactly six typed read methods without widening the frozen base Developer API. Request only the method group you need through `getReadProjectionDeveloperApiV1()`; method presence is still not proof that the live grant remains active.
 
 ## Related
 

--- a/docs/operon-docs/DOCS-130 Developer API identity and capability grants.md
+++ b/docs/operon-docs/DOCS-130 Developer API identity and capability grants.md
@@ -75,6 +75,14 @@ Operon does not silently open a partially authorized session. If any requested c
 
 Unknown capability names are rejected. Method presence is not proof of support or authority. After access succeeds, use `api.hasCapability(name)` and the capability advertisements to confirm the live session scope.
 
+## Read-projection extension grants
+
+`getReadProjectionDeveloperApiV1()` is an additive read-only extension. It accepts only the following canonical, ordered, unique capability list: `read-projection.system.diagnostics`, `read-projection.tasks.finder`, `read-projection.entities.resolve`, `read-projection.relationships.read`, `read-projection.context.build`, and `read-projection.timers.read`. These are dedicated Developer API grant identities; they map to the corresponding Runtime read capability but are not interchangeable with the frozen base API capability names. The extension has no discovery-only bypass: even diagnostics needs its exact extension grant.
+
+The access request is all-or-nothing. A pending `read-projection.context.build` request does not expose `read-projection.entities.resolve`, and an approved finder grant does not imply relationships or timers. Operon re-checks the live consumer instance, lifecycle, grant and capability before dispatch and after the awaited Runtime call, immediately before returning the projected DTO. A reload, revocation or Runtime transition during an in-flight read therefore returns `authority-insufficient` instead of forwarding a result under stale authority.
+
+Read-projection request IDs are correlation values only. The extension sends a sealed snapshot of the caller request to the Runtime and accepts a result only when its `requestId` matches. It does not turn a request ID into an identity, consent or idempotency claim.
+
 ## User approval
 
 The first ungranted request does not open a modal. The user reviews it in **Settings → Operon → Core → General → Developer API Integrations**.
@@ -112,6 +120,8 @@ Developer API access and mutation preview, apply, and recovery inputs must not a
 **Can I supply my own identity, consent, or idempotency values?** No. Those fields belong to Operon, and mutation input containing host-owned fields is rejected as an invalid request rather than being ignored. The one identifier you generate is the `requestId` on Runtime read DTOs, which is a correlation value and not a claim of authority.
 
 **Can I ask `getDeveloperApiV1()` for a task-workflow capability?** No. The base accessor remains unchanged and rejects adoption and periodic-note extension capabilities. Request them through `getTaskWorkflowDeveloperApiV1()` instead.
+
+**Do base read grants cover the read-projection extension?** No. The extension requests its own exact six-capability vocabulary through `getReadProjectionDeveloperApiV1()`. It is deliberately separate so that frozen base API consumers do not gain a new surface by accident.
 
 ## Related
 

--- a/docs/operon-docs/DOCS-131 Developer API reads and typed mutations.md
+++ b/docs/operon-docs/DOCS-131 Developer API reads and typed mutations.md
@@ -27,6 +27,38 @@ After opening a session with the required exact grants, choose the narrowest met
 
 Runtime read requests carry contract fields including a request ID and consistency policy. Read results preserve typed freshness and warnings. Task and context result types also carry provenance and truncation information where their contracts define those fields. Do not discard available safety metadata when making decisions.
 
+## Narrow read projection for project analysis
+
+The `getReadProjectionDeveloperApiV1()` extension is for an integration that needs only a bounded analysis read surface. It projects six groups: diagnostics, task finder, entity resolution, relationships, Context Pack construction and timers. Request only one or the smallest ordered subset, then call only the projected method that exists on the returned session.
+
+```ts
+const readAccess = operon.getReadProjectionDeveloperApiV1(this, {
+  contractVersion: 1,
+  runtimeApi: { min: 1, max: 1 },
+  requestedCapabilities: [
+    "read-projection.context.build",
+    "read-projection.timers.read",
+  ],
+});
+
+if (!readAccess.ok) {
+  console.error(readAccess.error.code, readAccess.error.action);
+  return;
+}
+
+const context = await readAccess.api.context.build({
+  contractVersion: 1,
+  requestId: crypto.randomUUID(),
+  kind: "context",
+  consistency: "live-verified",
+  purpose: "analysis",
+  projection: "project-analysis",
+  selector: { kind: "operon-id", operonId },
+});
+```
+
+The result is an independent immutable snapshot, not a native Runtime object. Its `requestId`, `catalogRevision`, `asOf`, freshness, warnings, provenance and truncation data remain available when the Runtime contract supplies them. If the native result is malformed, has a different request ID, contains an invalid nested value, or the grant is no longer current, the extension fails closed with a typed result and does not pass the native value through.
+
 ```ts
 const result = await api.tasks.get({
   contractVersion: 1,

--- a/docs/operon-docs/DOCS-132 Developer API recovery, errors and audit.md
+++ b/docs/operon-docs/DOCS-132 Developer API recovery, errors and audit.md
@@ -109,15 +109,19 @@ Common actions include:
 
 | Error | What to do |
 | --- | --- |
+| `invalid-request` | Correct the exact request shape; do not retry it unchanged |
 | `unsupported-version` | Select a compatible Runtime API range or upgrade |
 | `capability-unavailable` | Rediscover live capabilities |
 | `authority-insufficient` | Request the exact grant and wait for user approval |
+| `handler-unavailable` | Treat the Runtime read handler or returned DTO as unavailable; inspect health before retrying |
 | `consent-denied` | Stop and do not prompt the same plan again |
 | `audit-unavailable` | Fix the environment before attempting a new write |
 | `receipt-store-unavailable` | Retry only the unchanged pre-dispatch apply |
 | `outcome-unknown` | Recover only the same plan |
 
 Unknown additive error codes mean stop and inspect. They never authorize an automatic retry.
+
+The read-projection extension preserves these distinctions at its own boundary: malformed caller input returns `invalid-request`; a missing, revoked or stale session grant returns `authority-insufficient`; and a throwing handler, malformed native DTO or mismatched native `requestId` returns `handler-unavailable`. It never rewrites all three cases into one generic failure.
 
 ## Security audit
 

--- a/docs/operon-docs/manifest.json
+++ b/docs/operon-docs/manifest.json
@@ -649,23 +649,23 @@
     },
     {
       "path": "DOCS-129 In-process Developer API overview.md",
-      "sha256": "3e4a2e7aa13e8c3e6082e1262be83b785495d6d5b96e07440e1e4a7ab7e4d1a8",
-      "bytes": 8637
+      "sha256": "59393f69bf2813ab5dd2318e7807c710d3cb9de0d3cc3f55ba25e4405065d764",
+      "bytes": 11498
     },
     {
       "path": "DOCS-130 Developer API identity and capability grants.md",
-      "sha256": "5d3a9e9d29c838d19c969a1f4626513de6d80a88a2147d14ddc59da3be9f9cf5",
-      "bytes": 8644
+      "sha256": "36386c9c738c3671989865c822069dccd409db8c7fc3653a0fff4fee35f2a0f0",
+      "bytes": 10405
     },
     {
       "path": "DOCS-131 Developer API reads and typed mutations.md",
-      "sha256": "1116752a4ba206a995fae54358ca51a34efc2687cd105fc96399a9266ac1ac64",
-      "bytes": 10019
+      "sha256": "663919f873f5298ac009412b3758e4aaa2643ec4ac3ec3bb85becef1e0aaac1d",
+      "bytes": 11497
     },
     {
       "path": "DOCS-132 Developer API recovery, errors and audit.md",
-      "sha256": "b47788f3ecb6746124b6c37a5bb20acca5de89f9756abb2cb58392e6188dcf08",
-      "bytes": 9353
+      "sha256": "763bb046fd8ba921765c83f02b1ee46dce5adee17d485f8a247e55143edafd80",
+      "bytes": 9934
     },
     {
       "path": "DOCS-133 JSONL sessions for scripts and agents.md",
@@ -703,5 +703,5 @@
       "bytes": 11348
     }
   ],
-  "generatedAt": "2026-08-29T17:29:20.153Z"
+  "generatedAt": "2026-08-30T03:32:20.374Z"
 }

--- a/main.ts
+++ b/main.ts
@@ -462,6 +462,13 @@ import {
 	type TaskWorkflowPreviewResultV1,
 	type TaskWorkflowSealedPlanV1,
 } from './src/agent-runtime/extensions/task-workflows-v1';
+import {
+	getOperonReadProjectionDeveloperApiV1,
+	isReadProjectionDeveloperCapabilityIdV1,
+	type ReadProjectionDeveloperApiAccessRequestV1,
+	type ReadProjectionDeveloperApiAccessResultV1,
+	type ReadProjectionDeveloperCapabilitySubsetV1,
+} from './src/agent-runtime/extensions/read-projection-v1';
 import type { FileTaskTemplateCandidateV1 } from './src/agent-runtime/contracts/v1/catalog';
 import type {
 	GeneralUpdateItemV1,
@@ -1606,6 +1613,22 @@ export default class OperonPlugin extends Plugin {
 		);
 	}
 
+	getReadProjectionDeveloperApiV1<
+		TCapabilities extends ReadProjectionDeveloperCapabilitySubsetV1,
+	>(
+		consumerPlugin: OperonDeveloperApiConsumerPluginV1,
+		request: ReadProjectionDeveloperApiAccessRequestV1<TCapabilities>,
+	): ReadProjectionDeveloperApiAccessResultV1<TCapabilities> {
+		const core = this.agentRuntimeCore ?? null;
+		return getOperonReadProjectionDeveloperApiV1(core, consumerPlugin, request, {
+			isDesktopAvailable: () => Platform.isDesktopApp,
+			isHostVersionSupported: () => requireApiVersion('1.12.2'),
+			lifecyclePhase: () => this.agentRuntimeLifecycle?.getPhase() ?? 'booting',
+			isCoreActive: candidate => this.agentRuntimeCore === candidate && this.agentRuntimeLifecycle?.getPhase() !== 'unloading',
+			grantController: this.developerApiGrantController,
+		});
+	}
+
 	private verifyDeveloperApiConsumer(
 		candidate: OperonDeveloperApiConsumerPluginV1,
 	): DeveloperApiConsumerDescriptorV1 | null {
@@ -1888,7 +1911,9 @@ export default class OperonPlugin extends Plugin {
 			listGrants: () => this.developerApiGrantController.list(),
 			approve: async (consumerId, capabilities) => {
 				const known = capabilities.filter((capability): capability is DeveloperApiGrantCapabilityV1 => (
-					isCapabilityIdV1(capability) || isTaskWorkflowCapabilityIdV1(capability)
+					isCapabilityIdV1(capability)
+					|| isTaskWorkflowCapabilityIdV1(capability)
+					|| isReadProjectionDeveloperCapabilityIdV1(capability)
 				));
 				await this.developerApiGrantController.approvePending(consumerId, known);
 			},

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"agent-runtime:mutation:live:published": "node scripts/release/run-published-cli-live-acceptance.mjs",
 		"agent-runtime:meeting:live:published": "node scripts/agent-runtime/cli/run-meeting-agent-acceptance.mjs",
 		"agent-runtime:fixtures:test": "python3 scripts/agent-runtime/fixtures/validate_fixtures.py && node scripts/agent-runtime/fixtures/run-fixture-tests.mjs",
-		"agent-runtime:developer-api": "node scripts/agent-runtime/developer-api/run-developer-api-tests.mjs && node scripts/agent-runtime/developer-api/security/run-security-tests.mjs && node --test scripts/agent-runtime/developer-api/developer-api-integration.test.mjs && npm run agent-runtime:developer-api:native-consumer:test",
+		"agent-runtime:developer-api": "node scripts/agent-runtime/developer-api/run-developer-api-tests.mjs && node scripts/agent-runtime/developer-api/security/run-security-tests.mjs && node --test scripts/agent-runtime/developer-api/developer-api-integration.test.mjs scripts/agent-runtime/developer-api/read-projection-consumer-compile.test.mjs && npm run agent-runtime:developer-api:native-consumer:test",
 		"developer-api:settings:test": "node scripts/run-developer-api-settings-tests.mjs",
 		"agent-runtime:developer-api:native-consumer:test": "node --test scripts/agent-runtime/developer-api/native-acceptance-consumer/native-consumer.test.mjs",
 		"agent-runtime:runtime": "node scripts/agent-runtime/runtime/run-graph-transaction-executor-tests.mjs && node scripts/agent-runtime/runtime/run-runtime-tests.mjs && node --test scripts/agent-runtime/runtime/runtime-integration.test.mjs",

--- a/scripts/agent-runtime/contracts/run-contract-tests.mjs
+++ b/scripts/agent-runtime/contracts/run-contract-tests.mjs
@@ -31,6 +31,7 @@ const productionContractImporters = new Set([
 	'src/agent-runtime/extensions/task-workflows-v1/developer-api.ts',
 	'src/agent-runtime/extensions/task-workflows-v1/task-workflow-mutation-session.ts',
 	'src/agent-runtime/extensions/task-workflows-v1/gateway.ts',
+	'src/agent-runtime/extensions/read-projection-v1/developer-api.ts',
 	'src/agent-runtime/runtime/types.ts',
 	'src/agent-runtime/runtime/catalog-builder.ts',
 	'src/agent-runtime/runtime/lifecycle.ts',

--- a/scripts/agent-runtime/developer-api/developer-api-grants.test.ts
+++ b/scripts/agent-runtime/developer-api/developer-api-grants.test.ts
@@ -67,6 +67,39 @@ test('records pending exact capabilities without granting partial access', () =>
 	assert.deepEqual(evaluation.effectiveCapabilities, []);
 });
 
+test('keeps base and read-projection grants in distinct exact scopes', () => {
+	const baseOnly = approveDeveloperApiCapabilities(
+		createEmptyDeveloperApiGrantPackage(),
+		consumer(),
+		['context.build'],
+		NOW,
+	);
+	const projectionRequest = evaluateDeveloperApiGrant(
+		baseOnly,
+		consumer(),
+		['read-projection.context.build'],
+	);
+	assert.equal(projectionRequest.state, 'pending');
+	assert.deepEqual(projectionRequest.grantedCapabilities, ['context.build']);
+	assert.deepEqual(projectionRequest.effectiveCapabilities, []);
+	assert.deepEqual(projectionRequest.pendingCapabilities, ['read-projection.context.build']);
+
+	const extensionOnly = approveDeveloperApiCapabilities(
+		createEmptyDeveloperApiGrantPackage(),
+		consumer(),
+		['read-projection.context.build'],
+		NOW,
+	);
+	assert.equal(
+		evaluateDeveloperApiGrant(extensionOnly, consumer(), ['read-projection.context.build']).state,
+		'active',
+	);
+	assert.equal(
+		evaluateDeveloperApiGrant(extensionOnly, consumer(), ['context.build']).state,
+		'pending',
+	);
+});
+
 test('dedupes semantically unchanged pending requests while persisting canonical supersets', () => {
 	const initial = recordDeveloperApiGrantRequest(
 		createEmptyDeveloperApiGrantPackage(),
@@ -410,7 +443,7 @@ test('grant controller verifies object identity and activates grants only after 
 	);
 });
 
-test('grant controller persists and restores an exact task-workflow extension grant', async () => {
+test('grant controller persists and restores exact additive extension grants', async () => {
 	let dataPackage = buildOperonDataPackageFromSettings(DEFAULT_SETTINGS);
 	const store = {
 		getDataPackage: () => structuredClone(dataPackage),
@@ -422,21 +455,25 @@ test('grant controller persists and restores an exact task-workflow extension gr
 		verify: () => consumer(),
 		isCurrent: () => true,
 	};
+	const extensionCapabilities = [
+		'tasks.filter-query',
+		'read-projection.context.build',
+	] as const;
 	const controller = new DeveloperApiGrantControllerV1({ store, verifier, now: () => new Date(NOW) });
-	controller.recordPending(consumer(), ['tasks.filter-query']);
+	controller.recordPending(consumer(), extensionCapabilities);
 	await controller.drain();
 	assert.deepEqual(
 		dataPackage.integrations.developerApi.consumersById['consumer.test']?.pendingCapabilities,
-		['tasks.filter-query'],
+		['read-projection.context.build', 'tasks.filter-query'],
 	);
-	await controller.approvePending('consumer.test', ['tasks.filter-query']);
-	assert.equal(controller.evaluate(consumer(), ['tasks.filter-query']).state, 'active');
+	await controller.approvePending('consumer.test', extensionCapabilities);
+	assert.equal(controller.evaluate(consumer(), extensionCapabilities).state, 'active');
 
 	const restarted = new DeveloperApiGrantControllerV1({ store, verifier, now: () => new Date(LATER) });
-	const restored = restarted.evaluate(consumer(), ['tasks.filter-query']);
+	const restored = restarted.evaluate(consumer(), extensionCapabilities);
 	assert.equal(restored.state, 'active');
-	assert.deepEqual(restored.effectiveCapabilities, ['tasks.filter-query']);
-	assert.deepEqual(restored.grantedCapabilities, ['tasks.filter-query']);
+	assert.deepEqual(restored.effectiveCapabilities, ['read-projection.context.build', 'tasks.filter-query']);
+	assert.deepEqual(restored.grantedCapabilities, ['read-projection.context.build', 'tasks.filter-query']);
 });
 
 test('grant controller keeps a queued first request pending until its durable record is written', async () => {

--- a/scripts/agent-runtime/developer-api/developer-api-integration.test.mjs
+++ b/scripts/agent-runtime/developer-api/developer-api-integration.test.mjs
@@ -75,7 +75,7 @@ test('general settings persistence preserves the host-owned Developer API grant 
 	assert.match(persistSettings, /developerApi: currentDeveloperApi,/u);
 });
 
-test('settings grant approval admits exact base and task-workflow extension capabilities', () => {
+test('settings grant approval admits exact base and additive extension capabilities', () => {
 	const settingsIntegration = methodBody(
 		mainSource,
 		'\tprivate buildDeveloperApiSettingsIntegration(): DeveloperApiSettingsIntegration',
@@ -83,7 +83,7 @@ test('settings grant approval admits exact base and task-workflow extension capa
 	);
 	assert.match(
 		settingsIntegration,
-		/isCapabilityIdV1\(capability\) \|\| isTaskWorkflowCapabilityIdV1\(capability\)/u,
+		/isCapabilityIdV1\(capability\)[\s\S]*?\|\| isTaskWorkflowCapabilityIdV1\(capability\)[\s\S]*?\|\| isReadProjectionDeveloperCapabilityIdV1\(capability\)/u,
 	);
 	assert.match(
 		settingsIntegration,

--- a/scripts/agent-runtime/developer-api/read-projection-consumer-compile.test.mjs
+++ b/scripts/agent-runtime/developer-api/read-projection-consumer-compile.test.mjs
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const tscPath = require.resolve('typescript/bin/tsc');
+const fixture = fileURLToPath(new URL('./read-projection-consumer-compile.ts', import.meta.url));
+const repositoryRoot = path.resolve(path.dirname(fixture), '../../..');
+
+test('a clean TypeScript consumer compiles against the public read-projection structural export', () => {
+	const result = spawnSync(process.execPath, [
+		tscPath,
+		'--noEmit',
+		'--pretty', 'false',
+		'--skipLibCheck',
+		'--strictNullChecks',
+		'--noImplicitAny',
+		'--resolveJsonModule',
+		'--esModuleInterop',
+		'--target', 'ES2020',
+		'--module', 'ESNext',
+		'--moduleResolution', 'node',
+		fixture,
+	], { cwd: repositoryRoot, encoding: 'utf8' });
+	assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+});

--- a/scripts/agent-runtime/developer-api/read-projection-consumer-compile.ts
+++ b/scripts/agent-runtime/developer-api/read-projection-consumer-compile.ts
@@ -1,5 +1,6 @@
 import type {
 	OperonReadProjectionDeveloperApiAccessorV1,
+	ReadProjectionDeveloperApiAccessResultV1,
 	ReadProjectionDeveloperApiAccessRequestV1,
 } from '../../../src/agent-runtime/extensions/read-projection-v1/public-contract';
 import type { OperonDeveloperApiConsumerPluginV1 } from '../../../src/agent-runtime/public/v1';
@@ -15,15 +16,29 @@ const request = {
 
 const access = operon.getReadProjectionDeveloperApiV1(consumer, request);
 if (access.ok) {
-	void access.api.context.build({
-		contractVersion: 1,
-		requestId: 'consumer-compile-context',
-		kind: 'context',
-		consistency: 'live-verified',
-		purpose: 'analysis',
-		projection: 'project-analysis',
-		selector: { kind: 'operon-id', operonId: 'abc1234' },
-	});
+	const api = access.api;
+	void consumeReadOnlyContext();
+	async function consumeReadOnlyContext(): Promise<void> {
+		const result = await api.context.build({
+			contractVersion: 1,
+			requestId: 'consumer-compile-context',
+			kind: 'context',
+			consistency: 'live-verified',
+			purpose: 'analysis',
+			projection: 'project-analysis',
+			selector: { kind: 'operon-id', operonId: 'abc1234' },
+		});
+		const requestId: string = result.requestId;
+		void requestId;
+		// @ts-expect-error DeepReadonlyV1 snapshots must not expose mutable warning arrays.
+		result.warnings.push();
+	}
 	// @ts-expect-error A context-only grant must not project the task finder.
 	void access.api.tasks.find;
+}
+
+declare const denied: ReadProjectionDeveloperApiAccessResultV1<readonly ['read-projection.context.build']>;
+if (!denied.ok) {
+	// @ts-expect-error The structured access error is part of the frozen public snapshot.
+	denied.error.code = 'handler-unavailable';
 }

--- a/scripts/agent-runtime/developer-api/read-projection-consumer-compile.ts
+++ b/scripts/agent-runtime/developer-api/read-projection-consumer-compile.ts
@@ -1,0 +1,29 @@
+import type {
+	OperonReadProjectionDeveloperApiAccessorV1,
+	ReadProjectionDeveloperApiAccessRequestV1,
+} from '../../../src/agent-runtime/extensions/read-projection-v1/public-contract';
+import type { OperonDeveloperApiConsumerPluginV1 } from '../../../src/agent-runtime/public/v1';
+
+declare const operon: OperonReadProjectionDeveloperApiAccessorV1;
+declare const consumer: OperonDeveloperApiConsumerPluginV1;
+
+const request = {
+	contractVersion: 1,
+	runtimeApi: { min: 1, max: 1 },
+	requestedCapabilities: ['read-projection.context.build'],
+} as const satisfies ReadProjectionDeveloperApiAccessRequestV1<readonly ['read-projection.context.build']>;
+
+const access = operon.getReadProjectionDeveloperApiV1(consumer, request);
+if (access.ok) {
+	void access.api.context.build({
+		contractVersion: 1,
+		requestId: 'consumer-compile-context',
+		kind: 'context',
+		consistency: 'live-verified',
+		purpose: 'analysis',
+		projection: 'project-analysis',
+		selector: { kind: 'operon-id', operonId: 'abc1234' },
+	});
+	// @ts-expect-error A context-only grant must not project the task finder.
+	void access.api.tasks.find;
+}

--- a/scripts/agent-runtime/developer-api/read-projection-developer-api.test.ts
+++ b/scripts/agent-runtime/developer-api/read-projection-developer-api.test.ts
@@ -1,0 +1,421 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	decodeContextPackV1,
+	decodeEntityResolutionResultV1,
+	decodeRelationshipResultV1,
+	decodeRuntimeDiagnosticsV1,
+	decodeTaskFinderResultV1,
+	decodeTimerReadResultV1,
+} from '../../../src/agent-runtime/contracts/v1/decode';
+import {
+	getOperonReadProjectionDeveloperApiV1,
+	projectContextPackV1,
+	projectEntityResolutionResultV1,
+	projectRelationshipResultV1,
+	projectRuntimeDiagnosticsV1,
+	projectTaskFinderResultV1,
+	projectTimerReadResultV1,
+	type ReadProjectionDeveloperApiAccessRequestV1,
+	type ReadProjectionDeveloperCapabilitySubsetV1,
+} from '../../../src/agent-runtime/extensions/read-projection-v1';
+import type { DeveloperApiGrantEvaluationV1 } from '../../../src/agent-runtime/developer-api/grants';
+import type { OperonDeveloperApiConsumerPluginV1 } from '../../../src/agent-runtime/public/v1/developer-api';
+import type { OperonAgentRuntimeCoreV1 } from '../../../src/agent-runtime/runtime/types';
+import type { RuntimeLifecyclePhaseV1 } from '../../../src/agent-runtime/contracts/v1/lifecycle';
+
+const consumerPlugin = {
+	manifest: { id: 'read-projection.test', name: 'Read projection test', version: '1.0.0' },
+} as OperonDeveloperApiConsumerPluginV1;
+const consumer = { id: 'read-projection.test', name: 'Read projection test', version: '1.0.0', instanceEpoch: 'instance-1' };
+const runtimeCapabilities = [
+	'system.diagnostics', 'tasks.finder', 'entities.resolve',
+	'relationships.read', 'context.build', 'timers.read',
+] as const;
+const projectionCapabilities = [
+	'read-projection.system.diagnostics', 'read-projection.tasks.finder',
+	'read-projection.entities.resolve', 'read-projection.relationships.read',
+	'read-projection.context.build', 'read-projection.timers.read',
+] as const;
+const allAccess: ReadProjectionDeveloperApiAccessRequestV1<ReadProjectionDeveloperCapabilitySubsetV1> = {
+	contractVersion: 1,
+	runtimeApi: { min: 1, max: 1 },
+	requestedCapabilities: projectionCapabilities,
+};
+const stamp = '2026-08-30T00:00:00.000Z';
+const hash = (character: string) => character.repeat(64);
+const freshness = { source: 'live-runtime' as const, coherence: 'verified' as const, observedAt: stamp, settled: true };
+const contextRevision = {
+	index: { sessionId: 'index-session', ramGeneration: 1, durable: { status: 'available' as const, snapshotId: 'snapshot-1', committedAt: stamp } },
+	settingsFingerprint: hash('a'), pinnedGeneration: 0, activeTrackerGeneration: 0,
+	repeatSeriesRevision: 0, projectSerialGeneration: 0, projectSerialSignature: hash('b'),
+};
+const task = {
+	identity: { operonId: 'abc1234', validity: 'canonical' as const, mutationAllowed: true },
+	description: 'Projection test task', representation: 'inline' as const,
+	locator: { representation: 'inline' as const, filePath: 'Tasks.md', lineNumber: 0 }, checkbox: 'open' as const,
+	dates: {}, datetimes: {},
+	relationships: { childOperonIds: [], blockingOperonIds: [], blockedByOperonIds: [], relatedOperonIds: [] },
+	recurrence: { repeating: false }, tracker: { active: false, sessionCount: 0 }, pinned: false,
+	sourceRevision: { algorithm: 'sha256' as const, contentDigest: hash('c') }, contextRevision,
+};
+const relationshipSet = { explicit: [], derived: [], inferred: [] };
+const contextPack = () => ({
+	contractVersion: 1 as const, requestId: 'context-1', kind: 'context-pack' as const,
+	purpose: 'analysis' as const, projection: 'project-analysis' as const, ok: true as const,
+	execution: { ...freshness, nativeSentinel: 'must-not-cross' }, contextRevision,
+	catalogRevision: hash('d'), asOf: stamp, entities: [task], relationships: relationshipSet,
+	provenance: [], truncations: [], warnings: [],
+});
+const taskFinderResult = () => ({
+	contractVersion: 1 as const, requestId: 'finder-1', kind: 'task-finder-result' as const, ok: true as const,
+	freshness, warnings: [], contextRevision,
+	rows: [{ kind: 'task' as const, task, score: 0.99 }],
+	page: { actualCount: 1, returnedCount: 1, truncated: false, asOf: stamp }, provenance: [], truncations: [],
+});
+const entityResult = () => ({
+	contractVersion: 1 as const, requestId: 'entity-1', kind: 'entity-resolution-result' as const, ok: true as const,
+	freshness, warnings: [], contextRevision, resolution: 'resolved' as const,
+	candidates: [{ identity: task.identity, description: task.description, locator: task.locator, confidence: 1, reasons: ['exact'], selector: { kind: 'operon-id' as const, operonId: 'abc1234' } }],
+	selected: { identity: task.identity, description: task.description, locator: task.locator, confidence: 1, reasons: ['exact'], selector: { kind: 'operon-id' as const, operonId: 'abc1234' } },
+});
+const relationshipResult = () => ({
+	contractVersion: 1 as const, requestId: 'relationship-1', kind: 'relationship-result' as const, ok: true as const,
+	freshness, warnings: [], contextRevision, relationships: relationshipSet, tasks: [task], provenance: [], truncations: [],
+});
+const timerResult = () => ({
+	contractVersion: 1 as const, requestId: 'timer-1', kind: 'timer-read-result' as const, ok: true as const,
+	freshness, warnings: [], contextRevision,
+	state: { active: null, transition: null },
+});
+const diagnostics = () => ({
+	contractVersion: 1 as const, kind: 'runtime-diagnostics' as const,
+	health: {
+		apiVersion: 1 as const, contractVersion: 1 as const, ok: true as const,
+		lifecyclePhase: 'ready' as const, v8PersistencePhase: 'idle' as const,
+		compatibility: { contractVersion: 1 as const, runtimeApi: { min: 1, max: 1 } },
+		capabilities: runtimeCapabilities.map(id => ({ id, availability: 'available' as const, stability: 'stable' as const })),
+		freshness, admission: { reads: true, writes: true }, warnings: [],
+	},
+	capabilities: runtimeCapabilities.map(id => ({ id, availability: 'available' as const, stability: 'stable' as const })),
+	warnings: [],
+});
+
+function runtime(): OperonAgentRuntimeCoreV1 {
+	return {
+		hasCapability: (capability: string) => runtimeCapabilities.includes(capability as typeof runtimeCapabilities[number]),
+		system: { capabilities: () => runtimeCapabilities.map(id => ({ id, availability: 'available' as const, stability: 'stable' as const })), diagnostics: async () => diagnostics() },
+		tasks: { find: async () => taskFinderResult() },
+		entities: { resolve: async () => entityResult() },
+		relationships: { get: async () => relationshipResult() },
+		context: { build: async () => contextPack() },
+		timers: { read: async () => timerResult() },
+	} as unknown as OperonAgentRuntimeCoreV1;
+}
+
+interface AccessState {
+	grant: DeveloperApiGrantEvaluationV1['state'];
+	current: boolean;
+	pending: number;
+	coreActive?: boolean;
+	lifecycle?: RuntimeLifecyclePhaseV1;
+}
+
+function open(core: OperonAgentRuntimeCoreV1, state: AccessState) {
+	return getOperonReadProjectionDeveloperApiV1(core, consumerPlugin, allAccess, {
+		isDesktopAvailable: () => true,
+		isHostVersionSupported: () => true,
+		lifecyclePhase: () => state.lifecycle ?? 'ready',
+		isCoreActive: candidate => state.coreActive !== false && candidate === core,
+		grantController: {
+			verifyConsumer: candidate => candidate === consumerPlugin ? consumer : null,
+			isConsumerCurrent: () => state.current,
+			evaluate: () => ({
+				state: state.grant, revision: 1,
+				grantedCapabilities: state.grant === 'active' ? [...projectionCapabilities] : [],
+				effectiveCapabilities: state.grant === 'active' ? [...projectionCapabilities] : [],
+				pendingCapabilities: state.grant === 'pending' ? [...projectionCapabilities] : [],
+				reason: state.grant === 'active'
+					? 'active'
+					: state.grant === 'revoked'
+						? 'revoked'
+						: 'capability-approval-required',
+			}),
+			recordPending: () => { state.pending += 1; },
+		},
+	});
+}
+
+test('read-projection context prototype rejects invalid packs and strips native additive fields', () => {
+	const valid = contextPack();
+	assert.equal(decodeContextPackV1(valid).ok, true);
+	const projected = projectContextPackV1(valid);
+	assert.ok(projected?.ok);
+	assert.equal(projected?.requestId, 'context-1');
+	assert.equal(projected?.catalogRevision, hash('d'));
+	assert.equal(projected?.asOf, stamp);
+	assert.equal('nativeSentinel' in (projected?.execution ?? {}), false);
+	assert.equal(Object.isFrozen(projected), true);
+
+	const invalidPlacement = { ...valid, placement: { mode: 'files', actualCount: 0, returnedCount: 0, truncated: false, files: [] } };
+	assert.equal(decodeContextPackV1(invalidPlacement).ok, false);
+	assert.equal(projectContextPackV1(invalidPlacement), null);
+	for (const key of ['__proto__', 'constructor', 'prototype']) {
+		const poisoned = structuredClone(valid) as Record<string, unknown>;
+		Object.defineProperty(poisoned.relationships as Record<string, unknown>, key, {
+			value: 'sentinel', enumerable: true, configurable: true,
+		});
+		assert.equal(decodeContextPackV1(poisoned).ok, false, `${key} must fail decoder admission`);
+		assert.equal(projectContextPackV1(poisoned), null, `${key} must not cross the projector`);
+	}
+	(valid.entities[0] as { description: string }).description = 'source mutated after projection';
+	assert.equal(projected?.ok && projected.entities[0]?.description, 'Projection test task');
+});
+
+test('read-projection access is exact, grant-bound, session-bound and version-gated', async () => {
+	const core = runtime();
+	const state = { grant: 'pending' as DeveloperApiGrantEvaluationV1['state'], current: true, pending: 0 };
+	const unverifiedConsumer = getOperonReadProjectionDeveloperApiV1(core, consumerPlugin, allAccess, {
+		isDesktopAvailable: () => true, isHostVersionSupported: () => true, lifecyclePhase: () => 'ready', isCoreActive: candidate => candidate === core,
+		grantController: { verifyConsumer: () => null, isConsumerCurrent: () => true, evaluate: () => ({ state: 'active', revision: 1, grantedCapabilities: [...projectionCapabilities], effectiveCapabilities: [...projectionCapabilities], pendingCapabilities: [], reason: 'active' }), recordPending: () => undefined },
+	});
+	assert.equal(unverifiedConsumer.ok, false);
+	if (!unverifiedConsumer.ok) assert.equal(unverifiedConsumer.error.code, 'authority-insufficient');
+	const baseOnlyGrant = getOperonReadProjectionDeveloperApiV1(core, consumerPlugin, allAccess, {
+		isDesktopAvailable: () => true, isHostVersionSupported: () => true, lifecyclePhase: () => 'ready', isCoreActive: candidate => candidate === core,
+		grantController: {
+			verifyConsumer: () => consumer,
+			isConsumerCurrent: () => true,
+			evaluate: () => ({
+				state: 'pending', revision: 1,
+				grantedCapabilities: [...runtimeCapabilities],
+				effectiveCapabilities: [],
+				pendingCapabilities: [...projectionCapabilities],
+				reason: 'capability-approval-required',
+			}),
+			recordPending: () => undefined,
+		},
+	});
+	assert.equal(baseOnlyGrant.ok, false, 'a frozen base API grant must not admit the projection accessor');
+	if (!baseOnlyGrant.ok) assert.equal(baseOnlyGrant.error.code, 'authority-insufficient');
+	const pending = open(core, state);
+	assert.equal(pending.ok, false);
+	assert.equal(state.pending, 1);
+	state.grant = 'active';
+	const invalidVersion = getOperonReadProjectionDeveloperApiV1(core, consumerPlugin, { ...allAccess, runtimeApi: { min: 2, max: 2 } }, {
+		isDesktopAvailable: () => true, isHostVersionSupported: () => true, lifecyclePhase: () => 'ready', isCoreActive: candidate => candidate === core,
+		grantController: { verifyConsumer: () => consumer, isConsumerCurrent: () => true, evaluate: () => ({ state: 'active', revision: 1, grantedCapabilities: [...projectionCapabilities], effectiveCapabilities: [...projectionCapabilities], pendingCapabilities: [], reason: 'active' }), recordPending: () => undefined },
+	});
+	assert.equal(invalidVersion.ok, false);
+	if (!invalidVersion.ok) assert.equal(invalidVersion.error.code, 'unsupported-version');
+	const opened = open(core, state);
+	assert.equal(opened.ok, true);
+	if (!opened.ok) return;
+	assert.deepEqual(Object.keys(opened.api.context), ['build']);
+	assert.equal(opened.api.hasCapability('read-projection.context.build'), true);
+	state.current = false;
+	const stale = await opened.api.context.build({ contractVersion: 1, requestId: 'context-stale', kind: 'context', consistency: 'live-verified', purpose: 'analysis', projection: 'project-analysis', selector: { kind: 'operon-id', operonId: 'abc1234' } });
+	assert.equal(stale.ok, false);
+	if (!stale.ok) assert.equal(stale.error.code, 'authority-insufficient');
+});
+
+test('all six read projections are decoder-admitted, request-correlated, copied and frozen', async () => {
+	const state = { grant: 'active' as DeveloperApiGrantEvaluationV1['state'], current: true, pending: 0 };
+	const opened = open(runtime(), state);
+	assert.equal(opened.ok, true);
+	if (!opened.ok) return;
+	const [system, finder, entity, relationship, context, timer] = await Promise.all([
+		opened.api.system.diagnostics(),
+		opened.api.tasks.find({ contractVersion: 1, requestId: 'finder-1', kind: 'task-finder', consistency: 'live-verified' }),
+		opened.api.entities.resolve({ contractVersion: 1, requestId: 'entity-1', kind: 'entity-resolve', consistency: 'live-verified', selector: { kind: 'operon-id', operonId: 'abc1234' } }),
+		opened.api.relationships.get({ contractVersion: 1, requestId: 'relationship-1', kind: 'relationship', consistency: 'live-verified', selector: { kind: 'operon-id', operonId: 'abc1234' } }),
+		opened.api.context.build({ contractVersion: 1, requestId: 'context-1', kind: 'context', consistency: 'live-verified', purpose: 'analysis', projection: 'project-analysis', selector: { kind: 'operon-id', operonId: 'abc1234' } }),
+		opened.api.timers.read({ contractVersion: 1, requestId: 'timer-1', kind: 'timer-read', consistency: 'live-verified' }),
+	]);
+	assert.equal(decodeRuntimeDiagnosticsV1(system).ok, true);
+	assert.equal(decodeTaskFinderResultV1(finder).ok, true);
+	assert.equal(decodeEntityResolutionResultV1(entity).ok, true);
+	assert.equal(decodeRelationshipResultV1(relationship).ok, true);
+	assert.equal(decodeContextPackV1(context).ok, true);
+	assert.equal(decodeTimerReadResultV1(timer).ok, true);
+	assert.equal(Object.isFrozen(context), true);
+	assert.equal(Object.isFrozen((context as { entities?: unknown[] }).entities?.[0]), true);
+});
+
+test('read-projection snapshots caller input and rejects a mismatched native request id', async () => {
+	const state = { grant: 'active' as DeveloperApiGrantEvaluationV1['state'], current: true, pending: 0 };
+	const core = runtime() as unknown as { tasks: { find: (request: unknown) => Promise<unknown> } } & OperonAgentRuntimeCoreV1;
+	let observed: unknown;
+	core.tasks.find = async request => {
+		observed = request;
+		return { ...taskFinderResult(), requestId: 'native-mismatch' };
+	};
+	const opened = open(core, state);
+	assert.equal(opened.ok, true);
+	if (!opened.ok) return;
+	const request = { contractVersion: 1 as const, requestId: 'finder-original', kind: 'task-finder' as const, consistency: 'live-verified' as const };
+	const result = await opened.api.tasks.find(request);
+	assert.notEqual(observed, request);
+	assert.equal(Object.isFrozen(observed), true);
+	assert.equal(result.requestId, 'finder-original');
+	assert.equal(result.ok, false);
+	if (!result.ok) assert.equal(result.error.code, 'handler-unavailable');
+});
+
+test('all six reads close an in-flight result when the exact extension grant is revoked', async () => {
+	const diagnosticsGate = deferred<ReturnType<typeof diagnostics>>();
+	const finderGate = deferred<ReturnType<typeof taskFinderResult>>();
+	const entityGate = deferred<ReturnType<typeof entityResult>>();
+	const relationshipGate = deferred<ReturnType<typeof relationshipResult>>();
+	const contextGate = deferred<ReturnType<typeof contextPack>>();
+	const timerGate = deferred<ReturnType<typeof timerResult>>();
+	const core = runtime() as unknown as {
+		system: { diagnostics: () => Promise<ReturnType<typeof diagnostics>> };
+		tasks: { find: () => Promise<ReturnType<typeof taskFinderResult>> };
+		entities: { resolve: () => Promise<ReturnType<typeof entityResult>> };
+		relationships: { get: () => Promise<ReturnType<typeof relationshipResult>> };
+		context: { build: () => Promise<ReturnType<typeof contextPack>> };
+		timers: { read: () => Promise<ReturnType<typeof timerResult>> };
+	} & OperonAgentRuntimeCoreV1;
+	core.system.diagnostics = () => diagnosticsGate.promise;
+	core.tasks.find = () => finderGate.promise;
+	core.entities.resolve = () => entityGate.promise;
+	core.relationships.get = () => relationshipGate.promise;
+	core.context.build = () => contextGate.promise;
+	core.timers.read = () => timerGate.promise;
+	const state: AccessState = { grant: 'active', current: true, pending: 0 };
+	const opened = open(core, state);
+	assert.equal(opened.ok, true);
+	if (!opened.ok) return;
+	const pending = [
+		opened.api.system.diagnostics(),
+		opened.api.tasks.find({ contractVersion: 1, requestId: 'finder-1', kind: 'task-finder', consistency: 'live-verified' }),
+		opened.api.entities.resolve({ contractVersion: 1, requestId: 'entity-1', kind: 'entity-resolve', consistency: 'live-verified', selector: { kind: 'operon-id', operonId: 'abc1234' } }),
+		opened.api.relationships.get({ contractVersion: 1, requestId: 'relationship-1', kind: 'relationship', consistency: 'live-verified', selector: { kind: 'operon-id', operonId: 'abc1234' } }),
+		opened.api.context.build({ contractVersion: 1, requestId: 'context-1', kind: 'context', consistency: 'live-verified', purpose: 'analysis', projection: 'project-analysis', selector: { kind: 'operon-id', operonId: 'abc1234' } }),
+		opened.api.timers.read({ contractVersion: 1, requestId: 'timer-1', kind: 'timer-read', consistency: 'live-verified' }),
+	] as const;
+	state.grant = 'revoked';
+	diagnosticsGate.resolve(diagnostics());
+	finderGate.resolve(taskFinderResult());
+	entityGate.resolve(entityResult());
+	relationshipGate.resolve(relationshipResult());
+	contextGate.resolve(contextPack());
+	timerGate.resolve(timerResult());
+	const [diagnosticResult, ...readResults] = await Promise.all(pending);
+	assert.equal(diagnosticResult.health.ok, false);
+	if (!diagnosticResult.health.ok) assert.equal(diagnosticResult.health.error.code, 'authority-insufficient');
+	for (const result of readResults) {
+		assert.equal(result.ok, false);
+		if (!result.ok) assert.equal(result.error.code, 'authority-insufficient');
+	}
+});
+
+test('read-projection failures preserve invalid-request, authority, and handler fidelity', async () => {
+	const state: AccessState = { grant: 'active', current: true, pending: 0 };
+	const opened = open(runtime(), state);
+	assert.equal(opened.ok, true);
+	if (!opened.ok) return;
+	const invalid = await opened.api.tasks.find({
+		contractVersion: 1,
+		requestId: 'invalid-finder',
+		kind: 'task-finder',
+		consistency: 'live-verified',
+		unexpected: true,
+	} as never);
+	assert.equal(invalid.ok, false);
+	if (!invalid.ok) assert.equal(invalid.error.code, 'invalid-request');
+	state.current = false;
+	const denied = await opened.api.tasks.find({ contractVersion: 1, requestId: 'denied-finder', kind: 'task-finder', consistency: 'live-verified' });
+	assert.equal(denied.ok, false);
+	if (!denied.ok) assert.equal(denied.error.code, 'authority-insufficient');
+	state.current = true;
+	const malformedCore = runtime();
+	(malformedCore.tasks as unknown as { find: () => Promise<unknown> }).find = async () => ({ malformed: true });
+	const malformedAccess = open(malformedCore, state);
+	assert.equal(malformedAccess.ok, true);
+	if (!malformedAccess.ok) return;
+	const unavailable = await malformedAccess.api.tasks.find({ contractVersion: 1, requestId: 'unavailable-finder', kind: 'task-finder', consistency: 'live-verified' });
+	assert.equal(unavailable.ok, false);
+	if (!unavailable.ok) assert.equal(unavailable.error.code, 'handler-unavailable');
+});
+
+test('diagnostics rechecks consumer reload and reads recheck core and lifecycle after await', async () => {
+	const diagnosticGate = deferred<ReturnType<typeof diagnostics>>();
+	const finderGate = deferred<ReturnType<typeof taskFinderResult>>();
+	const contextGate = deferred<ReturnType<typeof contextPack>>();
+	const core = runtime() as unknown as {
+		system: { diagnostics: () => Promise<ReturnType<typeof diagnostics>> };
+		tasks: { find: () => Promise<ReturnType<typeof taskFinderResult>> };
+		context: { build: () => Promise<ReturnType<typeof contextPack>> };
+	} & OperonAgentRuntimeCoreV1;
+	core.system.diagnostics = () => diagnosticGate.promise;
+	core.tasks.find = () => finderGate.promise;
+	core.context.build = () => contextGate.promise;
+	const state: AccessState = { grant: 'active', current: true, pending: 0 };
+	const opened = open(core, state);
+	assert.equal(opened.ok, true);
+	if (!opened.ok) return;
+
+	const diagnosticPromise = opened.api.system.diagnostics();
+	state.current = false;
+	diagnosticGate.resolve(diagnostics());
+	assert.equal((await diagnosticPromise).health.ok, false, 'consumer reload must fence diagnostics');
+
+	state.current = true;
+	const finderPromise = opened.api.tasks.find({ contractVersion: 1, requestId: 'finder-1', kind: 'task-finder', consistency: 'live-verified' });
+	state.coreActive = false;
+	finderGate.resolve(taskFinderResult());
+	assert.equal((await finderPromise).ok, false, 'core replacement must fence a finder result');
+
+	state.coreActive = true;
+	const contextPromise = opened.api.context.build({ contractVersion: 1, requestId: 'context-1', kind: 'context', consistency: 'live-verified', purpose: 'analysis', projection: 'project-analysis', selector: { kind: 'operon-id', operonId: 'abc1234' } });
+	state.lifecycle = 'settling';
+	contextGate.resolve(contextPack());
+	assert.equal((await contextPromise).ok, false, 'lifecycle transition must fence a context result');
+});
+
+test('decoder/projector parity is fail-closed across all six result DTOs', () => {
+	for (const [decode, project, valid] of [
+		[decodeRuntimeDiagnosticsV1, projectRuntimeDiagnosticsV1, diagnostics()],
+		[decodeTaskFinderResultV1, projectTaskFinderResultV1, taskFinderResult()],
+		[decodeEntityResolutionResultV1, projectEntityResolutionResultV1, entityResult()],
+		[decodeRelationshipResultV1, projectRelationshipResultV1, relationshipResult()],
+		[decodeContextPackV1, projectContextPackV1, contextPack()],
+		[decodeTimerReadResultV1, projectTimerReadResultV1, timerResult()],
+	] as const) {
+		assert.equal(decode(valid).ok, true);
+		assert.ok(project(valid));
+		const malformed = { ...valid, contractVersion: 999 };
+		assert.equal(decode(malformed).ok, false);
+		assert.equal(project(malformed), null);
+	}
+});
+
+test('every read projection removes decoder-admitted additive freshness fields', () => {
+	const samples: Array<{
+		value: Record<string, unknown>;
+		decode: (value: unknown) => { ok: boolean };
+		project: (value: unknown) => object | null;
+		freshnessAt: (value: Record<string, unknown>) => Record<string, unknown>;
+	}> = [
+		{ value: taskFinderResult(), decode: decodeTaskFinderResultV1, project: projectTaskFinderResultV1, freshnessAt: value => value.freshness as Record<string, unknown> },
+		{ value: entityResult(), decode: decodeEntityResolutionResultV1, project: projectEntityResolutionResultV1, freshnessAt: value => value.freshness as Record<string, unknown> },
+		{ value: relationshipResult(), decode: decodeRelationshipResultV1, project: projectRelationshipResultV1, freshnessAt: value => value.freshness as Record<string, unknown> },
+		{ value: timerResult(), decode: decodeTimerReadResultV1, project: projectTimerReadResultV1, freshnessAt: value => value.freshness as Record<string, unknown> },
+		{ value: diagnostics(), decode: decodeRuntimeDiagnosticsV1, project: projectRuntimeDiagnosticsV1, freshnessAt: value => (value.health as Record<string, unknown>).freshness as Record<string, unknown> },
+	];
+	for (const sample of samples) {
+		sample.freshnessAt(sample.value).nativeSentinel = 'must-not-cross';
+		assert.equal(sample.decode(sample.value).ok, true, 'response-open freshness is decoder-admitted');
+		const projected = sample.project(sample.value);
+		assert.ok(projected);
+		assert.equal('nativeSentinel' in sample.freshnessAt(projected as Record<string, unknown>), false);
+	}
+});
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>(settle => { resolve = settle; });
+	return { promise, resolve };
+}

--- a/scripts/agent-runtime/developer-api/read-projection-developer-api.test.ts
+++ b/scripts/agent-runtime/developer-api/read-projection-developer-api.test.ts
@@ -311,6 +311,52 @@ test('all six reads close an in-flight result when the exact extension grant is 
 	}
 });
 
+test('all six rejected reads recheck the exact extension grant before classifying the failure', async () => {
+	const diagnosticsGate = deferred<ReturnType<typeof diagnostics>>();
+	const finderGate = deferred<ReturnType<typeof taskFinderResult>>();
+	const entityGate = deferred<ReturnType<typeof entityResult>>();
+	const relationshipGate = deferred<ReturnType<typeof relationshipResult>>();
+	const contextGate = deferred<ReturnType<typeof contextPack>>();
+	const timerGate = deferred<ReturnType<typeof timerResult>>();
+	const core = runtime() as unknown as {
+		system: { diagnostics: () => Promise<ReturnType<typeof diagnostics>> };
+		tasks: { find: () => Promise<ReturnType<typeof taskFinderResult>> };
+		entities: { resolve: () => Promise<ReturnType<typeof entityResult>> };
+		relationships: { get: () => Promise<ReturnType<typeof relationshipResult>> };
+		context: { build: () => Promise<ReturnType<typeof contextPack>> };
+		timers: { read: () => Promise<ReturnType<typeof timerResult>> };
+	} & OperonAgentRuntimeCoreV1;
+	core.system.diagnostics = () => diagnosticsGate.promise;
+	core.tasks.find = () => finderGate.promise;
+	core.entities.resolve = () => entityGate.promise;
+	core.relationships.get = () => relationshipGate.promise;
+	core.context.build = () => contextGate.promise;
+	core.timers.read = () => timerGate.promise;
+	const state: AccessState = { grant: 'active', current: true, pending: 0 };
+	const opened = open(core, state);
+	assert.equal(opened.ok, true);
+	if (!opened.ok) return;
+	const pending = [
+		opened.api.system.diagnostics(),
+		opened.api.tasks.find({ contractVersion: 1, requestId: 'finder-rejection', kind: 'task-finder', consistency: 'live-verified' }),
+		opened.api.entities.resolve({ contractVersion: 1, requestId: 'entity-rejection', kind: 'entity-resolve', consistency: 'live-verified', selector: { kind: 'operon-id', operonId: 'abc1234' } }),
+		opened.api.relationships.get({ contractVersion: 1, requestId: 'relationship-rejection', kind: 'relationship', consistency: 'live-verified', selector: { kind: 'operon-id', operonId: 'abc1234' } }),
+		opened.api.context.build({ contractVersion: 1, requestId: 'context-rejection', kind: 'context', consistency: 'live-verified', purpose: 'analysis', projection: 'project-analysis', selector: { kind: 'operon-id', operonId: 'abc1234' } }),
+		opened.api.timers.read({ contractVersion: 1, requestId: 'timer-rejection', kind: 'timer-read', consistency: 'live-verified' }),
+	] as const;
+	state.grant = 'revoked';
+	for (const gate of [diagnosticsGate, finderGate, entityGate, relationshipGate, contextGate, timerGate]) {
+		gate.reject(new Error('native read rejected'));
+	}
+	const [diagnosticResult, ...readResults] = await Promise.all(pending);
+	assert.equal(diagnosticResult.health.ok, false);
+	if (!diagnosticResult.health.ok) assert.equal(diagnosticResult.health.error.code, 'authority-insufficient');
+	for (const result of readResults) {
+		assert.equal(result.ok, false);
+		if (!result.ok) assert.equal(result.error.code, 'authority-insufficient');
+	}
+});
+
 test('read-projection failures preserve invalid-request, authority, and handler fidelity', async () => {
 	const state: AccessState = { grant: 'active', current: true, pending: 0 };
 	const opened = open(runtime(), state);
@@ -414,8 +460,12 @@ test('every read projection removes decoder-admitted additive freshness fields',
 	}
 });
 
-function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (reason?: unknown) => void } {
 	let resolve!: (value: T) => void;
-	const promise = new Promise<T>(settle => { resolve = settle; });
-	return { promise, resolve };
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
 }

--- a/scripts/agent-runtime/developer-api/run-developer-api-tests.mjs
+++ b/scripts/agent-runtime/developer-api/run-developer-api-tests.mjs
@@ -10,6 +10,7 @@ try {
 	for (const entry of [
 		'developer-api.test.ts',
 		'task-workflows-developer-api.test.ts',
+		'read-projection-developer-api.test.ts',
 		'developer-api-grants.test.ts',
 		'operon-storage-grant-persistence.test.ts',
 		'recovery-store.test.ts',

--- a/src/agent-runtime/developer-api/grants.ts
+++ b/src/agent-runtime/developer-api/grants.ts
@@ -3,8 +3,15 @@ import {
 	type CapabilityIdV1,
 } from '../contracts/v1/capabilities';
 import { isTaskWorkflowCapabilityIdV1, type TaskWorkflowCapabilityIdV1 } from '../extensions/task-workflows-v1';
+import {
+	isReadProjectionDeveloperCapabilityIdV1,
+	type ReadProjectionDeveloperCapabilityIdV1,
+} from '../extensions/read-projection-v1/contracts';
 
-export type DeveloperApiGrantCapabilityV1 = CapabilityIdV1 | TaskWorkflowCapabilityIdV1;
+export type DeveloperApiGrantCapabilityV1 =
+	| CapabilityIdV1
+	| TaskWorkflowCapabilityIdV1
+	| ReadProjectionDeveloperCapabilityIdV1;
 
 export const DEVELOPER_API_GRANT_PACKAGE_VERSION = 1 as const;
 
@@ -498,7 +505,11 @@ function replaceRecord(
 function normalizeCapabilities(value: unknown): DeveloperApiGrantCapabilityV1[] {
 	if (!Array.isArray(value)) return [];
 	return [...new Set(value.filter((item): item is DeveloperApiGrantCapabilityV1 => (
-		typeof item === 'string' && (isCapabilityIdV1(item) || isTaskWorkflowCapabilityIdV1(item))
+		typeof item === 'string' && (
+			isCapabilityIdV1(item)
+			|| isTaskWorkflowCapabilityIdV1(item)
+			|| isReadProjectionDeveloperCapabilityIdV1(item)
+		)
 	)))].sort((left, right) => left.localeCompare(right));
 }
 

--- a/src/agent-runtime/extensions/read-projection-v1/contracts.ts
+++ b/src/agent-runtime/extensions/read-projection-v1/contracts.ts
@@ -1,0 +1,35 @@
+import type { CapabilityIdV1 } from '../../contracts/v1/capabilities';
+
+/**
+ * These are Developer API grant identities, not Runtime V1 capability ids.
+ * Keeping the namespaces distinct prevents a base API grant from admitting
+ * the narrower read-projection accessor implicitly.
+ */
+export const READ_PROJECTION_DEVELOPER_CAPABILITY_IDS_V1 = [
+	'read-projection.system.diagnostics',
+	'read-projection.tasks.finder',
+	'read-projection.entities.resolve',
+	'read-projection.relationships.read',
+	'read-projection.context.build',
+	'read-projection.timers.read',
+] as const;
+
+export type ReadProjectionDeveloperCapabilityIdV1 =
+	typeof READ_PROJECTION_DEVELOPER_CAPABILITY_IDS_V1[number];
+
+export const READ_PROJECTION_RUNTIME_CAPABILITY_BY_GRANT_V1: Readonly<
+	Record<ReadProjectionDeveloperCapabilityIdV1, CapabilityIdV1>
+> = Object.freeze({
+	'read-projection.system.diagnostics': 'system.diagnostics',
+	'read-projection.tasks.finder': 'tasks.finder',
+	'read-projection.entities.resolve': 'entities.resolve',
+	'read-projection.relationships.read': 'relationships.read',
+	'read-projection.context.build': 'context.build',
+	'read-projection.timers.read': 'timers.read',
+});
+
+export function isReadProjectionDeveloperCapabilityIdV1(
+	value: string,
+): value is ReadProjectionDeveloperCapabilityIdV1 {
+	return (READ_PROJECTION_DEVELOPER_CAPABILITY_IDS_V1 as readonly string[]).includes(value);
+}

--- a/src/agent-runtime/extensions/read-projection-v1/developer-api.ts
+++ b/src/agent-runtime/extensions/read-projection-v1/developer-api.ts
@@ -170,6 +170,7 @@ function createSession<
 				if (!active('read-projection.system.diagnostics')) return diagnosticsFailure('authority-insufficient', 'The read-projection diagnostics capability is no longer active for this session.');
 				return projected ?? diagnosticsFailure('handler-unavailable', 'Operon returned an invalid diagnostics DTO.');
 			} catch {
+				if (!active('read-projection.system.diagnostics')) return diagnosticsFailure('authority-insufficient', 'The read-projection diagnostics capability is no longer active for this session.');
 				return diagnosticsFailure('handler-unavailable', 'Operon diagnostics are unavailable.');
 			}
 		};
@@ -241,7 +242,7 @@ async function runRead<TRequest extends { readonly requestId: string }, TResult 
 		if (!admitted()) return readFailure(kind, requestId, 'authority-insufficient', 'The requested read-projection capability is no longer active for this session.') as TResult;
 		if (projected && projected.requestId === requestId) return projected;
 	} catch {
-		// An invalid native result is not allowed to cross the public boundary.
+		if (!admitted()) return readFailure(kind, requestId, 'authority-insufficient', 'The requested read-projection capability is no longer active for this session.') as TResult;
 	}
 	return readFailure(kind, requestId, 'handler-unavailable', 'Operon returned an invalid read DTO.') as TResult;
 }
@@ -260,7 +261,7 @@ async function runContextRead(
 		if (!admitted()) return contextFailure(requestId, decoded.value, 'authority-insufficient', 'The read-projection context capability is no longer active for this session.');
 		if (projected && projected.requestId === requestId) return projected;
 	} catch {
-		// An invalid native result is not allowed to cross the public boundary.
+		if (!admitted()) return contextFailure(requestId, decoded.value, 'authority-insufficient', 'The read-projection context capability is no longer active for this session.');
 	}
 	return contextFailure(requestId, decoded.value, 'handler-unavailable', 'Operon returned an invalid context DTO.');
 }

--- a/src/agent-runtime/extensions/read-projection-v1/developer-api.ts
+++ b/src/agent-runtime/extensions/read-projection-v1/developer-api.ts
@@ -1,0 +1,696 @@
+import type {
+	ContextPackV1,
+	ContextRequestV1,
+	EntityResolutionResultV1,
+	EntityResolveRequestV1,
+	RelationshipRequestV1,
+	RelationshipResultV1,
+	TaskFinderRequestV1,
+	TaskFinderResultV1,
+} from '../../contracts/v1/context';
+import {
+	decodeContextPackV1,
+	decodeContextRequestV1,
+	decodeEntityResolutionResultV1,
+	decodeEntityResolveRequestV1,
+	decodeRelationshipRequestV1,
+	decodeRelationshipResultV1,
+	decodeRuntimeDiagnosticsV1,
+	decodeTaskFinderRequestV1,
+	decodeTaskFinderResultV1,
+	decodeTimerReadRequestV1,
+	decodeTimerReadResultV1,
+} from '../../contracts/v1/decode';
+import type { RuntimeDiagnosticsV1, RuntimeLifecyclePhaseV1 } from '../../contracts/v1/lifecycle';
+import { structuredErrorV1, type StructuredErrorV1 } from '../../contracts/v1/primitives';
+import type { TimerReadRequestV1, TimerReadResultV1 } from '../../contracts/v1/timer';
+import type { DeveloperApiGrantControllerV1 } from '../../developer-api/grant-controller';
+import type { DeveloperApiConsumerDescriptorV1 } from '../../developer-api/grants';
+import type { OperonDeveloperApiConsumerPluginV1 } from '../../public/v1/developer-api';
+import type { OperonAgentRuntimeCoreV1 } from '../../runtime/types';
+import {
+	isReadProjectionDeveloperCapabilityIdV1,
+	READ_PROJECTION_DEVELOPER_CAPABILITY_IDS_V1,
+	READ_PROJECTION_RUNTIME_CAPABILITY_BY_GRANT_V1,
+} from './contracts';
+import type {
+	OperonReadProjectionDeveloperApiV1,
+	ReadProjectionDeveloperAccessCapabilityV1,
+	ReadProjectionDeveloperApiAccessRequestV1,
+	ReadProjectionDeveloperApiAccessResultV1,
+	ReadProjectionDeveloperCapabilitySubsetV1,
+} from './public-contract';
+
+export type {
+	OperonReadProjectionDeveloperApiAccessorV1,
+	OperonReadProjectionDeveloperApiV1,
+	ReadProjectionDeveloperAccessCapabilityV1,
+	ReadProjectionDeveloperApiAccessRequestV1,
+	ReadProjectionDeveloperApiAccessResultV1,
+	ReadProjectionDeveloperCapabilitySubsetV1,
+} from './public-contract';
+
+/**
+ * The native Runtime facade deliberately remains private. This extension is a
+ * second public boundary for integrations that need the six read DTOs used by
+ * project analysis, without receiving an open-ended Runtime object.
+ */
+const ACCESS_CAPABILITIES_V1 = READ_PROJECTION_DEVELOPER_CAPABILITY_IDS_V1;
+
+export interface ReadProjectionDeveloperApiRuntimeOptionsV1 {
+	readonly isDesktopAvailable: () => boolean;
+	readonly isHostVersionSupported: () => boolean;
+	readonly lifecyclePhase: () => RuntimeLifecyclePhaseV1;
+	readonly isCoreActive: (core: OperonAgentRuntimeCoreV1) => boolean;
+	readonly grantController: Pick<
+		DeveloperApiGrantControllerV1,
+		'verifyConsumer' | 'isConsumerCurrent' | 'evaluate' | 'recordPending'
+	>;
+}
+
+/**
+ * Additive accessor: it never changes, delegates to, or widens
+ * getDeveloperApiV1(). Read results are decoded, bound to their request id,
+ * then reconstructed as a strict public snapshot before crossing this seam.
+ */
+export function getOperonReadProjectionDeveloperApiV1<
+	TCapabilities extends ReadProjectionDeveloperCapabilitySubsetV1,
+>(
+	core: OperonAgentRuntimeCoreV1 | null,
+	consumerPlugin: OperonDeveloperApiConsumerPluginV1,
+	request: ReadProjectionDeveloperApiAccessRequestV1<TCapabilities>,
+	options: ReadProjectionDeveloperApiRuntimeOptionsV1,
+): ReadProjectionDeveloperApiAccessResultV1<TCapabilities> {
+	const decoded = decodeAccessRequest(request);
+	if (!decoded) return failure('invalid-request', 'The read-projection Developer API access request is invalid.');
+	try {
+		if (!options.isDesktopAvailable() || !options.isHostVersionSupported()) {
+			return failure('unsupported-platform', 'The read-projection Developer API requires supported Obsidian Desktop.');
+		}
+		if (!core || !options.isCoreActive(core)) {
+			return failure('handler-unavailable', 'The Operon Runtime facade is unavailable.');
+		}
+		if (decoded.runtimeApi.min > 1 || decoded.runtimeApi.max < 1) {
+			return failure('unsupported-version', 'The requested Runtime API range does not include V1.');
+		}
+		const consumer = options.grantController.verifyConsumer(consumerPlugin);
+		if (!consumer) return failure('authority-insufficient', 'The Developer API consumer is not the active host plugin instance.');
+		const grant = options.grantController.evaluate(consumer, decoded.requestedCapabilities);
+		if (grant.state !== 'active') {
+			if (grant.state === 'pending') options.grantController.recordPending(consumer, decoded.requestedCapabilities);
+			return failure('authority-insufficient', 'The requested read-projection capability set requires an active exact-capability grant.');
+		}
+		if (options.lifecyclePhase() !== 'ready') {
+			return failure('live-settling', 'The Operon Runtime is not ready.', true);
+		}
+		for (const capability of decoded.requestedCapabilities) {
+			const runtimeCapability = READ_PROJECTION_RUNTIME_CAPABILITY_BY_GRANT_V1[capability];
+			const advertised = core.system.capabilities().find(item => item.id === runtimeCapability);
+			if (!advertised || (advertised.availability !== 'available' && advertised.availability !== 'degraded')) {
+				return failure('capability-unavailable', `The read-projection Developer API capability is unavailable: ${capability}.`);
+			}
+		}
+		return freezeStructure({
+			contractVersion: 1,
+			kind: 'read-projection-developer-api-access-result',
+			ok: true,
+			api: createSession(core, consumer, decoded.requestedCapabilities, options),
+		});
+	} catch {
+		return failure('handler-unavailable', 'The read-projection Developer API accessor is unavailable.');
+	}
+}
+
+function createSession<
+	TCapabilities extends ReadProjectionDeveloperCapabilitySubsetV1,
+>(
+	core: OperonAgentRuntimeCoreV1,
+	consumer: DeveloperApiConsumerDescriptorV1,
+	requested: TCapabilities,
+	options: ReadProjectionDeveloperApiRuntimeOptionsV1,
+): OperonReadProjectionDeveloperApiV1<TCapabilities> {
+	const requestedSet = new Set<ReadProjectionDeveloperAccessCapabilityV1>(requested);
+	const active = (capability: ReadProjectionDeveloperAccessCapabilityV1): boolean => {
+		try {
+			const runtimeCapability = READ_PROJECTION_RUNTIME_CAPABILITY_BY_GRANT_V1[capability];
+			return requestedSet.has(capability)
+				&& options.isCoreActive(core)
+				&& options.grantController.isConsumerCurrent(consumer)
+				&& options.lifecyclePhase() === 'ready'
+				&& core.hasCapability(runtimeCapability)
+				&& options.grantController.evaluate(consumer, requested).effectiveCapabilities.includes(capability);
+		} catch {
+			return false;
+		}
+	};
+	const api: Record<string, unknown> = {
+		contractVersion: 1,
+		runtimeApi: 1,
+		hasCapability: (capability: string) => (
+			isReadProjectionCapability(capability) && active(capability)
+		),
+		system: {},
+		tasks: {},
+		entities: {},
+		relationships: {},
+		context: {},
+		timers: {},
+	};
+	const system = api.system as Record<string, unknown>;
+	const tasks = api.tasks as Record<string, unknown>;
+	const entities = api.entities as Record<string, unknown>;
+	const relationships = api.relationships as Record<string, unknown>;
+	const context = api.context as Record<string, unknown>;
+	const timers = api.timers as Record<string, unknown>;
+	if (requestedSet.has('read-projection.system.diagnostics')) {
+		system.diagnostics = async (): Promise<RuntimeDiagnosticsV1> => {
+			if (!active('read-projection.system.diagnostics')) return diagnosticsFailure('authority-insufficient', 'The read-projection diagnostics capability is not active for this session.');
+			try {
+				const projected = projectRuntimeDiagnosticsV1(await core.system.diagnostics());
+				if (!active('read-projection.system.diagnostics')) return diagnosticsFailure('authority-insufficient', 'The read-projection diagnostics capability is no longer active for this session.');
+				return projected ?? diagnosticsFailure('handler-unavailable', 'Operon returned an invalid diagnostics DTO.');
+			} catch {
+				return diagnosticsFailure('handler-unavailable', 'Operon diagnostics are unavailable.');
+			}
+		};
+	}
+	if (requestedSet.has('read-projection.tasks.finder')) {
+		tasks.find = (request: TaskFinderRequestV1): Promise<TaskFinderResultV1> => runRead(
+			request,
+			'task-finder-result',
+			() => active('read-projection.tasks.finder'),
+			decodeTaskFinderRequestV1,
+			read => core.tasks.find(read),
+			projectTaskFinderResultV1,
+		);
+	}
+	if (requestedSet.has('read-projection.entities.resolve')) {
+		entities.resolve = (request: EntityResolveRequestV1): Promise<EntityResolutionResultV1> => runRead(
+			request,
+			'entity-resolution-result',
+			() => active('read-projection.entities.resolve'),
+			decodeEntityResolveRequestV1,
+			read => core.entities.resolve(read),
+			projectEntityResolutionResultV1,
+		);
+	}
+	if (requestedSet.has('read-projection.relationships.read')) {
+		relationships.get = (request: RelationshipRequestV1): Promise<RelationshipResultV1> => runRead(
+			request,
+			'relationship-result',
+			() => active('read-projection.relationships.read'),
+			decodeRelationshipRequestV1,
+			read => core.relationships.get(read),
+			projectRelationshipResultV1,
+		);
+	}
+	if (requestedSet.has('read-projection.context.build')) {
+		context.build = (request: ContextRequestV1): Promise<ContextPackV1> => runContextRead(
+			request,
+			() => active('read-projection.context.build'),
+			read => core.context.build(read),
+		);
+	}
+	if (requestedSet.has('read-projection.timers.read')) {
+		timers.read = (request: TimerReadRequestV1): Promise<TimerReadResultV1> => runRead(
+			request,
+			'timer-read-result',
+			() => active('read-projection.timers.read'),
+			decodeTimerReadRequestV1,
+			read => core.timers.read(read),
+			projectTimerReadResultV1,
+		);
+	}
+	return freezeStructure(api) as OperonReadProjectionDeveloperApiV1<TCapabilities>;
+}
+
+async function runRead<TRequest extends { readonly requestId: string }, TResult extends { readonly requestId: string }>(
+	request: unknown,
+	kind: string,
+	admitted: () => boolean,
+	decodeRequest: (value: unknown) => { ok: true; value: TRequest } | { ok: false },
+	invoke: (request: TRequest) => Promise<TResult>,
+	project: (value: unknown) => TResult | null,
+): Promise<TResult> {
+	const decoded = decodeRequest(request);
+	const requestId = decoded.ok ? decoded.value.requestId : safeRequestId(request);
+	if (!decoded.ok) return readFailure(kind, requestId, 'invalid-request', 'The read-projection request is invalid.') as TResult;
+	if (!admitted()) return readFailure(kind, requestId, 'authority-insufficient', 'The requested read-projection capability is not active for this session.') as TResult;
+	try {
+		const projected = project(await invoke(freezeDto(decoded.value)));
+		if (!admitted()) return readFailure(kind, requestId, 'authority-insufficient', 'The requested read-projection capability is no longer active for this session.') as TResult;
+		if (projected && projected.requestId === requestId) return projected;
+	} catch {
+		// An invalid native result is not allowed to cross the public boundary.
+	}
+	return readFailure(kind, requestId, 'handler-unavailable', 'Operon returned an invalid read DTO.') as TResult;
+}
+
+async function runContextRead(
+	request: unknown,
+	admitted: () => boolean,
+	invoke: (request: ContextRequestV1) => Promise<ContextPackV1>,
+): Promise<ContextPackV1> {
+	const decoded = decodeContextRequestV1(request);
+	const requestId = decoded.ok ? decoded.value.requestId : safeRequestId(request);
+	if (!decoded.ok) return contextFailure(requestId, request, 'invalid-request', 'The context request is invalid.');
+	if (!admitted()) return contextFailure(requestId, decoded.value, 'authority-insufficient', 'The read-projection context capability is not active for this session.');
+	try {
+		const projected = projectContextPackV1(await invoke(freezeDto(decoded.value)));
+		if (!admitted()) return contextFailure(requestId, decoded.value, 'authority-insufficient', 'The read-projection context capability is no longer active for this session.');
+		if (projected && projected.requestId === requestId) return projected;
+	} catch {
+		// An invalid native result is not allowed to cross the public boundary.
+	}
+	return contextFailure(requestId, decoded.value, 'handler-unavailable', 'Operon returned an invalid context DTO.');
+}
+
+/** Context is intentionally first and explicit: it carries the widest nested read DTO. */
+export function projectContextPackV1(value: unknown): ContextPackV1 | null {
+	try {
+		const decoded = decodeContextPackV1(value);
+		if (!decoded.ok) return null;
+		const source = decoded.value;
+		const projected: Record<string, unknown> = {
+			contractVersion: 1,
+			requestId: source.requestId,
+			kind: 'context-pack',
+			ok: source.ok,
+			purpose: source.purpose,
+			projection: source.projection,
+			warnings: projectWarnings(source.warnings),
+		};
+		if (source.ok) {
+			projected.execution = projectFreshness(source.execution);
+			projected.contextRevision = snapshot(source.contextRevision);
+			projected.entities = snapshot(source.entities);
+			projected.relationships = snapshot(source.relationships);
+			projected.provenance = snapshot(source.provenance);
+			projected.truncations = snapshot(source.truncations);
+			if (source.catalogRevision !== undefined) projected.catalogRevision = source.catalogRevision;
+			if (source.asOf !== undefined) projected.asOf = source.asOf;
+			if (source.catalog !== undefined) projected.catalog = snapshot(source.catalog);
+			if (source.policies !== undefined) projected.policies = snapshot(source.policies);
+			if (source.resourceRevisions !== undefined) projected.resourceRevisions = snapshot(source.resourceRevisions);
+			if (source.summary !== undefined) projected.summary = snapshot(source.summary);
+			if (source.query !== undefined) projected.query = snapshot(source.query);
+			if (source.placement !== undefined) projected.placement = snapshot(source.placement);
+		} else {
+			projected.error = projectStructuredError(source.error);
+			if (source.contextRevision !== undefined) projected.contextRevision = snapshot(source.contextRevision);
+		}
+		return freezeDto(projected) as ContextPackV1;
+	} catch {
+		return null;
+	}
+}
+
+export function projectTaskFinderResultV1(value: unknown): TaskFinderResultV1 | null {
+	try {
+		const decoded = decodeTaskFinderResultV1(value);
+		if (!decoded.ok) return null;
+		const source = decoded.value;
+		const projected: Record<string, unknown> = baseReadProjection(source, 'task-finder-result');
+		if (source.ok) {
+			projected.contextRevision = snapshot(source.contextRevision);
+			projected.rows = snapshot(source.rows);
+			projected.page = snapshot(source.page);
+			projected.provenance = snapshot(source.provenance);
+			projected.truncations = snapshot(source.truncations);
+		} else {
+			projected.error = projectStructuredError(source.error);
+			if (source.contextRevision !== undefined) projected.contextRevision = snapshot(source.contextRevision);
+		}
+		return freezeDto(projected) as unknown as TaskFinderResultV1;
+	} catch {
+		return null;
+	}
+}
+
+export function projectEntityResolutionResultV1(value: unknown): EntityResolutionResultV1 | null {
+	try {
+		const decoded = decodeEntityResolutionResultV1(value);
+		if (!decoded.ok) return null;
+		const source = decoded.value;
+		const projected: Record<string, unknown> = baseReadProjection(source, 'entity-resolution-result');
+		if (source.ok) {
+			projected.contextRevision = snapshot(source.contextRevision);
+			projected.resolution = source.resolution;
+			projected.candidates = snapshot(source.candidates);
+			if (source.selected !== undefined) projected.selected = snapshot(source.selected);
+		} else {
+			projected.error = projectStructuredError(source.error);
+			if (source.contextRevision !== undefined) projected.contextRevision = snapshot(source.contextRevision);
+		}
+		return freezeDto(projected) as unknown as EntityResolutionResultV1;
+	} catch {
+		return null;
+	}
+}
+
+export function projectRelationshipResultV1(value: unknown): RelationshipResultV1 | null {
+	try {
+		const decoded = decodeRelationshipResultV1(value);
+		if (!decoded.ok) return null;
+		const source = decoded.value;
+		const projected: Record<string, unknown> = baseReadProjection(source, 'relationship-result');
+		if (source.ok) {
+			projected.contextRevision = snapshot(source.contextRevision);
+			projected.relationships = snapshot(source.relationships);
+			projected.tasks = snapshot(source.tasks);
+			projected.provenance = snapshot(source.provenance);
+			projected.truncations = snapshot(source.truncations);
+		} else {
+			projected.error = projectStructuredError(source.error);
+			if (source.contextRevision !== undefined) projected.contextRevision = snapshot(source.contextRevision);
+		}
+		return freezeDto(projected) as unknown as RelationshipResultV1;
+	} catch {
+		return null;
+	}
+}
+
+export function projectTimerReadResultV1(value: unknown): TimerReadResultV1 | null {
+	try {
+		const decoded = decodeTimerReadResultV1(value);
+		if (!decoded.ok) return null;
+		const source = decoded.value;
+		const projected: Record<string, unknown> = baseReadProjection(source, 'timer-read-result');
+		if (source.ok) {
+			projected.state = snapshot(source.state);
+			projected.contextRevision = snapshot(source.contextRevision);
+		} else {
+			projected.error = projectStructuredError(source.error);
+		}
+		return freezeDto(projected) as unknown as TimerReadResultV1;
+	} catch {
+		return null;
+	}
+}
+
+export function projectRuntimeDiagnosticsV1(value: unknown): RuntimeDiagnosticsV1 | null {
+	try {
+		const decoded = decodeRuntimeDiagnosticsV1(value);
+		if (!decoded.ok) return null;
+		const source = decoded.value;
+		const projected: Record<string, unknown> = {
+			contractVersion: 1,
+			kind: 'runtime-diagnostics',
+			health: projectRuntimeHealth(source.health),
+			capabilities: projectCapabilityAdvertisements(source.capabilities),
+			warnings: projectWarnings(source.warnings),
+		};
+		if (source.catalog !== undefined) {
+			projected.catalog = {
+				catalogRevision: source.catalog.catalogRevision,
+				settingsFingerprint: source.catalog.settingsFingerprint,
+				fieldCount: source.catalog.fieldCount,
+				pipelineCount: source.catalog.pipelineCount,
+				priorityCount: source.catalog.priorityCount,
+			};
+		}
+		if (source.transport !== undefined) {
+			const transport: Record<string, unknown> = {};
+			for (const key of ['channel', 'available', 'endpointKind', 'securityBackend', 'persistentTransportAvailable', 'failureReason'] as const) {
+				if (source.transport[key] !== undefined) transport[key] = source.transport[key];
+			}
+			projected.transport = transport;
+		}
+		return freezeDto(projected) as unknown as RuntimeDiagnosticsV1;
+	} catch {
+		return null;
+	}
+}
+
+function baseReadProjection(source: {
+	readonly contractVersion: number;
+	readonly requestId: string;
+	readonly ok: boolean;
+	readonly freshness: unknown;
+	readonly warnings: readonly unknown[];
+}, kind: string): Record<string, unknown> {
+	return {
+		contractVersion: 1,
+		requestId: source.requestId,
+		kind,
+		ok: source.ok,
+		freshness: projectFreshness(source.freshness),
+		warnings: projectWarnings(source.warnings),
+	};
+}
+
+function projectRuntimeHealth(value: RuntimeDiagnosticsV1['health']): Record<string, unknown> {
+	const projected: Record<string, unknown> = {
+		apiVersion: value.apiVersion,
+		contractVersion: 1,
+		ok: value.ok,
+		lifecyclePhase: value.lifecyclePhase,
+		v8PersistencePhase: value.v8PersistencePhase,
+		compatibility: snapshot({
+			contractVersion: value.compatibility.contractVersion,
+			runtimeApi: {
+				min: value.compatibility.runtimeApi.min,
+				max: value.compatibility.runtimeApi.max,
+			},
+		}),
+		capabilities: projectCapabilityAdvertisements(value.capabilities),
+		freshness: projectFreshness(value.freshness),
+		admission: { reads: value.admission.reads, writes: value.admission.writes },
+		warnings: projectWarnings(value.warnings),
+	};
+	if (value.contextRevision !== undefined) projected.contextRevision = snapshot(value.contextRevision);
+	if (value.retryAfterMs !== undefined) projected.retryAfterMs = value.retryAfterMs;
+	if (!value.ok) projected.error = projectStructuredError(value.error);
+	return projected;
+}
+
+function projectCapabilityAdvertisements(value: readonly unknown[]): readonly Record<string, unknown>[] {
+	return value.map(entry => {
+		const source = entry as {
+			id: string;
+			availability: string;
+			stability: string;
+			reason?: string;
+			deprecation?: { announcedIn: string; removal: string; replacement?: string };
+		};
+		const projected: Record<string, unknown> = {
+			id: source.id,
+			availability: source.availability,
+			stability: source.stability,
+		};
+		if (source.reason !== undefined) projected.reason = source.reason;
+		if (source.deprecation !== undefined) {
+			projected.deprecation = {
+				announcedIn: source.deprecation.announcedIn,
+				removal: source.deprecation.removal,
+				...(source.deprecation.replacement === undefined ? {} : { replacement: source.deprecation.replacement }),
+			};
+		}
+		return projected;
+	});
+}
+
+function projectFreshness(value: unknown): Record<string, unknown> {
+	const source = value as { source: unknown; coherence: unknown; observedAt: unknown; settled: unknown };
+	return {
+		source: source.source,
+		coherence: source.coherence,
+		observedAt: source.observedAt,
+		settled: source.settled,
+	};
+}
+
+function projectWarnings(value: readonly unknown[]): readonly Record<string, unknown>[] {
+	return value.map(entry => {
+		const source = entry as { code: unknown; message: unknown; path?: unknown };
+		return {
+			code: source.code,
+			message: source.message,
+			...(source.path === undefined ? {} : { path: source.path }),
+		};
+	});
+}
+
+function projectStructuredError(value: StructuredErrorV1): Record<string, unknown> {
+	return {
+		contractVersion: 1,
+		code: value.code,
+		reason: value.reason,
+		retryable: value.retryable,
+		action: value.action,
+		...(value.details === undefined ? {} : { details: snapshot(value.details) }),
+	};
+}
+
+function readFailure(
+	kind: string,
+	requestId: string,
+	code: 'invalid-request' | 'authority-insufficient' | 'handler-unavailable',
+	reason: string,
+): Record<string, unknown> {
+	return freezeDto({
+		contractVersion: 1,
+		requestId,
+		kind,
+		ok: false,
+		freshness: unavailableFreshness(),
+		warnings: [],
+		error: structuredErrorV1(code, reason),
+	});
+}
+
+function contextFailure(
+	requestId: string,
+	request: unknown,
+	code: 'invalid-request' | 'authority-insufficient' | 'handler-unavailable',
+	reason: string,
+): ContextPackV1 {
+	const record = isPlainRecord(request) ? request : {};
+	const purpose = isContextPurpose(record.purpose) ? record.purpose : 'read';
+	const projection = isContextProjection(record.projection) ? record.projection : 'exact-task';
+	return freezeDto({
+		contractVersion: 1,
+		requestId,
+		kind: 'context-pack',
+		ok: false,
+		purpose,
+		projection,
+		warnings: [],
+		error: structuredErrorV1(code, reason),
+	});
+}
+
+function diagnosticsFailure(
+	code: 'authority-insufficient' | 'handler-unavailable',
+	reason: string,
+): RuntimeDiagnosticsV1 {
+	return freezeDto({
+		contractVersion: 1,
+		kind: 'runtime-diagnostics',
+		health: {
+			apiVersion: 1,
+			contractVersion: 1,
+			ok: false,
+			lifecyclePhase: 'booting',
+			v8PersistencePhase: 'idle',
+			compatibility: { contractVersion: 1, runtimeApi: { min: 1, max: 1 } },
+			capabilities: [],
+			freshness: unavailableFreshness(),
+			admission: { reads: false, writes: false },
+			warnings: [],
+			error: structuredErrorV1(code, reason),
+		},
+		capabilities: [],
+		warnings: [],
+	}) as unknown as RuntimeDiagnosticsV1;
+}
+
+function unavailableFreshness(): Record<string, unknown> {
+	return {
+		source: 'live-runtime',
+		coherence: 'unverified',
+		observedAt: new Date().toISOString(),
+		settled: false,
+	};
+}
+
+function decodeAccessRequest(value: unknown): ReadProjectionDeveloperApiAccessRequestV1<ReadProjectionDeveloperCapabilitySubsetV1> | null {
+	if (!isPlainRecord(value) || !hasExactKeys(value, ['contractVersion', 'runtimeApi', 'requestedCapabilities'])) return null;
+	if (value.contractVersion !== 1 || !isPlainRecord(value.runtimeApi) || !hasExactKeys(value.runtimeApi, ['min', 'max'])) return null;
+	const min = value.runtimeApi.min;
+	const max = value.runtimeApi.max;
+	if (
+		typeof min !== 'number'
+		|| typeof max !== 'number'
+		|| !Number.isSafeInteger(min)
+		|| !Number.isSafeInteger(max)
+		|| min < 1
+		|| min > max
+	) return null;
+	if (!Array.isArray(value.requestedCapabilities) || value.requestedCapabilities.length < 1 || value.requestedCapabilities.length > ACCESS_CAPABILITIES_V1.length) return null;
+	const requested = value.requestedCapabilities;
+	if (!requested.every(isReadProjectionCapability)) return null;
+	const positions = requested.map(capability => ACCESS_CAPABILITIES_V1.indexOf(capability));
+	if (new Set(requested).size !== requested.length || positions.some((position, index) => position < 0 || (index > 0 && position <= positions[index - 1]))) return null;
+	return freezeDto({
+		contractVersion: 1,
+		runtimeApi: { min, max },
+		requestedCapabilities: [...requested],
+	}) as unknown as ReadProjectionDeveloperApiAccessRequestV1<ReadProjectionDeveloperCapabilitySubsetV1>;
+}
+
+function failure(
+	code: Parameters<typeof structuredErrorV1>[0],
+	reason: string,
+	retryable = false,
+): ReadProjectionDeveloperApiAccessResultV1<ReadProjectionDeveloperCapabilitySubsetV1> {
+	return freezeStructure({
+		contractVersion: 1,
+		kind: 'read-projection-developer-api-access-result',
+		ok: false,
+		error: structuredErrorV1(code, reason, { retryable }),
+	});
+}
+
+function isReadProjectionCapability(value: unknown): value is ReadProjectionDeveloperAccessCapabilityV1 {
+	return typeof value === 'string' && isReadProjectionDeveloperCapabilityIdV1(value);
+}
+
+function isContextPurpose(value: unknown): value is ContextPackV1['purpose'] {
+	return value === 'read' || value === 'analysis' || value === 'planning' || value === 'creation' || value === 'mutation-readiness';
+}
+
+function isContextProjection(value: unknown): value is ContextPackV1['projection'] {
+	return value === 'exact-task' || value === 'task-neighborhood' || value === 'project-analysis'
+		|| value === 'planning-workload' || value === 'creation-context' || value === 'mutation-preview'
+		|| value === 'placement-candidates';
+}
+
+function safeRequestId(value: unknown): string {
+	try {
+		if (isPlainRecord(value) && typeof value.requestId === 'string' && /^[A-Za-z0-9][A-Za-z0-9._:-]*$/u.test(value.requestId)) return value.requestId;
+	} catch {
+		// Fall through to a valid fixed correlation id.
+	}
+	return 'read-projection';
+}
+
+function snapshot<T>(value: T): T {
+	return structuredClone(value);
+}
+
+function freezeDto<T>(value: T): T {
+	const clone = snapshot(value);
+	return freezeStructure(clone);
+}
+
+function freezeStructure<T>(value: T): T {
+	deepFreeze(value, new WeakSet<object>());
+	return value;
+}
+
+function deepFreeze(value: unknown, visited: WeakSet<object>): void {
+	if ((typeof value !== 'object' && typeof value !== 'function') || value === null) return;
+	if (visited.has(value)) return;
+	visited.add(value);
+	for (const child of Object.values(value)) deepFreeze(child, visited);
+	Object.freeze(value);
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+	if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+	const prototype: unknown = Object.getPrototypeOf(value);
+	return prototype === Object.prototype || prototype === null;
+}
+
+function hasExactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {
+	const keys = Reflect.ownKeys(value);
+	const actual: string[] = [];
+	for (const key of keys) {
+		if (typeof key !== 'string') return false;
+		actual.push(key);
+	}
+	actual.sort();
+	const sorted = [...expected].sort();
+	return actual.length === sorted.length && actual.every((key, index) => key === sorted[index]);
+}

--- a/src/agent-runtime/extensions/read-projection-v1/index.ts
+++ b/src/agent-runtime/extensions/read-projection-v1/index.ts
@@ -1,0 +1,3 @@
+export * from './contracts';
+export * from './public-contract';
+export * from './developer-api';

--- a/src/agent-runtime/extensions/read-projection-v1/public-contract.ts
+++ b/src/agent-runtime/extensions/read-projection-v1/public-contract.ts
@@ -11,7 +11,7 @@ import type {
 import type { RuntimeDiagnosticsV1 } from '../../contracts/v1/lifecycle';
 import type { StructuredErrorV1 } from '../../contracts/v1/primitives';
 import type { TimerReadRequestV1, TimerReadResultV1 } from '../../contracts/v1/timer';
-import type { OperonDeveloperApiConsumerPluginV1 } from '../../public/v1/developer-api';
+import type { DeepReadonlyV1, OperonDeveloperApiConsumerPluginV1 } from '../../public/v1/developer-api';
 import {
 	READ_PROJECTION_DEVELOPER_CAPABILITY_IDS_V1,
 	type ReadProjectionDeveloperCapabilityIdV1,
@@ -55,12 +55,12 @@ export type OperonReadProjectionDeveloperApiV1<
 	readonly contractVersion: 1;
 	readonly runtimeApi: 1;
 	readonly hasCapability: (capability: string) => boolean;
-	readonly system: ProjectedGroupV1<IncludesCapabilityV1<TCapabilities, 'read-projection.system.diagnostics'>, { readonly diagnostics: () => Promise<RuntimeDiagnosticsV1> }>;
-	readonly tasks: ProjectedGroupV1<IncludesCapabilityV1<TCapabilities, 'read-projection.tasks.finder'>, { readonly find: (request: TaskFinderRequestV1) => Promise<TaskFinderResultV1> }>;
-	readonly entities: ProjectedGroupV1<IncludesCapabilityV1<TCapabilities, 'read-projection.entities.resolve'>, { readonly resolve: (request: EntityResolveRequestV1) => Promise<EntityResolutionResultV1> }>;
-	readonly relationships: ProjectedGroupV1<IncludesCapabilityV1<TCapabilities, 'read-projection.relationships.read'>, { readonly get: (request: RelationshipRequestV1) => Promise<RelationshipResultV1> }>;
-	readonly context: ProjectedGroupV1<IncludesCapabilityV1<TCapabilities, 'read-projection.context.build'>, { readonly build: (request: ContextRequestV1) => Promise<ContextPackV1> }>;
-	readonly timers: ProjectedGroupV1<IncludesCapabilityV1<TCapabilities, 'read-projection.timers.read'>, { readonly read: (request: TimerReadRequestV1) => Promise<TimerReadResultV1> }>;
+	readonly system: ProjectedGroupV1<IncludesCapabilityV1<TCapabilities, 'read-projection.system.diagnostics'>, { readonly diagnostics: () => Promise<DeepReadonlyV1<RuntimeDiagnosticsV1>> }>;
+	readonly tasks: ProjectedGroupV1<IncludesCapabilityV1<TCapabilities, 'read-projection.tasks.finder'>, { readonly find: (request: DeepReadonlyV1<TaskFinderRequestV1>) => Promise<DeepReadonlyV1<TaskFinderResultV1>> }>;
+	readonly entities: ProjectedGroupV1<IncludesCapabilityV1<TCapabilities, 'read-projection.entities.resolve'>, { readonly resolve: (request: DeepReadonlyV1<EntityResolveRequestV1>) => Promise<DeepReadonlyV1<EntityResolutionResultV1>> }>;
+	readonly relationships: ProjectedGroupV1<IncludesCapabilityV1<TCapabilities, 'read-projection.relationships.read'>, { readonly get: (request: DeepReadonlyV1<RelationshipRequestV1>) => Promise<DeepReadonlyV1<RelationshipResultV1>> }>;
+	readonly context: ProjectedGroupV1<IncludesCapabilityV1<TCapabilities, 'read-projection.context.build'>, { readonly build: (request: DeepReadonlyV1<ContextRequestV1>) => Promise<DeepReadonlyV1<ContextPackV1>> }>;
+	readonly timers: ProjectedGroupV1<IncludesCapabilityV1<TCapabilities, 'read-projection.timers.read'>, { readonly read: (request: DeepReadonlyV1<TimerReadRequestV1>) => Promise<DeepReadonlyV1<TimerReadResultV1>> }>;
 }>;
 
 export type ReadProjectionDeveloperApiAccessResultV1<
@@ -70,7 +70,7 @@ export type ReadProjectionDeveloperApiAccessResultV1<
 	readonly kind: 'read-projection-developer-api-access-result';
 } & (
 	| Readonly<{ readonly ok: true; readonly api: OperonReadProjectionDeveloperApiV1<TCapabilities>; readonly error?: never }>
-	| Readonly<{ readonly ok: false; readonly error: StructuredErrorV1; readonly api?: never }>
+	| Readonly<{ readonly ok: false; readonly error: DeepReadonlyV1<StructuredErrorV1>; readonly api?: never }>
 )>;
 
 export interface OperonReadProjectionDeveloperApiAccessorV1 {

--- a/src/agent-runtime/extensions/read-projection-v1/public-contract.ts
+++ b/src/agent-runtime/extensions/read-projection-v1/public-contract.ts
@@ -1,0 +1,83 @@
+import type {
+	ContextPackV1,
+	ContextRequestV1,
+	EntityResolutionResultV1,
+	EntityResolveRequestV1,
+	RelationshipRequestV1,
+	RelationshipResultV1,
+	TaskFinderRequestV1,
+	TaskFinderResultV1,
+} from '../../contracts/v1/context';
+import type { RuntimeDiagnosticsV1 } from '../../contracts/v1/lifecycle';
+import type { StructuredErrorV1 } from '../../contracts/v1/primitives';
+import type { TimerReadRequestV1, TimerReadResultV1 } from '../../contracts/v1/timer';
+import type { OperonDeveloperApiConsumerPluginV1 } from '../../public/v1/developer-api';
+import {
+	READ_PROJECTION_DEVELOPER_CAPABILITY_IDS_V1,
+	type ReadProjectionDeveloperCapabilityIdV1,
+} from './contracts';
+
+export type ReadProjectionDeveloperAccessCapabilityV1 = ReadProjectionDeveloperCapabilityIdV1;
+
+type OrderedCapabilitySubsetsV1<T extends readonly ReadProjectionDeveloperAccessCapabilityV1[]> =
+	T extends readonly [
+		infer Head extends ReadProjectionDeveloperAccessCapabilityV1,
+		...infer Tail extends readonly ReadProjectionDeveloperAccessCapabilityV1[],
+	]
+		? OrderedCapabilitySubsetsV1<Tail> | readonly [Head, ...OrderedCapabilitySubsetsV1<Tail>]
+		: readonly [];
+
+export type ReadProjectionDeveloperCapabilitySubsetV1 = Exclude<
+	OrderedCapabilitySubsetsV1<typeof READ_PROJECTION_DEVELOPER_CAPABILITY_IDS_V1>,
+	readonly []
+>;
+
+export interface ReadProjectionDeveloperApiAccessRequestV1<
+	TCapabilities extends ReadProjectionDeveloperCapabilitySubsetV1,
+> {
+	readonly contractVersion: 1;
+	readonly runtimeApi: Readonly<{ readonly min: number; readonly max: number }>;
+	readonly requestedCapabilities: TCapabilities;
+}
+
+type IncludesCapabilityV1<
+	TCapabilities extends readonly ReadProjectionDeveloperAccessCapabilityV1[],
+	TCapability extends ReadProjectionDeveloperAccessCapabilityV1,
+> = TCapability extends TCapabilities[number] ? true : false;
+
+type ProjectedGroupV1<TEnabled extends boolean, TMethods> = TEnabled extends true
+	? Readonly<TMethods>
+	: Readonly<Record<never, never>>;
+
+export type OperonReadProjectionDeveloperApiV1<
+	TCapabilities extends ReadProjectionDeveloperCapabilitySubsetV1,
+> = Readonly<{
+	readonly contractVersion: 1;
+	readonly runtimeApi: 1;
+	readonly hasCapability: (capability: string) => boolean;
+	readonly system: ProjectedGroupV1<IncludesCapabilityV1<TCapabilities, 'read-projection.system.diagnostics'>, { readonly diagnostics: () => Promise<RuntimeDiagnosticsV1> }>;
+	readonly tasks: ProjectedGroupV1<IncludesCapabilityV1<TCapabilities, 'read-projection.tasks.finder'>, { readonly find: (request: TaskFinderRequestV1) => Promise<TaskFinderResultV1> }>;
+	readonly entities: ProjectedGroupV1<IncludesCapabilityV1<TCapabilities, 'read-projection.entities.resolve'>, { readonly resolve: (request: EntityResolveRequestV1) => Promise<EntityResolutionResultV1> }>;
+	readonly relationships: ProjectedGroupV1<IncludesCapabilityV1<TCapabilities, 'read-projection.relationships.read'>, { readonly get: (request: RelationshipRequestV1) => Promise<RelationshipResultV1> }>;
+	readonly context: ProjectedGroupV1<IncludesCapabilityV1<TCapabilities, 'read-projection.context.build'>, { readonly build: (request: ContextRequestV1) => Promise<ContextPackV1> }>;
+	readonly timers: ProjectedGroupV1<IncludesCapabilityV1<TCapabilities, 'read-projection.timers.read'>, { readonly read: (request: TimerReadRequestV1) => Promise<TimerReadResultV1> }>;
+}>;
+
+export type ReadProjectionDeveloperApiAccessResultV1<
+	TCapabilities extends ReadProjectionDeveloperCapabilitySubsetV1,
+> = Readonly<{
+	readonly contractVersion: 1;
+	readonly kind: 'read-projection-developer-api-access-result';
+} & (
+	| Readonly<{ readonly ok: true; readonly api: OperonReadProjectionDeveloperApiV1<TCapabilities>; readonly error?: never }>
+	| Readonly<{ readonly ok: false; readonly error: StructuredErrorV1; readonly api?: never }>
+)>;
+
+export interface OperonReadProjectionDeveloperApiAccessorV1 {
+	getReadProjectionDeveloperApiV1<
+		TCapabilities extends ReadProjectionDeveloperCapabilitySubsetV1,
+	>(
+		consumerPlugin: OperonDeveloperApiConsumerPluginV1,
+		request: ReadProjectionDeveloperApiAccessRequestV1<TCapabilities>,
+	): ReadProjectionDeveloperApiAccessResultV1<TCapabilities>;
+}


### PR DESCRIPTION
## Summary
- add a separately granted, capability-projected Developer API accessor for the six Runtime V1 read projections
- keep the frozen base accessor unchanged, recheck live authority before and after each read, and return copied immutable DTOs only
- cover exact grants, decoding, revocation, public consumer compilation, settings routing, and document the extension

## Validation
Passed:
- `npm run agent-runtime:developer-api`
- `npm run agent-runtime:contracts`
- `npm run developer-api:settings:test`
- `npm run bundle:size`
- `npm run build`
- `npm run docs:package:test`
- `npm run lint:strict`
- `git diff --check`

Known baseline gates (not changed by this diff):
- `npm run agent-runtime:context` completes its indexer and context assertions, then fails the pre-existing Cold Finder performance threshold: 178.67 ms and 182.05 ms median on two reruns versus 150 ms. Its direct imported context/runtime/indexer paths are unchanged in this branch.
- `npm run docs:public-v1:test` fails before checking the changed Developer API docs because four unchanged HEAD docs use `Updated: ...+0200`; the test requires no timezone suffix. The same four values are present at `HEAD`.

Closes #201.