### PR TITLE
Enable 'Mark Done' on mobile

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -19630,7 +19630,7 @@ export default class OperonPlugin extends Plugin {
 				statusVal,
 				buildWorkflowStatusIdentityIndex(this.settings.pipelines),
 			);
-			if (toggleResolution.workflow && currentIdentity.kind === 'configured') {
+			if (toggleResolution.workflow && currentIdentity.kind === 'configured' && this.agentRuntimeMutationGateway) {
 				return this.applyUiSemanticTransition(
 					task,
 					toggleResolution.workflow.definition.id,
@@ -25268,7 +25268,7 @@ export default class OperonPlugin extends Plugin {
 				currentStatus,
 				buildWorkflowStatusIdentityIndex(this.settings.pipelines),
 			);
-			if (currentStatusIdentity.kind === 'configured') {
+			if (currentStatusIdentity.kind === 'configured' && this.agentRuntimeMutationGateway) {
 				const sharedCoordinatorSucceeded = await this.applyUiSemanticTransition(
 					indexed,
 					nextWorkflow.definition.id,


### PR DESCRIPTION
## Background

While switchting from Tasks to Operon, I noticed that the desktop experience is good and what I did not have the time to build myself. On mobile, I was a bit disappointed, because - at first - I could not interact with the tasks like I wanted. I researched and learned, that some interaction was possible, but it was a little tedious to do 3-5 steps for a seemingly simple "Mark done". I consider this a bug, but I also want to be part of the solution, not the problem. 

Therefore I created this bugfix and request that you merge it (if it fits your vision of the project).

## Bugfix

This only uses the agentRuntimeMutationGateway only if it is present. This is the case on desktop, but somehow not supported on mobile.

Since setting the completion-date works on mobile as expected (marking it as done, creating the the occurence, writing the completion-date), it seems sensible to use the direct-write fallback if the MutationGateway is not available.

I only tested this (manually, successfully) with 'Mark Done', not with the cancellation as I primarily check things off successfully when on the go.

## Notes

Honest Disclaimer: I am not (at all) a JS/TS-pro, I analyzed this with a LLM.

However, the change makes sense to me and I verified this manually on Desktop and Mobile. `npm run check` showed no errors.