### PR TITLE
fix(runtime): seal plan resources in canonical code-unit order

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -469,7 +469,8 @@ import type {
 	MutationSpecV1,
 } from './src/agent-runtime/contracts/v1/mutation';
 import {
-	RESOURCE_QUEUE_ORDER_V1,
+	compareResourceKeysCanonicalV1,
+	compareResourceReferencesCanonicalV1,
 	validateVaultRelativePathV1,
 } from './src/agent-runtime/contracts/v1/identity';
 import type { AffectedResourceRevisionMapV1 } from './src/agent-runtime/contracts/v1/identity';
@@ -8178,12 +8179,7 @@ export default class OperonPlugin extends Plugin {
 				revision: sha256HexV1(String(this.storage.repeatSeries.getRevision())),
 			});
 		}
-		affectedResources.sort((left, right) => {
-			const kindOrder = RESOURCE_QUEUE_ORDER_V1[left.resourceKind]
-				- RESOURCE_QUEUE_ORDER_V1[right.resourceKind];
-			if (kindOrder !== 0) return kindOrder;
-			return left.resourceKey.localeCompare(right.resourceKey);
-		});
+		affectedResources.sort(compareResourceReferencesCanonicalV1);
 		predictedEffects = token.groups.map(group => ({
 			resourceKind: 'task-source' as const,
 			resourceKey: group.filePath,
@@ -9050,7 +9046,7 @@ export default class OperonPlugin extends Plugin {
 						resourceKey: filePath,
 						revision: sourceRevisionForTaskCreationV1(filePath, content),
 					}))
-					.sort((left, right) => left.resourceKey.localeCompare(right.resourceKey));
+					.sort((left, right) => compareResourceKeysCanonicalV1(left.resourceKey, right.resourceKey));
 				const atomicGroups = affectedResources.map((resource, order) => ({
 					groupId: `task-source:${resource.resourceKey}`,
 					order,
@@ -9811,18 +9807,8 @@ export default class OperonPlugin extends Plugin {
 				summary: 'Remove the finished task from pinned state.',
 			});
 		}
-		affectedResources.sort((left, right) => {
-			const kindOrder = RESOURCE_QUEUE_ORDER_V1[left.resourceKind]
-				- RESOURCE_QUEUE_ORDER_V1[right.resourceKind];
-			if (kindOrder !== 0) return kindOrder;
-			return left.resourceKey.localeCompare(right.resourceKey);
-		});
-		predictedEffects.sort((left, right) => {
-			const kindOrder = RESOURCE_QUEUE_ORDER_V1[left.resourceKind]
-				- RESOURCE_QUEUE_ORDER_V1[right.resourceKind];
-			if (kindOrder !== 0) return kindOrder;
-			return left.resourceKey.localeCompare(right.resourceKey);
-		});
+		affectedResources.sort(compareResourceReferencesCanonicalV1);
+		predictedEffects.sort(compareResourceReferencesCanonicalV1);
 		const primaryGroupResources = [
 			...(prepared.transition?.finalizeActiveTimer
 				? [{
@@ -12763,10 +12749,7 @@ export default class OperonPlugin extends Plugin {
 		const affectedResources = [...new Map(resourceCandidates.map(resource => [
 			`${resource.resourceKind}\0${resource.resourceKey}`,
 			resource,
-		])).values()].sort((left, right) => (
-			RESOURCE_QUEUE_ORDER_V1[left.resourceKind] - RESOURCE_QUEUE_ORDER_V1[right.resourceKind]
-			|| left.resourceKey.localeCompare(right.resourceKey)
-		));
+		])).values()].sort(compareResourceReferencesCanonicalV1);
 		const finalSources = new Map((graphSteps ?? []).filter(step => step.resourceKind === 'task-source').map(step => [step.resourceKey, step.after]));
 		const createEffects = buildIdentityPlaceholderCreateEffectsV1(
 			prepared.createEffects,

--- a/scripts/agent-runtime/mutation/canonical-resource-ordering.test.ts
+++ b/scripts/agent-runtime/mutation/canonical-resource-ordering.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Canonical resource ordering: planners and the decoder must agree (#200).
+ *
+ * The V1 decoder rejects any sealed plan whose `affectedResources` is not in
+ * canonical (UTF-16 code unit) order. Any planner that sorts the same list with
+ * `localeCompare` disagrees with it whenever two resource keys differ in letter
+ * case, punctuation, or non-ASCII characters, and the plan it just sealed then
+ * fails apply admission. These tests pin the shared comparators, drive the real
+ * transition planner over a synthetic two-note task graph whose paths sort
+ * differently under the two orders, and hand the sealed plan to
+ * `decodeMutationApplyRequestV1` — the admission gate every apply passes through.
+ *
+ * Nothing here reads a vault. Both notes and all tasks are synthetic.
+ */
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import {
+	computeReceiptTargetDigestV1,
+	computeSealedMutationPlanHashV1,
+	sha256HexV1,
+} from '../../../src/agent-runtime/contracts/v1/canonical';
+import { decodeMutationApplyRequestV1 } from '../../../src/agent-runtime/contracts/v1/decode';
+import {
+	compareResourceKeysCanonicalV1,
+	compareResourceReferencesCanonicalV1,
+} from '../../../src/agent-runtime/contracts/v1/identity';
+import type { SealedMutationPlanV1 } from '../../../src/agent-runtime/contracts/v1/mutation';
+import {
+	planRuntimeSemanticTransitionV1,
+	type RuntimeSemanticTransitionPlannerPortsV1,
+} from '../../../src/agent-runtime/runtime/semantic-transition';
+import type {
+	RuntimeExactTaskMutationSnapshotV1,
+	RuntimeTaskFieldMutationPreparationV1,
+} from '../../../src/agent-runtime/runtime/task-mutation-adapter';
+
+const EFFECTIVE_AT = '2026-07-24T12:00:00.000Z';
+
+/**
+ * Two synthetic notes whose paths sort one way under ICU collation and the other
+ * way under UTF-16 code units. Plain ASCII, differing only in letter case — the
+ * trigger does not need an exotic character.
+ *
+ *   localeCompare : "Projects/backend.md" < "Projects/Roadmap.md"   (b before R)
+ *   code units    : "Projects/Roadmap.md" < "Projects/backend.md"   (0x52 < 0x62)
+ */
+const CHILD_NOTE = 'Projects/backend.md';
+const PARENT_NOTE = 'Projects/Roadmap.md';
+
+function synthesizeTask(
+	operonId: string,
+	filePath: string,
+	parentTask = '',
+): RuntimeExactTaskMutationSnapshotV1 {
+	return {
+		operonId,
+		locator: { representation: 'inline', filePath, lineNumber: 0 },
+		description: operonId,
+		checkbox: 'open',
+		fieldValues: {
+			status: 'Projects.Open',
+			...(parentTask ? { parentTask } : {}),
+		},
+		tags: [],
+		sourceContent: `- [ ] ${operonId} {{operonId:: ${operonId}}}\n`,
+		duplicate: false,
+	};
+}
+
+function synthesizePreparation(
+	source: RuntimeExactTaskMutationSnapshotV1,
+): RuntimeTaskFieldMutationPreparationV1 {
+	return {
+		kind: 'task-fields',
+		operation: 'transition',
+		task: source,
+		fieldValues: {
+			status: 'Projects.done',
+			_checkbox: 'done',
+			dateCompleted: '2026-07-24',
+			dateCancelled: '',
+			datetimeModified: '2026-07-24T14:00:00',
+		},
+		sourceRevision: sha256HexV1(source.sourceContent),
+		targetDigest: sha256HexV1(source.operonId),
+		summary: `Transition ${source.operonId}.`,
+		noChange: false,
+		...(source.fieldValues['parentTask']
+			? { parentOperonId: source.fieldValues['parentTask'] }
+			: {}),
+		transition: {
+			fromStatusId: 'status-open',
+			toStatusId: 'status-done',
+			fromCheckbox: 'open',
+			toCheckbox: 'done',
+			terminal: true,
+			finalizeActiveTimer: false,
+			materializeRecurrence: false,
+			autoUnpin: false,
+		},
+	};
+}
+
+function synthesizePorts(
+	tasks: readonly RuntimeExactTaskMutationSnapshotV1[],
+): RuntimeSemanticTransitionPlannerPortsV1 {
+	const byId = new Map(tasks.map(item => [item.operonId, item]));
+	return {
+		getTask: operonId => byId.get(operonId) ?? null,
+		isPinned: () => false,
+		hasProjectSerialScopes: () => false,
+		stateRevisions: () => ({
+			activeTracker: 'tracker-rev',
+			repeatSeries: 'repeat-rev',
+			pinned: 'pinned-rev',
+			projectSerial: 'serial-rev',
+		}),
+		planRecurrence: () => {
+			throw new Error('recurrence is not part of this reproduction');
+		},
+	};
+}
+
+/** A task in one note whose parent lives in another note. */
+async function planCrossNoteCompletion() {
+	const child = synthesizeTask('chi0001', CHILD_NOTE, 'par0001');
+	const parent = synthesizeTask('par0001', PARENT_NOTE);
+	const result = await planRuntimeSemanticTransitionV1(
+		synthesizePreparation(child),
+		EFFECTIVE_AT,
+		synthesizePorts([child, parent]),
+	);
+	if (!result.ok) throw new Error(`planner refused the transition: ${result.reason}`);
+	return result.value;
+}
+
+test('the two notes are a case where ICU collation and code-unit order disagree', () => {
+	const icu = Math.sign(CHILD_NOTE.localeCompare(PARENT_NOTE));
+	const codeUnits = CHILD_NOTE < PARENT_NOTE ? -1 : CHILD_NOTE > PARENT_NOTE ? 1 : 0;
+	assert.notEqual(
+		icu,
+		codeUnits,
+		'precondition: pick two paths that sort differently under the two orders',
+	);
+});
+
+test('the planner seals affectedResources in the order the decoder demands', async () => {
+	const plan = await planCrossNoteCompletion();
+	const sealed = plan.affectedResources.map(resource => resource.resourceKey);
+	const canonical = [...sealed].sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+	assert.deepEqual(
+		sealed,
+		canonical,
+		'affectedResources must already be in code-unit order — the decoder re-derives it '
+			+ 'and rejects the plan when it differs',
+	);
+});
+
+test('an apply request carrying that plan passes V1 admission', async () => {
+	const planned = await planCrossNoteCompletion();
+	const idempotencyKey = 'repro-canonical-resource-ordering-0001';
+	const targets = [{
+		operonId: 'chi0001',
+		locator: { representation: 'inline' as const, filePath: CHILD_NOTE, lineNumber: 0 },
+		targetDigest: sha256HexV1('chi0001'),
+	}];
+	const unsealed: SealedMutationPlanV1 = {
+		contractVersion: 1,
+		planId: 'repro-plan-0001',
+		planHash: '0'.repeat(64),
+		clientInstanceId: 'repro',
+		correlationId: 'repro-correlation-0001',
+		idempotencyKeyHash: sha256HexV1(idempotencyKey),
+		receiptTargetDigest: computeReceiptTargetDigestV1(targets),
+		capability: 'tasks.transition.preview',
+		mutationKind: 'task.transition',
+		createdAt: EFFECTIVE_AT,
+		expiresAt: new Date(Date.parse(EFFECTIVE_AT) + 60_000).toISOString(),
+		targets,
+		contextRevision: {
+			index: { sessionId: 'repro-session', ramGeneration: 1, durable: { status: 'unavailable' } },
+			settingsFingerprint: sha256HexV1('repro-settings'),
+			pinnedGeneration: 0,
+			activeTrackerGeneration: 0,
+			repeatSeriesRevision: 0,
+			projectSerialGeneration: 0,
+			projectSerialSignature: sha256HexV1(''),
+		},
+		affectedResources: planned.affectedResources,
+		atomicGroups: planned.atomicGroups,
+		predictedEffects: planned.predictedEffects,
+		riskLevel: 'elevated',
+		requiresConfirmation: false,
+		requiredAcknowledgements: [],
+		warnings: [],
+		spec: {
+			operation: 'transition',
+			targetStatusId: 'status-done',
+			expectedStatusId: 'status-open',
+		},
+	} as unknown as SealedMutationPlanV1;
+	const plan: SealedMutationPlanV1 = {
+		...unsealed,
+		planHash: computeSealedMutationPlanHashV1(unsealed),
+	};
+
+	const admitted = decodeMutationApplyRequestV1({
+		contractVersion: 1,
+		requestId: 'repro-request-0001',
+		kind: 'mutation-apply',
+		plan,
+		authorization: { basis: 'user-explicit-request', reason: 'Reproduction.' },
+		idempotencyKey,
+		acknowledgements: [],
+	});
+
+	assert.equal(
+		admitted.ok,
+		true,
+		'apply admission rejected the plan the planner just sealed. Issues: '
+			+ JSON.stringify(admitted.ok ? [] : admitted.issues, null, 2),
+	);
+});
+
+test('the shared comparator orders keys by code units for pairs where ICU disagrees', () => {
+	const divergentPairs: ReadonlyArray<readonly [string, string]> = [
+		['Projects/Roadmap.md', 'Projects/backend.md'],
+		['Notes/B.md', 'Notes/a.md'],
+		['Cases/Case 7 Summary.md', 'Cases/Case 7 \u2014 Notes.md'],
+		['Notes/Zeta.md', 'Notes/\u00c5ngstr\u00f6m.md'],
+	];
+	for (const [left, right] of divergentPairs) {
+		const codeUnits = left < right ? -1 : left > right ? 1 : 0;
+		assert.equal(
+			Math.sign(compareResourceKeysCanonicalV1(left, right)),
+			codeUnits,
+			`comparator must use code-unit order for ${left} vs ${right}`,
+		);
+		assert.notEqual(
+			Math.sign(left.localeCompare(right)),
+			codeUnits,
+			`precondition: ${left} vs ${right} must diverge under ICU collation`,
+		);
+	}
+	assert.equal(
+		Math.sign(compareResourceReferencesCanonicalV1(
+			{ resourceKind: 'task-source', resourceKey: 'Projects/Roadmap.md' },
+			{ resourceKind: 'task-source', resourceKey: 'Projects/backend.md' },
+		)),
+		-1,
+		'reference comparator delegates key comparison to code-unit order',
+	);
+	assert.equal(
+		Math.sign(compareResourceReferencesCanonicalV1(
+			{ resourceKind: 'repeat-series', resourceKey: 'zzz' },
+			{ resourceKind: 'task-source', resourceKey: 'aaa' },
+		)),
+		-1,
+		'reference comparator keeps resource-kind queue order ahead of key order',
+	);
+});
+
+test('no plan-sealing sort orders resource keys with localeCompare', () => {
+	for (const file of [
+		'main.ts',
+		'src/agent-runtime/runtime/mutation-gateway.ts',
+		'src/agent-runtime/runtime/semantic-transition.ts',
+	]) {
+		const source = readFileSync(file, 'utf8');
+		assert.equal(
+			source.includes('resourceKey.localeCompare'),
+			false,
+			`${file} must sort resource references with the shared canonical comparator`,
+		);
+	}
+});

--- a/scripts/agent-runtime/mutation/run-mutation-tests.mjs
+++ b/scripts/agent-runtime/mutation/run-mutation-tests.mjs
@@ -12,6 +12,7 @@ try {
 			'scripts/agent-runtime/mutation/candidate-capability-smoke.test.ts',
 			'scripts/agent-runtime/mutation/modified-time-plugin-integration.test.ts',
 			'scripts/agent-runtime/mutation/mutation-acceptance-matrix.test.ts',
+			'scripts/agent-runtime/mutation/canonical-resource-ordering.test.ts',
 			'scripts/agent-runtime/mutation/mutation-gateway.test.ts',
 			'scripts/agent-runtime/mutation/source-transition-guards.test.ts',
 			'scripts/agent-runtime/mutation/task-mutation-adapter.test.ts',
@@ -37,6 +38,7 @@ try {
 	await import(pathToFileURL(join(outputDirectory, 'candidate-capability-smoke.test.js')).href);
 	await import(pathToFileURL(join(outputDirectory, 'modified-time-plugin-integration.test.js')).href);
 	await import(pathToFileURL(join(outputDirectory, 'mutation-acceptance-matrix.test.js')).href);
+	await import(pathToFileURL(join(outputDirectory, 'canonical-resource-ordering.test.js')).href);
 	await import(pathToFileURL(outputFile).href);
 	await import(pathToFileURL(join(outputDirectory, 'source-transition-guards.test.js')).href);
 	await import(pathToFileURL(join(outputDirectory, 'task-mutation-adapter.test.js')).href);

--- a/src/agent-runtime/contracts/v1/decode.ts
+++ b/src/agent-runtime/contracts/v1/decode.ts
@@ -70,6 +70,7 @@ import {
 	verifySealedMutationPlanHashV1,
 } from './canonical';
 import {
+	compareResourceKeysCanonicalV1,
 	OPERON_ID_PATTERN_V1,
 	RESOURCE_QUEUE_ORDER_V1,
 	RESOURCE_KINDS_V1,
@@ -3678,9 +3679,8 @@ function compareResourcesCanonicalV1(left: Record<string, unknown>, right: Recor
 		? RESOURCE_QUEUE_ORDER_V1[right.resourceKind as keyof typeof RESOURCE_QUEUE_ORDER_V1]
 		: Number.MAX_SAFE_INTEGER;
 	if (leftKind !== rightKind) return leftKind - rightKind;
-	const leftKey = String(left.resourceKey);
-	const rightKey = String(right.resourceKey);
-	return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0;
+	// Shared with the planners so sealed order and admitted order cannot drift.
+	return compareResourceKeysCanonicalV1(String(left.resourceKey), String(right.resourceKey));
 }
 
 function riskRank(value: unknown): number {

--- a/src/agent-runtime/contracts/v1/identity.ts
+++ b/src/agent-runtime/contracts/v1/identity.ts
@@ -96,6 +96,29 @@ export const RESOURCE_QUEUE_ORDER_V1: Readonly<Record<ResourceKindV1, number>> =
 	'task-source': 5,
 });
 
+/**
+ * Canonical resource ordering for sealed plans: UTF-16 code units, never `localeCompare`.
+ *
+ * The V1 decoder rejects any sealed plan whose `affectedResources` is not in canonical
+ * order, and it derives that order with `<` / `>`. A planner that sorts the same list
+ * with `localeCompare` disagrees with it as soon as two keys differ in letter case,
+ * punctuation, or non-ASCII characters, so the plan it just sealed fails apply
+ * admission. `localeCompare` is also host-locale dependent, which a sealed contract
+ * must never be. Every producer and consumer of canonical resource order must sort
+ * with these comparators.
+ */
+export function compareResourceKeysCanonicalV1(left: string, right: string): number {
+	return left < right ? -1 : left > right ? 1 : 0;
+}
+
+export function compareResourceReferencesCanonicalV1(
+	left: { readonly resourceKind: ResourceKindV1; readonly resourceKey: string },
+	right: { readonly resourceKind: ResourceKindV1; readonly resourceKey: string },
+): number {
+	return RESOURCE_QUEUE_ORDER_V1[left.resourceKind] - RESOURCE_QUEUE_ORDER_V1[right.resourceKind]
+		|| compareResourceKeysCanonicalV1(left.resourceKey, right.resourceKey);
+}
+
 export type TaskSelectorV1 =
 	| { kind: 'operon-id'; operonId: string }
 	| { kind: 'exact-locator'; locator: TaskSourceLocatorV1; expectedOperonId?: string }

--- a/src/agent-runtime/runtime/mutation-gateway.ts
+++ b/src/agent-runtime/runtime/mutation-gateway.ts
@@ -9,7 +9,7 @@ import type {
 	AffectedResourceRevisionMapV1,
 	ContextRevisionV1,
 } from '../contracts/v1/identity';
-import { RESOURCE_QUEUE_ORDER_V1 } from '../contracts/v1/identity';
+import { compareResourceReferencesCanonicalV1 } from '../contracts/v1/identity';
 import type {
 	AtomicResourceGroupV1,
 	AtomicGroupResultV1,
@@ -2453,10 +2453,7 @@ function buildSealedPlan(
 	];
 	const affectedResources = [...new Map(
 		affectedResourceCandidates.map(resource => [`${resource.resourceKind}\0${resource.resourceKey}`, resource]),
-	).values()].sort((left, right) => (
-		RESOURCE_QUEUE_ORDER_V1[left.resourceKind] - RESOURCE_QUEUE_ORDER_V1[right.resourceKind]
-			|| left.resourceKey.localeCompare(right.resourceKey)
-	));
+	).values()].sort(compareResourceReferencesCanonicalV1);
 	const targets = prepared.createEffects.map(effect => ({
 		operonId: effect.operonId,
 		locator: effect.locator,
@@ -2737,10 +2734,7 @@ function preparationMatchesPlan(
 	];
 	const currentResources = [...new Map(
 		currentResourceCandidates.map(resource => [`${resource.resourceKind}\0${resource.resourceKey}`, resource]),
-	).values()].sort((left, right) => (
-		RESOURCE_QUEUE_ORDER_V1[left.resourceKind] - RESOURCE_QUEUE_ORDER_V1[right.resourceKind]
-			|| left.resourceKey.localeCompare(right.resourceKey)
-	));
+	).values()].sort(compareResourceReferencesCanonicalV1);
 	const currentEffects = prepared.createEffects;
 	const plannedEffects = (plan.createEffects ?? []).filter(effect => (
 		currentResources.some(resource => resource.resourceKey === effect.locator.filePath)
@@ -2963,11 +2957,7 @@ function toGroupResults(commit: TaskCreationCommitSummary): AtomicGroupResultV1[
 					resourceKind: 'task-source' as const,
 					resourceKey: group.filePath,
 					revision: group.result.resultingRevision,
-				}])].sort((left, right) => (
-					RESOURCE_QUEUE_ORDER_V1[left.resourceKind]
-						- RESOURCE_QUEUE_ORDER_V1[right.resourceKind]
-					|| left.resourceKey.localeCompare(right.resourceKey)
-				)),
+				}])].sort(compareResourceReferencesCanonicalV1),
 			}
 			: {
 				error: structuredError(

--- a/src/agent-runtime/runtime/semantic-transition.ts
+++ b/src/agent-runtime/runtime/semantic-transition.ts
@@ -10,7 +10,7 @@ import type {
 	TaskSourceLocatorV1,
 } from '../contracts/v1/identity';
 import {
-	RESOURCE_QUEUE_ORDER_V1,
+	compareResourceReferencesCanonicalV1,
 	sameTaskSourceLocatorV1,
 } from '../contracts/v1/identity';
 import {
@@ -1345,10 +1345,8 @@ function compareResourceReferences(
 	left: Pick<ResourceRevisionV1, 'resourceKind' | 'resourceKey'>,
 	right: Pick<ResourceRevisionV1, 'resourceKind' | 'resourceKey'>,
 ): number {
-	const kindOrder = RESOURCE_QUEUE_ORDER_V1[left.resourceKind]
-		- RESOURCE_QUEUE_ORDER_V1[right.resourceKind];
-	if (kindOrder !== 0) return kindOrder;
-	return left.resourceKey.localeCompare(right.resourceKey);
+	// Must stay byte-identical to the decoder's canonical order.
+	return compareResourceReferencesCanonicalV1(left, right);
 }
 
 function isValidIsoInstant(value: string): boolean {


### PR DESCRIPTION
## Summary

Fixes #200 — which 3.6.1 closed, but the underlying fault is still present there: 3.6.1's fix (`src/core/mark-done-routing.ts`) resolves the *mobile* mark-done routing gap from #203, while #200 is a desktop-side contract disagreement inside the agent runtime. The repro from #200 still fails 2 of 3 on a clean 3.6.1 checkout.

**Root cause:** the V1 decoder rejects any sealed plan whose `affectedResources` is not in canonical order, and it derives that order with raw `<` / `>` (UTF-16 code units) — `compareResourcesCanonicalV1` in `contracts/v1/decode.ts`. Every planner that builds the list sorts it with `String.prototype.localeCompare`. The two orders agree only on same-case ASCII, so any mutation whose plan touches two task-source files differing in letter case (`Projects/backend.md` vs `Projects/Roadmap.md`), punctuation, or non-ASCII is sealed in an order the decoder refuses, and fails apply admission with *"Affected resources violate canonical queue order."* — which no UI surface ever shows; the user sees "Mark done" do nothing, or *"failed to save task changes"*. `localeCompare` is also host-locale dependent, so which plans are admissible varies by machine; a sealed contract should not.

**Confirmed failing operations** (each verified against a live 3.6.1 runtime over a two-note fixture; `buildPreparedMutationPlan` copies `prepared.affectedResources` into the sealed plan verbatim, so a planner's order is the order admission checks):

| Operation | Planner sort |
| --- | --- |
| Completing a task whose ancestor lives in another note | `semantic-transition.ts` `compareResourceReferences` |
| `replace-relationships` between tasks in two notes | `main.ts` relationship branch of `prepareAgentRuntimeTaskMutation` |
| Any field `update` on a task whose parent lives in another note (parent postflight pulls in the second file) | `main.ts` update tail of `prepareAgentRuntimeTaskMutation` |
| Cross-file `relocate-inline` (same path serves `convert` / `delete` with cross-file ancestors) | `main.ts` `prepareAgentRuntimeSourceTransition` |

Isolation evidence: the identical well-formed apply request succeeds with the plan's `affectedResources` in code-unit order and fails V1 admission with the same plan reordered to ICU order — ordering is the only variable.

## The fix

One shared comparator pair in `contracts/v1/identity.ts` — `compareResourceKeysCanonicalV1` / `compareResourceReferencesCanonicalV1` (resource-kind queue order first, then code-unit key order) — used by **both** sides so they cannot drift again:

- the decoder's `compareResourcesCanonicalV1` delegates its key comparison to it (unknown-kind handling unchanged),
- every planner sort of plan resources now calls it: `semantic-transition.ts`, the three sorts in `mutation-gateway.ts` (`buildSealedPlan`, `preparationMatchesPlan`, `toGroupResults`), and the five in `main.ts` (`prepareAgentRuntimeSourceTransition`, the relationship branch and update tail of `prepareAgentRuntimeTaskMutation`, its `predictedEffects` sort, and `buildAgentRuntimeIdentityPlanCandidate`).

The last two of those (`predictedEffects`, the identity-placeholder candidate) have no order check today and are included for consistency only, so a future order check cannot resurrect the bug. The read-side context listing in `context-bridge.ts` is deliberately left as is — nothing re-derives its order, and it sorts by different semantics.

Standardising on code-unit order (rather than making the decoder match `localeCompare`) keeps contract validation deterministic and host-independent.

## Tests

`scripts/agent-runtime/mutation/canonical-resource-ordering.test.ts` (wired into `run-mutation-tests.mjs`):

1. precondition — the fixture paths sort differently under ICU vs code units,
2. the real transition planner seals `affectedResources` in the order the decoder demands (fails on 3.6.1),
3. a sealed apply request carrying that plan passes `decodeMutationApplyRequestV1` (fails on 3.6.1),
4. the shared comparators use code-unit order for case / punctuation / non-ASCII divergent pairs and keep kind order first,
5. no plan-sealing source file sorts `resourceKey` with `localeCompare`.

Ran locally: `npm run check` (strict lint, contract checks, production build), `npm run agent-runtime:mutation` 177/177, contracts / runtime / creation / context suites.

One pre-existing, unrelated failure worth knowing about when running the mutation suite east of ~UTC+2:25: *"relationship replacement updates both dependency owners and seals exact current state"* hardcodes a UTC-shaped literal derived from local time (fixture bug, fails in e.g. Asia/Singapore, passes under `TZ=UTC`). Happy to file it separately.
